### PR TITLE
Refactor code with custom traversal and separate And, Or, Is processing

### DIFF
--- a/sheriff/.juspay/indexedKeys.yaml
+++ b/sheriff/.juspay/indexedKeys.yaml
@@ -1,10 +1,10 @@
 tables:
   - name: MerchantKey
     indexedKeys:
-      - status
-      - partitionKey
+      - [status]
+      - [partitionKey]
       
   - name: TxnRiskCheck
     indexedKeys:
-      - status
-      - partitionKey
+      - [status]
+      - [partitionKey]

--- a/sheriff/src/Sheriff/Rules.hs
+++ b/sheriff/src/Sheriff/Rules.hs
@@ -22,43 +22,43 @@ logArgNo :: ArgNo
 logArgNo = 2
 
 logRule1 :: Rule
-logRule1 = FunctionRule "LogRule" "logErrorT" logArgNo stringifierFns [] textTypesToCheck
+logRule1 = FunctionRuleT $ FunctionRule "LogRule" "logErrorT" logArgNo stringifierFns [] textTypesToCheck
 
 logRule2 :: Rule
-logRule2 = FunctionRule "LogRule" "logErrorV" logArgNo stringifierFns [] textTypesToCheck
+logRule2 = FunctionRuleT $ FunctionRule "LogRule" "logErrorV" logArgNo stringifierFns [] textTypesToCheck
 
 logRule3 :: Rule
-logRule3 = FunctionRule "LogRule" "logError" logArgNo stringifierFns [] textTypesToCheck
+logRule3 = FunctionRuleT $ FunctionRule "LogRule" "logError" logArgNo stringifierFns [] textTypesToCheck
 
 logRule4 :: Rule
-logRule4 = FunctionRule "LogRule" "logInfoT" logArgNo stringifierFns [] textTypesToCheck
+logRule4 = FunctionRuleT $ FunctionRule "LogRule" "logInfoT" logArgNo stringifierFns [] textTypesToCheck
 
 logRule5 :: Rule
-logRule5 = FunctionRule "LogRule" "logInfoV" logArgNo stringifierFns [] textTypesToCheck
+logRule5 = FunctionRuleT $ FunctionRule "LogRule" "logInfoV" logArgNo stringifierFns [] textTypesToCheck
 
 logRule6 :: Rule
-logRule6 = FunctionRule "LogRule" "logInfo" logArgNo stringifierFns [] textTypesToCheck
+logRule6 = FunctionRuleT $ FunctionRule "LogRule" "logInfo" logArgNo stringifierFns [] textTypesToCheck
 
 logRule7 :: Rule
-logRule7 = FunctionRule "LogRule" "logDebugT" logArgNo stringifierFns [] textTypesToCheck
+logRule7 = FunctionRuleT $ FunctionRule "LogRule" "logDebugT" logArgNo stringifierFns [] textTypesToCheck
 
 logRule8 :: Rule
-logRule8 = FunctionRule "LogRule" "logDebugV" logArgNo stringifierFns [] textTypesToCheck
+logRule8 = FunctionRuleT $ FunctionRule "LogRule" "logDebugV" logArgNo stringifierFns [] textTypesToCheck
 
 logRule9 :: Rule
-logRule9 = FunctionRule "LogRule" "logDebug" logArgNo stringifierFns [] textTypesToCheck
+logRule9 = FunctionRuleT $ FunctionRule "LogRule" "logDebug" logArgNo stringifierFns [] textTypesToCheck
 
 showRule :: Rule
-showRule = FunctionRule "ShowRule" "show" 1 stringifierFns textTypesBlocked textTypesToCheck
+showRule = FunctionRuleT $ FunctionRule "ShowRule" "show" 1 stringifierFns textTypesBlocked textTypesToCheck
 
 noUseRule :: Rule
-noUseRule = FunctionRule "NoDecodeUtf8Rule" "$text-1.2.4.1$Data.Text.Encoding$decodeUtf8" 0 [] [] []
+noUseRule = FunctionRuleT $ FunctionRule "NoDecodeUtf8Rule" "$text-1.2.4.1$Data.Text.Encoding$decodeUtf8" 0 [] [] []
 
 dbRule :: Rule
-dbRule = DBRule "NonIndexedDBRule" "TxnRiskCheck" ["partitionKey"]
+dbRule = DBRuleT $ DBRule "NonIndexedDBRule" "TxnRiskCheck" [["partitionKey"]]
 
 dbRuleCustomer :: Rule
-dbRuleCustomer = DBRule "NonIndexedDBRule" "MerchantKey" ["status"]
+dbRuleCustomer = DBRuleT $ DBRule "NonIndexedDBRule" "MerchantKey" [["status"]]
 
 stringifierFns :: FnsBlockedInArg
 stringifierFns = ["show", "encode", "encodeJSON"]


### PR DESCRIPTION
Changes:
1. Separated types for DB Rule and Function Rule
2. Replaced `biplateRef` with a custom traversal which doesn't further expand the tree when returned `true`
3. Created separate handling for the `Or`, `And` and `Is` clause from Sequelize
4. Changed `indexedKeys.yaml` file structure to treat every key as composite key. Keys with just one column will be equivalent to single column key
5. Other minor refactorings