### PR TITLE
feature: Add Fail on Non-Indexed DB Query 

### DIFF
--- a/sheriff/.gitignore
+++ b/sheriff/.gitignore
@@ -3,5 +3,5 @@ result
 test/dumps
 test/out*
 cabal.project.local
-.juspay*
+.juspay/tmp*
 .tmp*

--- a/sheriff/.juspay/indexedKeys.yaml
+++ b/sheriff/.juspay/indexedKeys.yaml
@@ -1,0 +1,10 @@
+tables:
+  - name: MerchantKey
+    indexedKeys:
+      - status
+      - partitionKey
+      
+  - name: TxnRiskCheck
+    indexedKeys:
+      - status
+      - partitionKey

--- a/sheriff/README.MD
+++ b/sheriff/README.MD
@@ -8,6 +8,7 @@ It supports the following rules as of now
 1. Blocking certain type of argument to a function call :- Give a particular argument number `arg_no` and list of types to be blocked in that argument `types_blocked_in_arg`
 2. Blocking use of certain function in an argument to a function call :- Give a particular argument number `arg_no` and list of functions to be blocked in argument. <br>_Note: The function presence will be checked and blocked only if the type of the argument is in list of `types_to_check_in_arg`_
 3. Blocking use of a particular function in the code (specify argument number `arg_no` as `0` in the rule)
+4. Blocking querying in DB on non-indexed columns (indexed columns are provided in a yaml file)
 
 This tool is useful for developers to enforce better coding practices and prevent use of some specific unsafe function in the code.
 
@@ -18,11 +19,8 @@ Add this to your ghc-options in cabal and mention `sheriff` in build-depends
 ```
 -fplugin=Sheriff.Plugin
 ```
-Also, we can provide flags to the plugin in following order:
-throwCompilationErrors, saveErrorsToFile, errorsFilesPath
+Also, we can provide flags to the plugin in as follows:
 ```
--fplugin-opt=Sheriff.Plugin:true
--fplugin-opt=Sheriff.Plugin:false
--fplugin-opt=Sheriff.Plugin:.juspay/tmp/sheriff/
+-fplugin-opt=Sheriff.Plugin:{"throwCompilationError":true,"saveToFile":true,"savePath":".juspay/tmp/sheriff/","indexedKeysPath":".juspay/indexedKeys.yaml","failOnFileNotFound":true}
 ```
-By default, it throwsCompilationErrors and doesn't log to file.
+By default, it throwsCompilationErrors and doesn't log to file. Also, it fails, if indexedKeys file is not found or is invalid

--- a/sheriff/sheriff.cabal
+++ b/sheriff/sheriff.cabal
@@ -56,6 +56,7 @@ library
                 , aeson
                 , directory
                 , extra
+                , yaml
                 , aeson-pretty
     hs-source-dirs:   src
     default-language: Haskell2010
@@ -83,15 +84,10 @@ test-suite sheriff-test
 
     if flag(Dev)
         ghc-options: 
-            -- Plugin options order: throwCompilationError (Bool == true/false), saveToFile (Bool == true/false), filePath (string)
+            -- Plugin options order: {"throwCompilationError":true,"saveToFile":true,"savePath":".juspay/tmp/sheriff/","indexedKeysPath":".juspay/tmp"}
             -fplugin=Sheriff.Plugin 
-            -fplugin-opt=Sheriff.Plugin:false
-            -fplugin-opt=Sheriff.Plugin:true
-            -fplugin-opt=Sheriff.Plugin:.juspay/tmp/sheriff/
+            -fplugin-opt=Sheriff.Plugin:{"throwCompilationError":true,"saveToFile":true,"savePath":".juspay/tmp/sheriff/","indexedKeysPath":".juspay/indexedKeys.yaml","failOnFileNotFound":true}
             -dumpdir=.juspay/tmp/sheriff/ -ddump-to-file -ddump-parsed-ast -ddump-tc-ast
     else
         ghc-options: 
             -fplugin=Sheriff.Plugin
