### PR TITLE
Add partial function syntax support for non-indexed db query rule

### DIFF
--- a/sheriff/src/Sheriff/Types.hs
+++ b/sheriff/src/Sheriff/Types.hs
@@ -98,10 +98,11 @@ instance Show LocalVar where
   show (FnLocal x) = "FnLocal " Prelude.<> showS x
 
 data DBFieldSpecType = 
-    Selector  -- $sel:fiedl1:TableName
-  | Lens      -- (\\ x -> x ^. _fieldNameLens)
-  | RecordDot -- (\\ x -> (getField @\"fieldName\" x))
+    Selector  -- DB.fieldName ==> $sel:fieldName:TableName
+  | Lens      -- (\x -> x ^. _fieldNameLens), (^. _fieldNameLens)
+  | RecordDot -- (\x -> x.fieldName), (.fieldName) ==> (\\ x -> (getField @\"fieldName\" x)) 
   | None
+  deriving (Show, Eq)
 
 data Violation = 
     ArgTypeBlocked String Rule


### PR DESCRIPTION
The support for partial function syntax was missing on non-indexed DB query rule.
1. (.fieldName)
2. (^. _fieldName)

**Changes:**
1. Added support for partial record dot preprocessor, by finding "@"  in the parsed syntax and using `HasField` constraint to find the type
2. Added support for partial lens support by adding `SectionR` (right side partial operator application) and then using the combination of table name for the lens

**Sample result screenshot:**

<img width="648" alt="image" src="https://github.com/juspay/spider/assets/129847168/11ff0af6-6d04-4055-825d-515cce2fb70c">
