### PR TITLE
Sheriff/enhancements - exception rules, configurable rules

### DIFF
--- a/sheriff/.juspay/sheriffRules.yaml
+++ b/sheriff/.juspay/sheriffRules.yaml
@@ -1,0 +1,35 @@
+rules:
+  - ruleName: "GeneralRuleTest"
+    conditions:
+      - fnName: "pack"
+        isQualified: false
+        argNo: 0
+        action: "Blocked"
+        argTypes: []
+        argFns: []
+        suggestedFixes: ["Remove `pack` function call from the error location."]
+    ruleInfo: 
+        fnName: "show"
+        isQualified: false
+        argNo: 1
+        action: "Blocked"
+        argTypes: ["Text", "String", "Char", "[Char]", "Maybe", "(,)", "[]"]
+        argFns: []
+        suggestedFixes: ["Remove `show` function call from the error location. If quotes are required, manually add them to the text.","You might want to use a convertor function like `Data.Text.pack`, `Data.Text.unpack`, `decodeUtf8`, `encodeUtf8`, etc."]
+  
+  - fn_rule_name: "ShowRule"
+    fn_name: "show"
+    arg_no: 1
+    fns_blocked_in_arg: []
+    types_blocked_in_arg: ["Text", "String", "Char", "[Char]", "Maybe", "(,)", "[]"]
+    types_to_check_in_arg: ["Text", "String", "Char", "[Char]", "Maybe", "(,)", "[]"]
+    fn_rule_fixes: ["Remove `show` function call from the error location. If quotes are required, manually add them to the text.","You might want to use a convertor function like `Data.Text.pack`, `Data.Text.unpack`, `decodeUtf8`, `encodeUtf8`, etc."]
+
+  - db_rule_name: "DBRuleTest"
+    table_name: "TxnRiskCheck"
+    indexed_cols_names: 
+      - partitionKey
+      - and:
+        - txnId
+        - customerId
+    db_rule_fixes: ["You might want to include an indexed column in the `where` clause of the query."]

--- a/sheriff/src/Sheriff/Plugin.hs
+++ b/sheriff/src/Sheriff/Plugin.hs
@@ -452,9 +452,9 @@ getWhereClauseFnNameWithAllArgs (L _ (HsApp _ funl funr)) = do
   case res of
     Nothing -> Nothing
     Just (fnName, ls) -> Just (fnName, ls ++ [funr])
-getWhereClauseFnNameWithAllArgs (L _ (OpApp _ lfun op rfun)) = do
+getWhereClauseFnNameWithAllArgs (L loc (OpApp _ lfun op rfun)) = do
   case showS op of
-    "($)" -> getWhereClauseFnNameWithAllArgs $ mkHsApp lfun rfun
+    "($)" -> getWhereClauseFnNameWithAllArgs $ (L loc (HsApp noExtField lfun rfun))
     _ -> Nothing
 getWhereClauseFnNameWithAllArgs (L loc ap@(HsPar _ expr)) = getWhereClauseFnNameWithAllArgs expr
 -- If condition inside the list, add dummy type
@@ -476,9 +476,9 @@ getFnNameWithAllArgs (L _ (HsApp _ funl funr)) = do
   case res of
     Nothing -> Nothing
     Just (fnName, ls) -> Just (fnName, ls ++ [funr])
-getFnNameWithAllArgs (L _ (OpApp _ funl op funr)) = do
+getFnNameWithAllArgs (L loc (OpApp _ funl op funr)) = do
   case showS op of
-    "($)" -> getFnNameWithAllArgs $ mkHsApp funl funr
+    "($)" -> getFnNameWithAllArgs $ (L loc (HsApp noExtField funl funr))
     _ -> Nothing
 getFnNameWithAllArgs (L loc ap@(HsWrap _ _ expr)) = do
   getFnNameWithAllArgs (L loc expr)

--- a/sheriff/src/Sheriff/Plugin.hs
+++ b/sheriff/src/Sheriff/Plugin.hs
@@ -38,7 +38,7 @@ import GHC
     Name,
     Pat (..),
     PatSynBind (..),
-    noLoc, Module (moduleName), moduleNameString,Id(..),getName,nameSrcSpan,IdP(..),GhcPass
+    noLoc, noExtField, Module (moduleName), moduleNameString,Id(..),getName,nameSrcSpan,IdP(..),GhcPass
   )
 import GHC.Hs.Binds
 import GhcPlugins (idName,Var (varName), getOccString, unLoc, Plugin (pluginRecompile), PluginRecompile (..),showSDocUnsafe,ppr,elemNameSet,pprPrefixName,idType,tidyOpenType, isEnumerationTyCon)