-            -fplugin-opt=Sheriff.Plugin:true
-            -fplugin-opt=Sheriff.Plugin:false
-            -fplugin-opt=Sheriff.Plugin:.juspay/tmp/sheriff/

--- a/sheriff/src/Sheriff/Rules.hs
+++ b/sheriff/src/Sheriff/Rules.hs
@@ -22,37 +22,43 @@ logArgNo :: ArgNo
 logArgNo = 2
 
 logRule1 :: Rule
-logRule1 = Rule "LogRule" "logErrorT" logArgNo stringifierFns [] textTypesToCheck
+logRule1 = FunctionRule "LogRule" "logErrorT" logArgNo stringifierFns [] textTypesToCheck
 
 logRule2 :: Rule
-logRule2 = Rule "LogRule" "logErrorV" logArgNo stringifierFns [] textTypesToCheck
+logRule2 = FunctionRule "LogRule" "logErrorV" logArgNo stringifierFns [] textTypesToCheck
 
 logRule3 :: Rule
-logRule3 = Rule "LogRule" "logError" logArgNo stringifierFns [] textTypesToCheck
+logRule3 = FunctionRule "LogRule" "logError" logArgNo stringifierFns [] textTypesToCheck
 
 logRule4 :: Rule
-logRule4 = Rule "LogRule" "logInfoT" logArgNo stringifierFns [] textTypesToCheck
+logRule4 = FunctionRule "LogRule" "logInfoT" logArgNo stringifierFns [] textTypesToCheck
 
 logRule5 :: Rule
-logRule5 = Rule "LogRule" "logInfoV" logArgNo stringifierFns [] textTypesToCheck
+logRule5 = FunctionRule "LogRule" "logInfoV" logArgNo stringifierFns [] textTypesToCheck
 
 logRule6 :: Rule
-logRule6 = Rule "LogRule" "logInfo" logArgNo stringifierFns [] textTypesToCheck
+logRule6 = FunctionRule "LogRule" "logInfo" logArgNo stringifierFns [] textTypesToCheck
 
 logRule7 :: Rule
-logRule7 = Rule "LogRule" "logDebugT" logArgNo stringifierFns [] textTypesToCheck
+logRule7 = FunctionRule "LogRule" "logDebugT" logArgNo stringifierFns [] textTypesToCheck
 
 logRule8 :: Rule
-logRule8 = Rule "LogRule" "logDebugV" logArgNo stringifierFns [] textTypesToCheck
+logRule8 = FunctionRule "LogRule" "logDebugV" logArgNo stringifierFns [] textTypesToCheck
 
 logRule9 :: Rule
-logRule9 = Rule "LogRule" "logDebug" logArgNo stringifierFns [] textTypesToCheck
+logRule9 = FunctionRule "LogRule" "logDebug" logArgNo stringifierFns [] textTypesToCheck
 
 showRule :: Rule
-showRule = Rule "ShowRule" "show" 1 stringifierFns textTypesBlocked textTypesToCheck
+showRule = FunctionRule "ShowRule" "show" 1 stringifierFns textTypesBlocked textTypesToCheck
 
 noUseRule :: Rule
-noUseRule = Rule "NoDecodeUtf8Rule" "$text-1.2.4.1$Data.Text.Encoding$decodeUtf8" 0 [] [] []
+noUseRule = FunctionRule "NoDecodeUtf8Rule" "$text-1.2.4.1$Data.Text.Encoding$decodeUtf8" 0 [] [] []
+
+dbRule :: Rule
+dbRule = DBRule "NonIndexedDBRule" "TxnRiskCheck" ["partitionKey"]
+
+dbRuleCustomer :: Rule
+dbRuleCustomer = DBRule "NonIndexedDBRule" "MerchantKey" ["status"]
 
 stringifierFns :: FnsBlockedInArg
 stringifierFns = ["show", "encode", "encodeJSON"]

