### PR TITLE
Add type debugging, fix HsAppType for logInfoV, allow list, tuples and maybe nesting while validating types

### DIFF
--- a/sheriff/src/Sheriff/Rules.hs
+++ b/sheriff/src/Sheriff/Rules.hs
@@ -85,16 +85,16 @@ dbRuleCustomer :: Rule
 dbRuleCustomer = DBRuleT $ DBRule "NonIndexedDBRule" "MerchantKey" [NonCompositeKey "status"] dbRuleSuggestions
 
 fnsAllowedInStringifierFns :: TypesAllowedInArg
-fnsAllowedInStringifierFns = ["EnumTypes", "Integer", "Double", "Float", "Int64", "Int", "Bool", "Number"]
+fnsAllowedInStringifierFns = ["EnumTypes", "Integer", "Double", "Float", "Int64", "Int", "Bool", "Number", "(,)", "[]", "Maybe"]
 
 stringifierFns :: FnsBlockedInArg
 stringifierFns = [("show", 1, fnsAllowedInStringifierFns), ("encode", 1, []), ("encodeJSON", 1, [])]
 
 textTypesBlocked :: TypesBlockedInArg
-textTypesBlocked = ["Text", "String", "Char", "[Char]"]
+textTypesBlocked = ["Text", "String", "Char", "[Char]", "Maybe", "(,)", "[]"]
 
 textTypesToCheck :: TypesToCheckInArg
-textTypesToCheck = ["Text", "String", "Char", "[Char]"]
+textTypesToCheck = ["Text", "String", "Char", "[Char]", "Maybe", "(,)", "[]"]
 
 -- Suggestions
 

--- a/sheriff/test/Test1.hs
+++ b/sheriff/test/Test1.hs
@@ -162,8 +162,20 @@ main = do
     logErrorT "tag" $ encodeJSON en2
     logError "tag" $ show en3
     logErrorT "tag" $ encodeJSON en3
+    logError "tag" $ show (en, "This is Text" :: String)
+    logErrorT "tag" $ encodeJSON (en, "This is Text" :: String)
+    logError "tag" $ show (en, 20 :: Int) -- Should not throw error because of show is allowed on both enums and int
+    logErrorT "tag" $ encodeJSON (en, 20 :: Int) -- Should throw error because of encodeJSON
     logError "tag" $ obAT1 <> show Test1.obAT1
     fn $ logError "tag2" $ show obA
+
+    print $ show temp
+    print $ show temp1
+    print $ show temp2
+    print $ show temp3
+    print $ show temp4
+    logError "tag" $ show temp5
+    logError "tag" $ show temp6
   where
     logErrorT = Test1.logErrorT
 
@@ -172,6 +184,27 @@ logInfoT x _ = x
 
 logger :: forall a b. (IsString b, Show a) => String -> a -> b
 logger _ = fromString . show
+
+temp :: [Text]
+temp = []
+
+temp1 :: Maybe Text
+temp1 = Nothing
+
+temp2 :: (Text, Text)
+temp2 = ("A", "B")
+
+temp3 :: (Text, Int)
+temp3 = ("A", 10)
+
+temp4 :: (Int, Int)
+temp4 = (20, 10)
+
+temp5 :: [EnumT]
+temp5 = []
+
+temp6 :: [EnumT2]
+temp6 = []
 
 fn :: IO () -> IO ()
 fn x = do


### PR DESCRIPTION
1. Added support for logging, how a type is represented internally when determining type of any `LHsExpr GhcTc`
2. Added `HsAppType` constructor to fix logRules not being applied to `logDebugV`, `logInfoV` & `logErrorV`
3. Updated allowed types list for `show` inside some log function to allow `list, tuples and Maybe` types if the further type for them is allowed. For e.g. `Maybe Int` will be allowed since `Int` is allowed, but `Maybe Text` will fail as `Text` is not allowed