@@ -232,9 +232,9 @@ isBadFunApp rules opts ap@(L _ (HsVar _ v)) = isBadFunAppHelper rules opts ap
 isBadFunApp rules opts ap@(L _ (HsApp _ funl funr)) = isBadFunAppHelper rules opts ap
 isBadFunApp rules opts ap@(L loc (HsWrap _ _ expr)) = isBadFunApp rules opts (L loc expr)
 isBadFunApp rules opts ap@(L _ (ExplicitList _ _ _)) = isBadFunAppHelper rules opts ap
-isBadFunApp rules opts (L _ (OpApp _ lfun op rfun)) = do
+isBadFunApp rules opts (L loc (OpApp _ lfun op rfun)) = do
   case showS op of
-    "($)" -> isBadFunAppHelper rules opts $ mkHsApp lfun rfun
+    "($)" -> isBadFunAppHelper rules opts $ (L loc (HsApp noExtField lfun rfun))
     _ -> pure []
 isBadFunApp _ _ _ = pure []
 

--- a/sheriff/src/Sheriff/Rules.hs
+++ b/sheriff/src/Sheriff/Rules.hs
@@ -6,28 +6,6 @@ import Sheriff.Types
 badPracticeRules :: Rules
 badPracticeRules = [
     defaultRule
-  -- , logRule1 
-  -- , logRule2 
-  -- , logRule3 
-  -- , logRule4 
-  -- , logRule5 
-  -- , logRule6
-  -- , logRule7
-  -- , logRule8
-  -- , logRule9
-  -- , logRule10
-  -- , logRule11
-  -- , logRule12
-  -- , logRule13
-  -- , logRule14
-  -- , logRule15
-  , showRule
-  ]
-
--- Exceptions to rule out if these rules are also applied to same LHsExpr
-exceptionRules :: Rules
-exceptionRules = [
-    defaultRule
   , logRule1 
   , logRule2 
   , logRule3 
@@ -43,6 +21,13 @@ exceptionRules = [
   , logRule13
   , logRule14
   , logRule15
+  , showRule
+  ]
+
+-- Exceptions to rule out if these rules are also applied to same LHsExpr
+exceptionRules :: Rules
+exceptionRules = [
+    defaultRule
   , updateFunctionRuleArgNo logRule1  1
   , updateFunctionRuleArgNo logRule2  1
   , updateFunctionRuleArgNo logRule3  1

--- a/sheriff/src/Sheriff/Rules.hs
+++ b/sheriff/src/Sheriff/Rules.hs
@@ -6,21 +6,21 @@ import Sheriff.Types
 badPracticeRules :: Rules
 badPracticeRules = [
     defaultRule
-  , logRule1 
-  , logRule2 
-  , logRule3 
-  , logRule4 
-  , logRule5 
-  , logRule6
-  , logRule7
-  , logRule8
-  , logRule9
-  , logRule10
-  , logRule11
-  , logRule12
-  , logRule13
-  , logRule14
-  , logRule15
+  -- , logRule1 
+  -- , logRule2 
+  -- , logRule3 
+  -- , logRule4 
+  -- , logRule5 
+  -- , logRule6
+  -- , logRule7
+  -- , logRule8
+  -- , logRule9
+  -- , logRule10
+  -- , logRule11
+  -- , logRule12
+  -- , logRule13
+  -- , logRule14
+  -- , logRule15
   , showRule
   ]
 

--- a/sheriff/src/Sheriff/Rules.hs
+++ b/sheriff/src/Sheriff/Rules.hs
@@ -24,6 +24,42 @@ badPracticeRules = [
   , showRule
   ]
 
+-- Exceptions to rule out if these rules are also applied to same LHsExpr
+exceptionRules :: Rules
+exceptionRules = [
+    defaultRule
+  , logRule1 
+  , logRule2 
+  , logRule3 
+  , logRule4 
+  , logRule5 
+  , logRule6
+  , logRule7
+  , logRule8
+  , logRule9
+  , logRule10
+  , logRule11
+  , logRule12
+  , logRule13
+  , logRule14
+  , logRule15
+  , updateFunctionRuleArgNo logRule1  1
+  , updateFunctionRuleArgNo logRule2  1
+  , updateFunctionRuleArgNo logRule3  1
+  , updateFunctionRuleArgNo logRule4  1
+  , updateFunctionRuleArgNo logRule5  1
+  , updateFunctionRuleArgNo logRule6 1
+  , updateFunctionRuleArgNo logRule7 1
+  , updateFunctionRuleArgNo logRule8 1
+  , updateFunctionRuleArgNo logRule9 1
+  , updateFunctionRuleArgNo logRule10 1
+  , updateFunctionRuleArgNo logRule11 1
+  , updateFunctionRuleArgNo logRule12 1
+  , updateFunctionRuleArgNo logRule13 1
+  , updateFunctionRuleArgNo logRule14 1
+  , updateFunctionRuleArgNo logRule15 1
+  ]
+
 logArgNo :: ArgNo
 logArgNo = 2
 
@@ -84,11 +120,15 @@ dbRule = DBRuleT $ DBRule "NonIndexedDBRule" "TxnRiskCheck" [NonCompositeKey "pa
 dbRuleCustomer :: Rule
 dbRuleCustomer = DBRuleT $ DBRule "NonIndexedDBRule" "MerchantKey" [NonCompositeKey "status"] dbRuleSuggestions
 
-fnsAllowedInStringifierFns :: TypesAllowedInArg
-fnsAllowedInStringifierFns = ["EnumTypes", "Integer", "Double", "Float", "Int64", "Int", "Bool", "Number", "(,)", "[]", "Maybe"]
+updateFunctionRuleArgNo :: Rule -> ArgNo -> Rule
+updateFunctionRuleArgNo (FunctionRuleT fnRule) newArgNo = FunctionRuleT $ fnRule{arg_no = newArgNo}
+updateFunctionRuleArgNo rule _ = rule
+
+typesAllowedInStringifierFns :: TypesAllowedInArg
+typesAllowedInStringifierFns = ["EnumTypes", "Integer", "Double", "Float", "Int64", "Int", "Bool", "Number", "(,)", "[]", "Maybe"]
 
 stringifierFns :: FnsBlockedInArg
-stringifierFns = [("show", 1, fnsAllowedInStringifierFns), ("encode", 1, []), ("encodeJSON", 1, [])]
+stringifierFns = [("show", 1, typesAllowedInStringifierFns), ("encode", 1, []), ("encodeJSON", 1, [])]
 
 textTypesBlocked :: TypesBlockedInArg
 textTypesBlocked = ["Text", "String", "Char", "[Char]", "Maybe", "(,)", "[]"]

--- a/sheriff/src/Sheriff/Types.hs
+++ b/sheriff/src/Sheriff/Types.hs
@@ -154,7 +154,7 @@ instance Show Violation where
   show (ArgTypeBlocked typ rule) = "Use of '" <> (fn_name rule) <> "' on '" <> typ <> "' is not allowed."
   show (FnBlockedInArg (fnName, typ) rule) = "Use of '" <> fnName <> "' on type '" <> typ <> "' inside argument of '" <> (fn_name rule) <> "' is not allowed."
   show (FnUseBlocked rule) = "Use of '" <> (fn_name rule) <> "' in the code is not allowed."
-  show (NonIndexedDBColumn colName tableName rule) = "Querying on non-indexed column '" <> colName <> "' of table '" <> (tableName) <> "' is not allowed."
+  show (NonIndexedDBColumn colName tableName _) = "Querying on non-indexed column '" <> colName <> "' of table '" <> (tableName) <> "' is not allowed."
   show NoViolation = "NoViolation"
 
 getViolationSuggestions :: Violation -> Suggestions
@@ -172,6 +172,14 @@ getViolationType v = case v of
   FnUseBlocked _ -> "FnUseBlocked"
   NonIndexedDBColumn _ _ _ -> "NonIndexedDBColumn"
   NoViolation -> "NoViolation"
+
+getViolationRule :: Violation -> Rule
+getViolationRule v = case v of
+  ArgTypeBlocked _ r -> FunctionRuleT r
+  FnBlockedInArg _ r -> FunctionRuleT r
+  FnUseBlocked r -> FunctionRuleT r
+  NonIndexedDBColumn _ _ r -> DBRuleT r
+  NoViolation -> defaultRule
 
 getRuleName :: Violation -> String
 getRuleName v = case v of

--- a/sheriff/src/Sheriff/Types.hs
+++ b/sheriff/src/Sheriff/Types.hs
@@ -13,6 +13,7 @@ data PluginOpts = PluginOpts {
     failOnFileNotFound :: Bool,
     savePath :: String,
     indexedKeysPath :: String,
+    rulesConfigPath :: String,
     matchAllInsideAnd :: Bool
   } deriving (Show, Eq)
 
@@ -24,7 +25,8 @@ defaultPluginOpts =
     failOnFileNotFound = True, 
     matchAllInsideAnd = False,
     savePath = ".juspay/tmp/sheriff/", 
-    indexedKeysPath = ".juspay/indexedKeys.yaml" 
+    indexedKeysPath = ".juspay/indexedKeys.yaml" ,
+    rulesConfigPath = ".juspay/sheriffRules.yaml" 
   }
 
 instance FromJSON PluginOpts where
@@ -34,9 +36,18 @@ instance FromJSON PluginOpts where
     throwCompilationError <- o .:? "throwCompilationError" .!= (throwCompilationError defaultPluginOpts)
     savePath <- o .:? "savePath" .!= (savePath defaultPluginOpts)
     indexedKeysPath <- o .:? "indexedKeysPath" .!= (indexedKeysPath defaultPluginOpts)
+    rulesConfigPath <- o .:? "rulesConfigPath" .!= (rulesConfigPath defaultPluginOpts)
     matchAllInsideAnd <- o .:? "matchAllInsideAnd" .!= (matchAllInsideAnd defaultPluginOpts)
-    return PluginOpts { saveToFile = saveToFile, throwCompilationError = throwCompilationError, matchAllInsideAnd = matchAllInsideAnd, savePath = savePath, indexedKeysPath = indexedKeysPath, failOnFileNotFound = failOnFileNotFound }
+    return PluginOpts { saveToFile = saveToFile, throwCompilationError = throwCompilationError, matchAllInsideAnd = matchAllInsideAnd, savePath = savePath, indexedKeysPath = indexedKeysPath, rulesConfigPath = rulesConfigPath, failOnFileNotFound = failOnFileNotFound }
 
+data SheriffRules = SheriffRules
+  { rules :: Rules
+  } deriving (Show, Eq)
+
+instance FromJSON SheriffRules where
+  parseJSON = withObject "SheriffRules" $ \o -> do
+    rules <- o .: "rules"
+    return SheriffRules { rules = rules }
 
 data YamlTables = YamlTables
   { tables :: [YamlTable]
@@ -93,6 +104,7 @@ instance ToJSON CompileError where
 
 type Rules = [Rule]
 type ArgNo = Int
+type ArgTypes = [String]
 type FnsBlockedInArg = [(String, ArgNo, TypesAllowedInArg)]
 type TypesAllowedInArg = [String]
 type TypesBlockedInArg = [String]
@@ -108,9 +120,20 @@ data FunctionRule =
       fns_blocked_in_arg    :: FnsBlockedInArg,
       types_blocked_in_arg  :: TypesBlockedInArg,
       types_to_check_in_arg :: TypesToCheckInArg,
-      fnRuleFixes           :: Suggestions
+      fn_rule_fixes         :: Suggestions
     }
   deriving (Show, Eq)  
+
+instance FromJSON FunctionRule where
+  parseJSON = withObject "FunctionRule" $ \o -> do
+                fn_rule_name <- o .: "fn_rule_name"
+                fn_name <- o .: "fn_name"
+                arg_no <- o .: "arg_no"
+                fns_blocked_in_arg <- o .: "fns_blocked_in_arg"
+                types_blocked_in_arg <- o .: "types_blocked_in_arg"
+                types_to_check_in_arg <- o .: "types_to_check_in_arg"
+                fn_rule_fixes <- o .: "fn_rule_fixes"
+                return (FunctionRule {fn_rule_name = fn_rule_name, fn_name = fn_name, arg_no = arg_no, fns_blocked_in_arg = fns_blocked_in_arg, types_blocked_in_arg = types_blocked_in_arg, types_to_check_in_arg = types_to_check_in_arg, fn_rule_fixes = fn_rule_fixes})
 
 data DBRule =
   DBRule 
@@ -118,14 +141,77 @@ data DBRule =
       db_rule_name       :: String,
       table_name         :: String,
       indexed_cols_names :: [YamlTableKeys],
-      dbRuleFixes        :: Suggestions
+      db_rule_fixes        :: Suggestions
     }
   deriving (Show, Eq)  
+
+instance FromJSON DBRule where
+  parseJSON = withObject "DBRule" $ \o -> do
+                db_rule_name       <- o .: "db_rule_name"
+                table_name         <- o .: "table_name"
+                indexed_cols_names <- o .: "indexed_cols_names"
+                db_rule_fixes      <- o .: "db_rule_fixes"
+                return (DBRule {db_rule_name = db_rule_name, table_name = table_name, indexed_cols_names = indexed_cols_names, db_rule_fixes = db_rule_fixes})
+
+data Action = Allowed | Blocked
+  deriving (Show, Eq)
+
+instance FromJSON Action where
+  parseJSON = withText "Action" $ \s -> case s of
+                "Allowed" -> return Allowed
+                "Blocked" -> return Blocked
+                _         -> fail "Invalid Action in rule"
+
+-- First check for arg_types if it is allowed or not. If allowed, then further check for arg_fns
+data FunctionInfo = 
+  FunctionInfo 
+    {
+      fnName         :: String,
+      isQualified    :: Bool,
+      argNo          :: ArgNo,
+      fnAction       :: Action,
+      argTypes       :: ArgTypes,
+      argFns         :: [FunctionInfo],
+      suggestedFixes :: Suggestions
+    }
+  deriving (Show, Eq)  
+
+instance FromJSON FunctionInfo where
+  parseJSON = withObject "FunctionInfo" $ \o -> do
+                fnName         <- o .: "fnName"
+                isQualified    <- o .:? "isQualified" .!= False
+                argNo          <- o .: "argNo"
+                fnAction       <- o .: "action"
+                argTypes       <- o .: "argTypes"
+                argFns         <- o .: "argFns"
+                suggestedFixes <- o .: "suggestedFixes"
+                return (FunctionInfo { fnName = fnName, isQualified = isQualified, argNo = argNo, fnAction = fnAction, argTypes = argTypes, argFns = argFns, suggestedFixes = suggestedFixes })
+
+-- First check for all conditions to be true, and if satisfied, then
+data GeneralRule = 
+  GeneralRule 
+    {
+      ruleName   :: String,
+      conditions :: [FunctionInfo],
+      ruleInfo   :: FunctionInfo
+    }
+  deriving (Show, Eq)
+
+instance FromJSON GeneralRule where
+  parseJSON = withObject "GeneralRule" $ \o -> do
+                ruleName   <- o .: "ruleName"
+                conditions <- o .: "conditions"
+                ruleInfo   <- o .: "ruleInfo"
+                return (GeneralRule {ruleName = ruleName, conditions = conditions, ruleInfo = ruleInfo})
 
 data Rule = 
     DBRuleT DBRule
   | FunctionRuleT FunctionRule
+  | GeneralRuleT GeneralRule
   deriving (Show, Eq)  
+
+instance FromJSON Rule where
+  parseJSON str = (DBRuleT <$> parseJSON str) <|> (FunctionRuleT <$> parseJSON str) <|> (GeneralRuleT <$> parseJSON str)
 
 data LocalVar = FnArg Var | FnWhere Var | FnLocal Var
   deriving (Eq)
@@ -159,10 +245,10 @@ instance Show Violation where
 
 getViolationSuggestions :: Violation -> Suggestions
 getViolationSuggestions v = case v of
-  ArgTypeBlocked _ r -> fnRuleFixes r
-  FnBlockedInArg _ r -> fnRuleFixes r
-  FnUseBlocked r -> fnRuleFixes r
-  NonIndexedDBColumn _ _ r -> dbRuleFixes r
+  ArgTypeBlocked _ r -> fn_rule_fixes r
+  FnBlockedInArg _ r -> fn_rule_fixes r
+  FnUseBlocked r -> fn_rule_fixes r
+  NonIndexedDBColumn _ _ r -> db_rule_fixes r
   NoViolation -> []
 
 getViolationType :: Violation -> String

--- a/sheriff/test/Test1.hs
+++ b/sheriff/test/Test1.hs
@@ -159,7 +159,7 @@ main = do
     logError "tag" $ show en
     logErrorT "tag" $ encodeJSON en
     logError "tag" $ show en2
-    logErrorT "tag" $ encodeJSON en2
+    logErrorT (T.pack $ show "tag") $ encodeJSON en2
     logError "tag" $ show en3
     logErrorT "tag" $ encodeJSON en3
     logError "tag" $ show (en, "This is Text" :: String)


### PR DESCRIPTION
1. Add exceptions rules to not throw error if any exception is satisfied for same src span
2. Fix src span issue with ($) operator cases
3. Add rules list from the config files along with default must rules
4. Make error location more specific. Instead of indicating the whole log function, it will specifically point out which show is wrong