--- a/sheriff/src/Sheriff/Types.hs
+++ b/sheriff/src/Sheriff/Types.hs
@@ -5,6 +5,47 @@ import SrcLoc
 import Var
 import Outputable as OP hiding ((<>))
 
+data PluginOpts = PluginOpts {
+    saveToFile :: Bool,
+    throwCompilationError :: Bool,
+    failOnFileNotFound :: Bool,
+    savePath :: String,
+    indexedKeysPath :: String
+  } deriving (Show, Eq)
+
+defaultPluginOpts :: PluginOpts
+defaultPluginOpts = PluginOpts { saveToFile = False, throwCompilationError = True, failOnFileNotFound = True, savePath = ".juspay/tmp/sheriff/", indexedKeysPath = ".juspay/indexedKeys.yaml" }
+
+instance FromJSON PluginOpts where
+  parseJSON = withObject "PluginOpts" $ \o -> do
+    saveToFile <- o .:? "saveToFile" .!= (saveToFile defaultPluginOpts)
+    failOnFileNotFound <- o .:? "failOnFileNotFound" .!= (failOnFileNotFound defaultPluginOpts)
+    throwCompilationError <- o .:? "throwCompilationError" .!= (throwCompilationError defaultPluginOpts)
+    savePath <- o .:? "savePath" .!= (savePath defaultPluginOpts)
+    indexedKeysPath <- o .:? "indexedKeysPath" .!= (indexedKeysPath defaultPluginOpts)
+    return PluginOpts { saveToFile = saveToFile, throwCompilationError = throwCompilationError, savePath = savePath, indexedKeysPath = indexedKeysPath, failOnFileNotFound = failOnFileNotFound }
+
+
+data YamlTables = YamlTables
+  { tables :: [YamlTable]
+  } deriving (Show, Eq)
+
+instance FromJSON YamlTables where
+  parseJSON = withObject "YamlTables" $ \o -> do
+    tableList <- o .: "tables"
+    return YamlTables { tables = tableList }
+
+data YamlTable = YamlTable
+  { tableName :: String
+  , indexedKeys :: [String]
+  } deriving (Show, Eq)
+
+instance FromJSON YamlTable where
+  parseJSON = withObject "YamlTable" $ \o -> do
+    name <- o .: "name"
+    keys <- o .: "indexedKeys"
+    return YamlTable { tableName = name, indexedKeys = keys }
+
 data CompileError = CompileError
   {
     pkg_name :: String,
@@ -30,15 +71,23 @@ type FnsBlockedInArg = [String]
 type TypesBlockedInArg = [String]
 type TypesToCheckInArg = [String]
 
-data Rule = Rule 
-  {
-    rule_name :: String,
-    fn_name :: String,
-    arg_no :: ArgNo,
-    fns_blocked_in_arg :: FnsBlockedInArg,
-    types_blocked_in_arg :: TypesBlockedInArg,
-    types_to_check_in_arg :: TypesToCheckInArg
-  } deriving (Show, Eq)  
+data Rule = 
+    FunctionRule
+    {
+      rule_name             :: String,
+      fn_name               :: String,
+      arg_no                :: ArgNo,
+      fns_blocked_in_arg    :: FnsBlockedInArg,
+      types_blocked_in_arg  :: TypesBlockedInArg,
+      types_to_check_in_arg :: TypesToCheckInArg
+    }
+  | DBRule 
+    {
+      rule_name          :: String,
+      table_name         :: String,
+      indexed_cols_names :: [String]
+    } 
+  deriving (Show, Eq)  
 
 data LocalVar = FnArg Var | FnWhere Var | FnLocal Var
   deriving (Eq)
@@ -48,9 +97,16 @@ instance Show LocalVar where
   show (FnWhere x) = "FnWhere " Prelude.<> showS x
   show (FnLocal x) = "FnLocal " Prelude.<> showS x
 
+data DBFieldSpecType = 
+    Selector  -- $sel:fiedl1:TableName
+  | Lens      -- (\\ x -> x ^. _fieldNameLens)
+  | RecordDot -- (\\ x -> (getField @\"fieldName\" x))
+  | None
+
 data Violation = 
     ArgTypeBlocked String Rule
   | FnBlockedInArg String Rule
+  | NonIndexedDBColumn String String Rule
   | FnUseBlocked Rule
   | NoViolation
   deriving (Eq)
@@ -59,6 +115,7 @@ instance Show Violation where
   show (ArgTypeBlocked typ rule) = "Use of '" <> (fn_name rule) <> "' on '" <> typ <> "' is not allowed."
   show (FnBlockedInArg fnName rule) = "Use of '" <> fnName <> "' inside argument of '" <> (fn_name rule) <> "' is not allowed."
   show (FnUseBlocked rule) = "Use of '" <> (fn_name rule) <> "' in the code is not allowed."
+  show (NonIndexedDBColumn colName tableName rule) = "Querying on non-indexed column '" <> colName <> "' of table '" <> (tableName) <> "' is not allowed."
   show NoViolation = "NoViolation"
 
 getViolationType :: Violation -> String
@@ -66,6 +123,7 @@ getViolationType v = case v of
   ArgTypeBlocked _ _ -> "ArgTypeBlocked"
   FnBlockedInArg _ _ -> "FnBlockedInArg"
   FnUseBlocked _ -> "FnUseBlocked"
+  NonIndexedDBColumn _ _ _ -> "NonIndexedDBColumn"
   NoViolation -> "NoViolation"
 
 getRule :: Violation -> Rule
@@ -73,13 +131,17 @@ getRule v = case v of
   ArgTypeBlocked _ r -> r
   FnBlockedInArg _ r -> r
   FnUseBlocked r -> r
+  NonIndexedDBColumn _ _ r -> r
   NoViolation -> defaultRule
 
 showS :: (Outputable a) => a -> String
 showS = showSDocUnsafe . ppr
 
 defaultRule :: Rule
-defaultRule = Rule "NA" "NA" (-1) [] [] []
+defaultRule = FunctionRule "NA" "NA" (-1) [] [] []
 
 emptyLoggingError :: CompileError
 emptyLoggingError = CompileError "" "" "$NA$" noSrcSpan NoViolation
+
+yamlToDbRule :: YamlTable -> Rule
+yamlToDbRule table = DBRule "NonIndexedDBRule" (tableName table) (indexedKeys table)

--- a/sheriff/test/Test1.hs
+++ b/sheriff/test/Test1.hs
@@ -26,6 +26,12 @@ data B = B {f1 :: Int, f2 :: A, f3 :: Text}
 data CC = C1 | C2 Text | C3 Int | C4 Bool
     deriving (Generic, Show, ToJSON, FromJSON)
 
+data SeqIs = SeqIs Text Text
+    deriving (Generic, Show, ToJSON, FromJSON)
+
+ob :: SeqIs
+ob = SeqIs "fldName" "fldValue"
+
 -- Data objects
 obA :: A
 obA = A 25 "Hello ObjectA"


### PR DESCRIPTION
Changes:
1. Refactored the plugin opts. Using JSON option now instead of order based options
2. Refactored the plugin code to clearly differentiate between DB rules and function rules
3. Added DB rules for Non-Indexed column queries for three types of code
    - Direct field selector
    - Using Lens
    - Using RecordDotPreprocessor


`Sample yaml file:`
```
tables:
  - name: MerchantKey
    indexedKeys:
      - status
      - partitionKey
      
  - name: TxnRiskCheck
    indexedKeys:
      - status
      - partitionKey
```

Sample result:
<img width="950" alt="image" src="https://github.com/juspay/spider/assets/129847168/38a812bc-2f06-464e-8e8c-b349c168d685">
