### PR TITLE
Fix plugin bug for HsWrap case with biPlateRef and extract out rules

### DIFF
--- a/sheriff/README.MD
+++ b/sheriff/README.MD
@@ -1,5 +1,5 @@
 
-# Haskell Code Checker Plugin
+# Haskell Code Checker Plugin - Sheriff
 
 ## Overview
 
@@ -13,8 +13,16 @@ This tool is useful for developers to enforce better coding practices and preven
 
 ## Usage
 
-Add this to your ghc-options in cabal and mention `logerr` in build-depends
+Add this to your ghc-options in cabal and mention `sheriff` in build-depends
 
 ```
 -fplugin=Sheriff.Plugin
 ```
+Also, we can provide flags to the plugin in following order:
+throwCompilationErrors, saveErrorsToFile, errorsFilesPath
+```
+-fplugin-opt=Sheriff.Plugin:true
+-fplugin-opt=Sheriff.Plugin:false
+-fplugin-opt=Sheriff.Plugin:.juspay/tmp/sheriff/
+```
+By default, it throwsCompilationErrors and doesn't log to file.

--- a/sheriff/sheriff.cabal
+++ b/sheriff/sheriff.cabal
@@ -42,6 +42,7 @@ library
         Sheriff.Plugin
     other-modules: 
         Sheriff.Types
+        Sheriff.Rules
     build-depends:
                 bytestring
                 , containers
@@ -86,11 +87,11 @@ test-suite sheriff-test
             -fplugin=Sheriff.Plugin 
             -fplugin-opt=Sheriff.Plugin:false
             -fplugin-opt=Sheriff.Plugin:true
-            -fplugin-opt=Sheriff.Plugin:.juspay/tmp/logerr/
-            -dumpdir=.juspay/tmp/logerr/ -ddump-to-file -ddump-parsed-ast -ddump-tc-ast
+            -fplugin-opt=Sheriff.Plugin:.juspay/tmp/sheriff/
+            -dumpdir=.juspay/tmp/sheriff/ -ddump-to-file -ddump-parsed-ast -ddump-tc-ast
     else
         ghc-options: 
             -fplugin=Sheriff.Plugin
             -fplugin-opt=Sheriff.Plugin:true
             -fplugin-opt=Sheriff.Plugin:false
-            -fplugin-opt=Sheriff.Plugin:.juspay/tmp/logerr/
+            -fplugin-opt=Sheriff.Plugin:.juspay/tmp/sheriff/

--- a/sheriff/src/Sheriff/Rules.hs
+++ b/sheriff/src/Sheriff/Rules.hs
@@ -1,0 +1,64 @@
+module Sheriff.Rules where
+
+import Sheriff.Types
+
+-- TODO: Take these from the configuration file
+badPracticeRules :: Rules
+badPracticeRules = [
+    defaultRule
+  , logRule1 
+  , logRule2 
+  , logRule3 
+  , logRule4 
+  , logRule5 
+  , logRule6
+  , logRule7
+  , logRule8
+  , logRule9
+  , showRule
+  ]
+
+logArgNo :: ArgNo
+logArgNo = 2
+
+logRule1 :: Rule
+logRule1 = Rule "LogRule" "logErrorT" logArgNo stringifierFns [] textTypesToCheck
+
+logRule2 :: Rule
+logRule2 = Rule "LogRule" "logErrorV" logArgNo stringifierFns [] textTypesToCheck
+
+logRule3 :: Rule
+logRule3 = Rule "LogRule" "logError" logArgNo stringifierFns [] textTypesToCheck
+
+logRule4 :: Rule
+logRule4 = Rule "LogRule" "logInfoT" logArgNo stringifierFns [] textTypesToCheck
+
+logRule5 :: Rule
+logRule5 = Rule "LogRule" "logInfoV" logArgNo stringifierFns [] textTypesToCheck
+
+logRule6 :: Rule
+logRule6 = Rule "LogRule" "logInfo" logArgNo stringifierFns [] textTypesToCheck
+
+logRule7 :: Rule
+logRule7 = Rule "LogRule" "logDebugT" logArgNo stringifierFns [] textTypesToCheck
+
+logRule8 :: Rule
+logRule8 = Rule "LogRule" "logDebugV" logArgNo stringifierFns [] textTypesToCheck
+
+logRule9 :: Rule
+logRule9 = Rule "LogRule" "logDebug" logArgNo stringifierFns [] textTypesToCheck
+
+showRule :: Rule
+showRule = Rule "ShowRule" "show" 1 stringifierFns textTypesBlocked textTypesToCheck
+
+noUseRule :: Rule
+noUseRule = Rule "NoDecodeUtf8Rule" "$text-1.2.4.1$Data.Text.Encoding$decodeUtf8" 0 [] [] []
+
+stringifierFns :: FnsBlockedInArg
+stringifierFns = ["show", "encode", "encodeJSON"]
+
+textTypesBlocked :: TypesBlockedInArg
+textTypesBlocked = ["Text", "String", "Char", "[Char]"]
+
+textTypesToCheck :: TypesToCheckInArg
+textTypesToCheck = ["Text", "String", "Char", "[Char]"]

--- a/sheriff/test/Test1.hs
+++ b/sheriff/test/Test1.hs
@@ -132,6 +132,7 @@ main = do
     let obAT1 = "Dummy"
     let b = logInfoT "tester" logger
     logError "tag" $ obAT1 <> show Test1.obAT1
+    fn $ logError "tag2" $ show obA
   where
     logErrorT = Test1.logErrorT
 
@@ -140,6 +141,11 @@ logInfoT x _ = x
 
 logger :: forall a b. (IsString b, Show a) => String -> a -> b
 logger _ = fromString . show
+
+fn :: IO () -> IO ()
+fn x = do
+    _ <- x
+    pure ()
 
 -- myFun :: A -> IO Text
 -- myFun ob = do


### PR DESCRIPTION
In Sheriff plugin, one case was missed for finding HsApp and check for the rules.
when using `biPlateRef` , It was getting list of `LHsExpr`, which does contain `HsWrap` data constructor but not the `HsExpr` inside the `HsWrap` since it is not located HsExpr.
For that, we have to handle `HsWrap` case separately.

Also, restructuring is done to separate out rules from the plugin code.