### PR TITLE
GHC 9.2.8 support for fdep & fieldInspector

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,3 @@
 packages:
   ./fdep
-  ./coresyn2chart
-  ./sheriff
   ./fieldInspector

--- a/coresyn2chart/coresyn2chart.cabal
+++ b/coresyn2chart/coresyn2chart.cabal
@@ -38,13 +38,13 @@ common common-options
         bytestring
         , containers
         , filepath
-        , ghc ^>= 8.10.7
+        , ghc
         , unordered-containers
         , aeson
         , directory
         , extra
         , aeson-pretty
-        , base ^>=4.14.3.0
+        , base
         , text
         , base64-bytestring
         , optparse-applicative

--- a/fdep/fdep.cabal
+++ b/fdep/fdep.cabal
@@ -12,7 +12,7 @@ build-type:         Simple
 extra-doc-files:    CHANGELOG.md
 
 common common-options
-  build-depends:       base ^>=4.14.3.0
+  build-depends:       base
   ghc-options:         -Wall
                        -Wincomplete-uni-patterns
                        -Wincomplete-record-updates
@@ -39,10 +39,10 @@ library
                 bytestring
                 , containers
                 , filepath
-                , ghc ^>= 8.10.7
+                , ghc
                 , ghc-exactprint
                 , unordered-containers
-                , uniplate >= 1.6  && < 1.7
+                , uniplate
                 , references
                 , classyplate
                 , aeson
@@ -58,6 +58,7 @@ library
                 , deepseq
                 , websockets
                 , network
+                , primitive
     hs-source-dirs:   src
     default-language: Haskell2010
 

--- a/fdep/src/Fdep/Plugin.hs
+++ b/fdep/src/Fdep/Plugin.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE CPP #-}
 
 module Fdep.Plugin (plugin) where
 
-import Bag (bagToList)
 import Control.Concurrent ( forkIO )
 import Control.DeepSeq (force)
 import Control.Exception (SomeException, evaluate, try)
@@ -19,7 +19,6 @@ import Data.ByteString.Lazy (toStrict, writeFile)
 import qualified Data.ByteString.Lazy as BL
 import Data.Data (toConstr)
 import Data.Generics.Uniplate.Data ()
-import qualified Data.HashMap.Strict as HM
 import Data.List.Extra (splitOn)
 import qualified Data.Map as Map
 import Data.Maybe (fromJust, fromMaybe, isJust)
@@ -27,26 +26,38 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Data.Time ( diffUTCTime, getCurrentTime )
-import DynFlags ()
-import Text.Read (readMaybe)
 import Fdep.Types
     ( PFunction(PFunction),
       FunctionInfo(FunctionInfo) )
-import GHC (
-    GRHS (..),
-    GRHSs (..),
-    GhcTc,
-    HsExpr (..),
-    LGRHS,
-    LHsExpr,
-    LMatch,
-    Match (m_grhss),
-    MatchGroup (..),
-    Module (moduleName),
-    getName,
-    hsmodDecls,
-    moduleNameString, GhcPs
- )
+import Text.Read (readMaybe)
+import Prelude hiding (id, mapM, mapM_, writeFile)
+import qualified Prelude as P
+import qualified Data.List.Extra as Data.List
+import Network.Socket (withSocketsDo)
+import qualified Network.WebSockets as WS
+import System.Directory ( createDirectoryIfMissing )
+import System.Environment (lookupEnv)
+import GHC.IO (unsafePerformIO)
+#if __GLASGOW_HASKELL__ >= 900
+import Streamly.Prelude (fromList,mapM_,mapM,toList)
+import Streamly ( parallely)
+import GHC
+import GHC.Driver.Plugins (Plugin(..),CommandLineOption,defaultPlugin,PluginRecompile(..))
+import GHC.Driver.Env
+import GHC.Tc.Types
+import GHC.Unit.Module.ModSummary
+import GHC.Utils.Outputable (showSDocUnsafe,ppr)
+import GHC.Data.Bag (bagToList)
+import GHC.Types.Name hiding (varName)
+import GHC.Types.Var
+import qualified Data.Aeson.KeyMap as HM
+#else
+import Streamly.Prelude (fromList, mapM, mapM_, toList)
+import Streamly ( parallely )
+import qualified Data.HashMap.Strict as HM
+import Bag (bagToList)
+import DynFlags ()
+import GHC
 import GHC.Hs.Binds
     ( HsBindLR(PatBind, FunBind, AbsBinds, VarBind, PatSynBind,
                XHsBindsLR, fun_id, abs_binds, var_rhs),
@@ -57,35 +68,23 @@ import GHC.Hs.Binds
       PatSynBind(XPatSynBind, PSB, psb_def) )
 import GHC.Hs.Decls
     ( HsDecl(SigD, TyClD, InstD, DerivD, ValD), LHsDecl )
-import GHC.IO (unsafePerformIO)
 import GhcPlugins (HsParsedModule, Hsc, Plugin (..), PluginRecompile (..), Var (..), getOccString, hpm_module, ppr, showSDocUnsafe)
 import HscTypes (ModSummary (..),msHsFilePath)
 import Name (nameStableString)
-import Network.Socket (withSocketsDo)
-import qualified Network.WebSockets as WS
 import Outputable ()
 import Plugins (CommandLineOption, defaultPlugin)
 import SrcLoc ( GenLocated(L), getLoc, noLoc, unLoc )
-import Streamly ( parallely )
-import Streamly.Prelude (fromList, mapM, mapM_, toList)
-import System.Directory ( createDirectoryIfMissing )
-import System.Environment (lookupEnv)
 import TcRnTypes (TcGblEnv (..), TcM)
-import Prelude hiding (id, mapM, mapM_, writeFile)
-import qualified Prelude as P
-import qualified Data.List.Extra as Data.List
 import StringBuffer
+#endif
 
 plugin :: Plugin
 plugin =
     defaultPlugin
         { typeCheckResultAction = fDep
-        , pluginRecompile = purePlugin
+        , pluginRecompile = (\_ -> return NoForceRecompile)
         , parsedResultAction = collectDecls
         }
-
-purePlugin :: [CommandLineOption] -> IO PluginRecompile
-purePlugin _ = return NoForceRecompile
 
 filterList :: [Text]
 filterList =
@@ -171,7 +170,7 @@ getDecls x = do
         (L _ (SigD _ _)) -> pure mempty
         _ -> pure mempty
   where
-    getFunBind f@FunBind{fun_id = funId} = [((T.pack $ showSDocUnsafe $ ppr $ unLoc funId) <> "**" <> (T.pack $ showSDocUnsafe $ ppr $ getLoc funId), PFunction ((T.pack $ showSDocUnsafe $ ppr $ unLoc funId) <> "**" <> (T.pack $ showSDocUnsafe $ ppr $ getLoc funId)) (T.pack $ showSDocUnsafe $ ppr f) (T.pack $ showSDocUnsafe $ ppr $ getLoc funId))]
+    getFunBind f@FunBind{fun_id = funId} = [((T.pack $ showSDocUnsafe $ ppr $ unLoc funId) <> "**" <> (T.pack $ showSDocUnsafe $ ppr $ getLoc' funId), PFunction ((T.pack $ showSDocUnsafe $ ppr $ unLoc funId) <> "**" <> (T.pack $ showSDocUnsafe $ ppr $ getLoc' funId)) (T.pack $ showSDocUnsafe $ ppr f) (T.pack $ showSDocUnsafe $ ppr $ getLoc' funId))]
     getFunBind _ = mempty
 
 shouldForkPerFile :: Bool
@@ -187,7 +186,7 @@ shouldForkPerFile = readBool $ unsafePerformIO $ lookupEnv "SHOULD_FORK"
     readBool _ = True
 
 shouldGenerateFdep :: Bool
-shouldGenerateFdep = True--readBool $ unsafePerformIO $ lookupEnv "GENERATE_FDEP"
+shouldGenerateFdep = readBool $ unsafePerformIO $ lookupEnv "GENERATE_FDEP"
   where
     readBool :: (Maybe String) -> Bool
     readBool (Just "true") = True
@@ -242,7 +241,7 @@ fDep opts modSummary tcEnv = do
                     eres <- try $ WS.runClient websocketHost websocketPort ("/" <> modulePath <> ".json") (\conn -> do mapM_ (loopOverLHsBindLR (Just conn) Nothing (T.pack ("/" <> modulePath <> ".json"))) (fromList binds))
                     case eres of
                         Left (err :: SomeException) -> when shouldLog $ print err
-                        Right val -> pure ()
+                        Right _ -> pure ()
                 t2 <- getCurrentTime
                 when shouldLog $ print ("generated dependancy for module: " <> moduleName' <> " at path: " <> path <> " total-timetaken: " <> show (diffUTCTime t2 t1))
     return tcEnv
@@ -268,15 +267,20 @@ sendTextData' conn path data_ = do
     when (shouldLog) $ print ("websocket call timetaken: " <> (T.pack $ show $ diffUTCTime t2 t1))
 
 loopOverLHsBindLR :: Maybe WS.Connection -> (Maybe Text) -> Text -> LHsBindLR GhcTc GhcTc -> IO ()
+#if __GLASGOW_HASKELL__ >= 900
+loopOverLHsBindLR mConn mParentName path (L _ x@(FunBind fun_ext id matches _)) = do
+#else
 loopOverLHsBindLR mConn mParentName path (L _ x@(FunBind fun_ext id matches _ _)) = do
+#endif
     funName <- evaluate $ force $ T.pack $ getOccString $ unLoc id
     fName <- evaluate $ force $ T.pack $ nameStableString $ getName id
+    print (funName,fName,(T.pack $ showSDocUnsafe (ppr (getLoc' id))))
     let matchList = mg_alts matches
     if funName `elem` (unsafePerformIO $ decodeBlacklistedFunctions) || ("$_in$$" `T.isPrefixOf` fName)
         then pure mempty
         else do
             when (shouldLog) $ print ("processing function: " <> fName)
-            name <- evaluate $ force (fName <> "**" <> (T.pack $ showSDocUnsafe (ppr (getLoc id))))
+            name <- evaluate $ force (fName <> "**" <> (T.pack $ showSDocUnsafe (ppr (getLoc' id))))
             typeSignature <- evaluate $ force $ (T.pack $ showSDocUnsafe (ppr (varType (unLoc id))))
             nestedNameWithParent <- evaluate $ force $ (maybe (name) (\x -> x <> "::" <> name) mParentName)
             data_ <- evaluate $ force $ (decodeUtf8 $ toStrict $ Data.Aeson.encode $ Object $ HM.fromList [("key", String nestedNameWithParent), ("typeSignature", String typeSignature)])
@@ -303,7 +307,11 @@ loopOverLHsBindLR _ _ _ (L _ (PatBind _ _ pat_rhs _)) = pure mempty
 
 processMatch :: WS.Connection -> Text -> Text -> LMatch GhcTc (LHsExpr GhcTc) -> IO ()
 processMatch con keyFunction path (L _ match) = do
+#if __GLASGOW_HASKELL__ >= 900
+    whereClause <- (evaluate . force) =<< (processHsLocalBinds con keyFunction path $ grhssLocalBinds (m_grhss match))
+#else
     whereClause <- (evaluate . force) =<< (processHsLocalBinds con keyFunction path $ unLoc $ grhssLocalBinds (m_grhss match))
+#endif
     mapM_ (processGRHS con keyFunction path) $ fromList $ grhssGRHSs (m_grhss match)
     pure mempty
 
@@ -322,7 +330,8 @@ processExpr :: WS.Connection -> Text -> Text -> LHsExpr GhcTc -> IO ()
 processExpr con keyFunction path x@(L _ (HsVar _ (L _ var))) = do
     let name = T.pack $ nameStableString $ varName var
         _type = T.pack $ showSDocUnsafe $ ppr $ varType var
-    expr <- evaluate $ force $ transformFromNameStableString (Just name, Just $ T.pack $ showSDocUnsafe $ ppr $ getLoc $ x, Just _type, mempty)
+    print (Just $ T.pack $ showSDocUnsafe $ ppr $ getLoc' $ x)
+    expr <- evaluate $ force $ transformFromNameStableString (Just name, Just $ T.pack $ showSDocUnsafe $ ppr $ getLoc' $ x, Just _type, mempty)
     sendTextData' con path (decodeUtf8 $ toStrict $ Data.Aeson.encode $ Object $ HM.fromList [("key", String keyFunction), ("expr", toJSON expr)])
 processExpr _ _ _ (L _ (HsUnboundVar _ _)) = pure mempty
 processExpr con keyFunction path (L _ (HsApp _ funl funr)) = do
@@ -338,10 +347,9 @@ processExpr con keyFunction path (L _ (HsTick _ _ fun)) =
     processExpr con keyFunction path fun
 processExpr con keyFunction path (L _ (HsStatic _ fun)) =
     processExpr con keyFunction path fun
-processExpr con keyFunction path (L _ x@(HsWrap _ _ fun)) =
-    processExpr con keyFunction path (noLoc fun)
 processExpr con keyFunction path (L _ (HsBinTick _ _ _ fun)) =
     processExpr con keyFunction path fun
+#if __GLASGOW_HASKELL__ < 900
 processExpr con keyFunction path (L _ (ExplicitList _ _ funList)) =
     mapM_ (processExpr con keyFunction path) (fromList funList)
 processExpr con keyFunction path (L _ (HsTickPragma _ _ _ _ fun)) =
@@ -350,6 +358,37 @@ processExpr con keyFunction path (L _ (HsSCC _ _ _ fun)) =
     processExpr con keyFunction path fun
 processExpr con keyFunction path (L _ (HsCoreAnn _ _ _ fun)) =
     processExpr con keyFunction path fun
+processExpr con keyFunction path (L _ x@(HsWrap _ _ fun)) =
+    processExpr con keyFunction path (noLoc fun)
+processExpr con keyFunction path (L _ (HsIf _ exprLStmt funl funm funr)) =
+    let stmts = (exprLStmt ^? biplateRef :: [LHsExpr GhcTc])
+     in mapM_ (processExpr con keyFunction path) $ fromList $ [funl, funm, funr] <> stmts
+processExpr con keyFunction path (L _ (HsTcBracketOut b exprLStmtL exprLStmtR)) =
+    let stmtsL = (exprLStmtL ^? biplateRef :: [LHsExpr GhcTc])
+        stmtsR = (exprLStmtR ^? biplateRef :: [LHsExpr GhcTc])
+     in mapM_ (processExpr con keyFunction path) (fromList $ stmtsL <> stmtsR)
+processExpr con keyFunction path (L _ x@(HsWrap _ fun)) =
+    processExpr con keyFunction path (fun)
+#else
+processExpr con keyFunction path (L _ (HsGetField _ exprLStmt _)) =
+    let stmts = exprLStmt ^? biplateRef :: [LHsExpr GhcTc]
+     in mapM_ (processExpr con keyFunction path) (fromList stmts)
+processExpr con keyFunction path (L _ (ExplicitList _ funList)) =
+    mapM_ (processExpr con keyFunction path) (fromList funList)
+processExpr con keyFunction path (L _ (HsPragE _ _ fun)) =
+    processExpr con keyFunction path fun
+processExpr con keyFunction path (L _ (HsProc _ lPat fun)) = do
+    let stmts = lPat ^? biplateRef :: [LHsExpr GhcTc]
+        stmts' = fun ^? biplateRef :: [LHsExpr GhcTc]
+    mapM_ (processExpr con keyFunction path) (fromList (stmts <> stmts'))
+processExpr con keyFunction path (L _ (HsIf exprLStmt funl funm funr)) =
+    let stmts = (exprLStmt ^? biplateRef :: [LHsExpr GhcTc])
+     in mapM_ (processExpr con keyFunction path) $ fromList $ [funl, funm, funr] <> stmts
+processExpr con keyFunction path (L _ (HsTcBracketOut b mQW exprLStmtL exprLStmtR)) =
+    let stmtsL = (exprLStmtL ^? biplateRef :: [LHsExpr GhcTc])
+        stmtsR = (exprLStmtR ^? biplateRef :: [LHsExpr GhcTc])
+     in mapM_ (processExpr con keyFunction path) (fromList $ stmtsL <> stmtsR)
+#endif
 processExpr con keyFunction path (L _ (ExprWithTySig _ fun _)) =
     processExpr con keyFunction path fun
 processExpr con keyFunction path (L _ (HsDo _ _ exprLStmt)) =
@@ -361,9 +400,6 @@ processExpr con keyFunction path (L _ (HsLet _ exprLStmt func)) =
 processExpr con keyFunction path (L _ (HsMultiIf _ exprLStmt)) =
     let stmts = exprLStmt ^? biplateRef :: [LHsExpr GhcTc]
      in mapM_ (processExpr con keyFunction path) (fromList stmts)
-processExpr con keyFunction path (L _ (HsIf _ exprLStmt funl funm funr)) =
-    let stmts = (exprLStmt ^? biplateRef :: [LHsExpr GhcTc])
-     in mapM_ (processExpr con keyFunction path) $ fromList $ [funl, funm, funr] <> stmts
 processExpr con keyFunction path (L _ (HsCase _ funl exprLStmt)) =
     let stmts = (exprLStmt ^? biplateRef :: [LHsExpr GhcTc])
      in mapM_ (processExpr con keyFunction path) $ fromList $ [funl] <> stmts
@@ -382,10 +418,10 @@ processExpr con keyFunction path (L _ x@(HsLam _ exprLStmt)) =
     let stmts = (exprLStmt ^? biplateRef :: [LHsExpr GhcTc])
      in mapM_ (processExpr con keyFunction path) (fromList stmts)
 processExpr con keyFunction path y@(L _ x@(HsLit _ hsLit)) = do
-    expr <- evaluate $ force $ transformFromNameStableString (Just $ ("$_lit$" <> (T.pack $ showSDocUnsafe $ ppr hsLit)), (Just $ T.pack $ showSDocUnsafe $ ppr $ getLoc $ y), (Just $ T.pack $ show $ toConstr hsLit), mempty)
+    expr <- evaluate $ force $ transformFromNameStableString (Just $ ("$_lit$" <> (T.pack $ showSDocUnsafe $ ppr hsLit)), (Just $ T.pack $ showSDocUnsafe $ ppr $ getLoc' $ y), (Just $ T.pack $ show $ toConstr hsLit), mempty)
     sendTextData' con path (decodeUtf8 $ toStrict $ Data.Aeson.encode $ Object $ HM.fromList [("key", String keyFunction), ("expr", toJSON expr)])
 processExpr con keyFunction path y@(L _ x@(HsOverLit _ overLitVal)) = do
-    expr <- evaluate $ force $ transformFromNameStableString (Just $ ("$_lit$" <> (T.pack $ showSDocUnsafe $ ppr overLitVal)), (Just $ T.pack $ showSDocUnsafe $ ppr $ getLoc $ y), (Just $ T.pack $ show $ toConstr overLitVal), mempty)
+    expr <- evaluate $ force $ transformFromNameStableString (Just $ ("$_lit$" <> (T.pack $ showSDocUnsafe $ ppr overLitVal)), (Just $ T.pack $ showSDocUnsafe $ ppr $ getLoc' $ y), (Just $ T.pack $ show $ toConstr overLitVal), mempty)
     sendTextData' con path (decodeUtf8 $ toStrict $ Data.Aeson.encode $ Object $ HM.fromList [("key", String keyFunction), ("expr", toJSON expr)])
 processExpr con keyFunction path (L _ (HsRecFld _ exprLStmt)) =
     let stmts = (exprLStmt ^? biplateRef :: [LHsExpr GhcTc])
@@ -405,14 +441,28 @@ processExpr con keyFunction path (L _ (HsRnBracketOut _ exprLStmtL exprLStmtR)) 
     let stmtsL = (exprLStmtL ^? biplateRef :: [LHsExpr GhcTc])
         stmtsR = (exprLStmtR ^? biplateRef :: [LHsExpr GhcTc])
      in mapM_ (processExpr con keyFunction path) (fromList $ stmtsL <> stmtsR)
-processExpr con keyFunction path (L _ (HsTcBracketOut _ exprLStmtL exprLStmtR)) =
-    let stmtsL = (exprLStmtL ^? biplateRef :: [LHsExpr GhcTc])
-        stmtsR = (exprLStmtR ^? biplateRef :: [LHsExpr GhcTc])
-     in mapM_ (processExpr con keyFunction path) (fromList $ stmtsL <> stmtsR)
 processExpr con keyFunction path (L _ (RecordCon _ (L _ (iD)) rcon_flds)) =
     let stmts = (rcon_flds ^? biplateRef :: [LHsExpr GhcTc])
      in mapM_ (processExpr con keyFunction path) (fromList stmts)
 processExpr con keyFunction path (L _ (RecordUpd _ rupd_expr rupd_flds)) =
     let stmts = (rupd_flds ^? biplateRef :: [LHsExpr GhcTc])
      in mapM_ (processExpr con keyFunction path) (fromList stmts)
-processExpr _ _ _ _ = pure mempty
+processExpr con keyFunction path (L _ x) =
+    let stmts = (x ^? biplateRef :: [LHsExpr GhcTc])
+     in mapM_ (processExpr con keyFunction path) (fromList stmts)
+
+
+-- processExpr _ _ _ (L _ (HsConLikeOut _ _)) = pure mempty
+-- processExpr _ _ _ (L _ (HsOverLabel _ _)) = pure mempty
+-- processExpr _ _ _ (L _ (HsIPVar _ _)) = pure mempty
+-- processExpr _ _ _ (L _ (SectionL _ _ _)) = pure mempty
+-- processExpr _ _ _ (L _ (HsProjection _ _)) = pure mempty
+-- processExpr _ _ _ (L _ (HsBracket _ _)) = pure mempty
+-- processExpr _ _ _ (L _ (XExpr _)) = pure mempty
+
+
+#if __GLASGOW_HASKELL__ > 900
+getLoc' = la2r . getLoc
+#else
+getLoc' = getLoc
+#endif

--- a/fieldInspector/fieldInspector.cabal
+++ b/fieldInspector/fieldInspector.cabal
@@ -79,14 +79,14 @@ common common-options
         bytestring
         , containers
         , filepath
-        , ghc ^>= 8.10.7
+        , ghc
         , unordered-containers
         , aeson
         , directory
         , extra
         , aeson-pretty
         , aeson
-        , base ^>=4.14.3.0
+        , base
         , text
         , base64-bytestring
         , optparse-applicative
@@ -102,7 +102,7 @@ common common-options
         , large-generics
         , large-anon
         , ghc-hasfield-plugin
-        , record-dot-preprocessor ==0.2.14
+        , record-dot-preprocessor
         , ghc-tcplugin-api
         , typelet
         , record-hasfield
@@ -177,8 +177,7 @@ test-suite fieldInspector-test
         , large-records
         , large-generics
         , large-anon
-        , ghc-hasfield-plugin
-        , record-dot-preprocessor ==0.2.14
+        , record-dot-preprocessor
         , ghc-tcplugin-api
         , typelet
         , record-hasfield

--- a/fieldInspector/src/FieldInspector/PluginFields.hs
+++ b/fieldInspector/src/FieldInspector/PluginFields.hs
@@ -2,12 +2,88 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE CPP #-}
 
 module FieldInspector.PluginFields (plugin) where
 
-import Bag (bagToList)
-import Control.Exception (evaluate)
-import Control.Reference (biplateRef, (^?))
+
+#if __GLASGOW_HASKELL__ >= 900
+import qualified Data.IntMap.Internal as IntMap
+import Streamly.Prelude (fromList,mapM_,mapM,toList)
+import Streamly ( parallely)
+import GHC
+import GHC.Driver.Plugins (Plugin(..),CommandLineOption,defaultPlugin,PluginRecompile(..))
+import GHC as GhcPlugins
+import GHC.Core.DataCon as GhcPlugins
+import GHC.Core.TyCo.Rep
+import GHC.Core.TyCon as GhcPlugins
+import GHC.Driver.Env
+import GHC.Tc.Types
+import GHC.Unit.Module.ModSummary
+import GHC.Utils.Outputable (showSDocUnsafe,ppr,SDoc)
+import GHC.Data.Bag (bagToList)
+import GHC.Types.Name hiding (varName)
+import GHC.Types.Var
+import qualified Data.Aeson.KeyMap as HM
+import GHC.Core.Opt.Monad
+import GHC.Core
+import GHC.Unit.Module.ModGuts
+import GHC.Types.Name.Reader
+import GHC.Types.Id
+import GHC.Data.FastString
+
+#else
+import CoreMonad (CoreM, CoreToDo (CoreDoPluginPass), liftIO)
+import CoreSyn (
+    AltCon (..),
+    Bind (NonRec, Rec),
+    CoreBind,
+    CoreExpr,
+    Expr (..),
+    mkStringLit
+ )
+import TyCoRep
+import GHC.IO (unsafePerformIO)
+import GHC.Hs
+import GHC.Hs.Decls
+import GhcPlugins (
+    CommandLineOption,Arg (..),
+    HsParsedModule(..),
+    Hsc,
+    Name,SDoc,DataCon,DynFlags,ModSummary(..),TyCon,
+    Literal (..),typeEnvElts,
+    ModGuts (mg_binds, mg_loc, mg_module),showSDoc,
+    Module (moduleName),tyConKind,
+    NamedThing (getName),getDynFlags,tyConDataCons,dataConOrigArgTys,dataConName,
+    Outputable (..),dataConFieldLabels,
+    Plugin (..),
+    Var,flLabel,dataConRepType,
+    coVarDetails,
+    defaultPlugin,
+    idName,
+    mkInternalName,
+    mkLitString,
+    mkLocalVar,
+    mkVarOcc,
+    moduleNameString,
+    nameStableString,
+    noCafIdInfo,
+    purePlugin,
+    showSDocUnsafe,
+    tyVarKind,
+    unpackFS,
+    tyConName,
+    msHsFilePath
+ )
+import Id (isExportedId,idType)
+import Name (getSrcSpan)
+import SrcLoc
+import Unique (mkUnique)
+import Var (isLocalId,varType)
+import FieldInspector.Types
+import TcRnTypes
+import TcRnMonad
+import DataCon
 import CoreMonad (CoreM, CoreToDo (CoreDoPluginPass))
 import CoreSyn (
     AltCon (..),
@@ -16,27 +92,7 @@ import CoreSyn (
     CoreExpr,
     Expr (..),
  )
-import Data.Aeson.Encode.Pretty (encodePretty)
-import Data.Bool (bool)
-import qualified Data.ByteString as DBS
-import Data.ByteString.Lazy (toStrict)
-import Data.Data (Data (toConstr))
-import Data.Generics.Uniplate.Data ()
-import Data.List (sortBy)
-import Data.List.Extra (groupBy, intercalate, splitOn)
-import Data.Map (Map)
-import qualified Data.Map as Map
-import Data.Maybe (mapMaybe)
-import Data.Text (Text, pack)
-import qualified Data.Text as T
-import FieldInspector.Types (
-    DataConInfo (..),
-    DataTypeUC (DataTypeUC),
-    FieldRep (FieldRep),
-    FieldUsage (FieldUsage),
-    TypeInfo (..),
-    TypeVsFields (TypeVsFields),
- )
+import Bag (bagToList)
 import GHC.Hs (
     ConDecl (
         ConDeclGADT,
@@ -118,6 +174,61 @@ import SrcLoc (
     getLoc,
     unLoc,
  )
+import TcRnMonad (MonadIO (liftIO))
+import TcRnTypes (TcGblEnv (tcg_binds), TcM)
+import TyCoRep (Type (AppTy, FunTy, TyConApp, TyVarTy))
+import Var (varName, varType)
+#endif
+
+import FieldInspector.Types
+import Control.Concurrent (MVar, modifyMVar, newMVar)
+import Data.Aeson
+import Data.Aeson.Encode.Pretty (encodePretty)
+import qualified Data.ByteString as DBS
+import Data.ByteString.Lazy (toStrict)
+import Data.Int (Int64)
+import Data.List.Extra (intercalate, isSuffixOf, replace, splitOn,groupBy)
+import Data.List ( sortBy, intercalate ,foldl')
+import qualified Data.Map as Map
+import Data.Text (Text, concat, isInfixOf, pack, unpack)
+import qualified Data.Text as T
+import Data.Text.Encoding (decodeUtf8, encodeUtf8)
+import Data.Time
+import Data.Map (Map)
+import Data.Data
+import Data.Maybe (catMaybes)
+import Control.Monad.IO.Class (liftIO)
+import System.IO (writeFile)
+import Control.Monad (forM)
+import Streamly (parallely, serially)
+import Streamly.Prelude hiding (concatMap, init, length, map, splitOn,foldl',intercalate)
+import System.Directory (createDirectoryIfMissing, removeFile)
+import System.Directory.Internal.Prelude hiding (mapM, mapM_)
+import Prelude hiding (id, mapM, mapM_)
+import Control.Exception (evaluate)
+import Control.Exception (evaluate)
+import Control.Reference (biplateRef, (^?))
+import Data.Aeson.Encode.Pretty (encodePretty)
+import Data.Bool (bool)
+import qualified Data.ByteString as DBS
+import Data.ByteString.Lazy (toStrict)
+import Data.Data (Data (toConstr))
+import Data.Generics.Uniplate.Data ()
+import Data.List (sortBy)
+import Data.List.Extra (groupBy, intercalate, splitOn)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Maybe (mapMaybe)
+import Data.Text (Text, pack)
+import qualified Data.Text as T
+import FieldInspector.Types (
+    DataConInfo (..),
+    DataTypeUC (DataTypeUC),
+    FieldRep (FieldRep),
+    FieldUsage (FieldUsage),
+    TypeInfo (..),
+    TypeVsFields (TypeVsFields),
+ )
 import Streamly (parallely)
 import Streamly.Prelude (fromList, mapM, toList)
 import System.Directory (createDirectoryIfMissing, removeFile)
@@ -129,18 +240,14 @@ import System.Directory.Internal.Prelude (
     on,
     throwIO,
  )
-import TcRnMonad (MonadIO (liftIO))
-import TcRnTypes (TcGblEnv (tcg_binds), TcM)
-import TyCoRep (Type (AppTy, FunTy, TyConApp, TyVarTy))
-import Var (varName, varType)
 import Prelude hiding (id, mapM, mapM_)
 
 plugin :: Plugin
 plugin =
     defaultPlugin
         { installCoreToDos = install
-        , pluginRecompile = GhcPlugins.purePlugin
-        , typeCheckResultAction = collectTypesTC
+        , pluginRecompile = (\_ -> return NoForceRecompile)
+        -- , typeCheckResultAction = collectTypesTC
         }
 install :: [CommandLineOption] -> [CoreToDo] -> CoreM [CoreToDo]
 install args todos = return (CoreDoPluginPass "FieldInspector" (buildCfgPass args) : todos)
@@ -152,21 +259,21 @@ removeIfExists fileName = removeFile fileName `catch` handleExists
         | isDoesNotExistError e = return ()
         | otherwise = throwIO e
 
-collectTypesTC :: [CommandLineOption] -> ModSummary -> TcGblEnv -> TcM TcGblEnv
-collectTypesTC opts modSummary tcEnv = do
-    _ <- liftIO $
-        forkIO $
-            do
-                let prefixPath = case opts of
-                        [] -> "/tmp/fieldInspector/"
-                        local : _ -> local
-                    modulePath = prefixPath <> msHsFilePath modSummary
-                    path = (intercalate "/" . init . splitOn "/") modulePath
-                    binds = bagToList $ tcg_binds tcEnv
-                createDirectoryIfMissing True path
-                functionVsUpdates <- getAllTypeManipulations binds
-                DBS.writeFile ((modulePath) <> ".typeUpdates.json") (toStrict $ encodePretty functionVsUpdates)
-    return tcEnv
+-- collectTypesTC :: [CommandLineOption] -> ModSummary -> TcGblEnv -> TcM TcGblEnv
+-- collectTypesTC opts modSummary tcEnv = do
+--     _ <- liftIO $
+--         forkIO $
+--             do
+--                 let prefixPath = case opts of
+--                         [] -> "/tmp/fieldInspector/"
+--                         local : _ -> local
+--                     modulePath = prefixPath <> msHsFilePath modSummary
+--                     path = (intercalate "/" . init . splitOn "/") modulePath
+--                     binds = bagToList $ tcg_binds tcEnv
+--                 createDirectoryIfMissing True path
+--                 functionVsUpdates <- getAllTypeManipulations binds
+--                 DBS.writeFile ((modulePath) <> ".typeUpdates.json") (toStrict $ encodePretty functionVsUpdates)
+--     return tcEnv
 
 buildCfgPass :: [CommandLineOption] -> ModGuts -> CoreM ModGuts
 buildCfgPass opts guts = do
@@ -198,7 +305,11 @@ getAllTypeManipulations binds = do
     pure $ catMaybes bindWiseUpdates
   where
     getDataTypeDetails :: HsExpr GhcTc -> Maybe TypeVsFields
-    getDataTypeDetails (RecordCon _ (L _ (iD)) rcon_flds) = Just (TypeVsFields (T.pack $ nameStableString $ getName $ idName iD) (extractRecordBinds (rcon_flds)))
+#if __GLASGOW_HASKELL__ >= 900
+    getDataTypeDetails (RecordCon _ (iD) rcon_flds) = Just (TypeVsFields (T.pack $ nameStableString $ getName (GHC.unXRec @(GhcTc) iD)) (extractRecordBinds (rcon_flds)))
+#else
+    getDataTypeDetails (RecordCon _ (iD) rcon_flds) = Just (TypeVsFields (T.pack $ nameStableString $ getName $ idName $ unLoc $ iD) (extractRecordBinds (rcon_flds)))
+#endif
     getDataTypeDetails (RecordUpd _ rupd_expr rupd_flds) = Just (TypeVsFields (T.pack $ showSDocUnsafe $ ppr rupd_expr) (getFieldUpdates rupd_flds))
 
     -- inferFieldType :: Name -> String
@@ -213,7 +324,20 @@ getAllTypeManipulations binds = do
             Orig module' occName -> ((moduleNameString $ moduleName module') <> "$" <> (showSDocUnsafe $ pprNameSpaceBrief $ occNameSpace occName) <> "$" <> (occNameString occName) <> "$" <> (unpackFS $ occNameFS occName))
             Exact name -> nameStableString name
 
-    getFieldUpdates :: [LHsRecUpdField GhcTc] -> [FieldRep]
+#if __GLASGOW_HASKELL__ >= 900
+    getFieldUpdates :: Either [LHsRecUpdField GhcTc] [LHsRecUpdProj GhcTc] -> Either [FieldRep] [Text]
+    getFieldUpdates fields = 
+        case fields of
+           Left x -> (Left . map (extractField . unLoc)) x 
+           Right x -> (Right . map (T.pack . showSDocUnsafe . ppr)) x
+      where
+        extractField :: HsRecUpdField GhcTc -> FieldRep
+        extractField (HsRecField{hsRecFieldLbl = lbl, hsRecFieldArg = expr, hsRecPun = pun}) =
+            if pun
+                then (FieldRep (T.pack $ showSDocUnsafe $ ppr lbl) (T.pack $ showSDocUnsafe $ ppr lbl) (T.pack $ inferFieldTypeAFieldOcc lbl))
+                else (FieldRep (T.pack $ showSDocUnsafe $ ppr lbl) (T.pack $ showSDocUnsafe $ ppr (unLoc expr)) (T.pack $ inferFieldTypeAFieldOcc lbl))
+#else
+    getFieldUpdates :: [LHsRecUpdField p]-> Either [FieldRep] [Text]
     getFieldUpdates fields = map extractField fields
       where
         extractField :: LHsRecUpdField GhcTc -> FieldRep
@@ -221,10 +345,11 @@ getAllTypeManipulations binds = do
             if pun
                 then (FieldRep (T.pack $ showSDocUnsafe $ ppr lbl) (T.pack $ showSDocUnsafe $ ppr lbl) (T.pack $ inferFieldTypeAFieldOcc lbl))
                 else (FieldRep (T.pack $ showSDocUnsafe $ ppr lbl) (T.pack $ showSDocUnsafe $ ppr (unLoc expr)) (T.pack $ inferFieldTypeAFieldOcc lbl))
+#endif
 
-    extractRecordBinds :: HsRecFields GhcTc (LHsExpr GhcTc) -> [FieldRep]
+    extractRecordBinds :: HsRecFields GhcTc (LHsExpr GhcTc) -> Either [FieldRep] [Text]
     extractRecordBinds (HsRecFields{rec_flds = fields}) =
-        map extractField fields
+        Left $ map extractField fields
       where
         extractField :: LHsRecField GhcTc (LHsExpr GhcTc) -> FieldRep
         extractField (L _ (HsRecField{hsRecFieldLbl = lbl, hsRecFieldArg = expr, hsRecPun = pun})) =
@@ -233,29 +358,43 @@ getAllTypeManipulations binds = do
                 else (FieldRep (T.pack $ showSDocUnsafe $ ppr lbl) (T.pack $ showSDocUnsafe $ ppr $ unLoc expr) (T.pack $ inferFieldTypeFieldOcc lbl))
 
     getFunctionName :: LHsBindLR GhcTc GhcTc -> [Text]
-    getFunctionName (L _ x@(FunBind fun_ext id matches _ _)) = [T.pack $ nameStableString $ getName id]
-    getFunctionName (L _ (VarBind{var_id = var, var_rhs = expr, var_inline = inline})) = [T.pack $ nameStableString $ getName var]
+    getFunctionName (L _ x@(FunBind fun_ext id matches _)) = [T.pack $ nameStableString $ getName id]
+    getFunctionName (L _ (VarBind{var_id = var, var_rhs = expr})) = [T.pack $ nameStableString $ getName var]
     getFunctionName (L _ (PatBind{pat_lhs = pat, pat_rhs = expr})) = [""]
     getFunctionName (L _ (AbsBinds{abs_binds = binds})) = Prelude.concatMap getFunctionName $ bagToList binds
 
 processPat :: LPat GhcTc -> [(Name, Maybe Text)]
 processPat (L _ pat) = case pat of
+#if __GLASGOW_HASKELL__ >= 900
+    ConPat _ _ details -> processDetails details
+#else
     ConPatIn _ details -> processDetails details
+#endif
     VarPat _ x@(L _ var) -> [(varName var, Just $ T.pack $ showSDocUnsafe $ ppr $ getLoc $ x)]
     ParPat _ pat' -> processPat pat'
     _ -> []
 
 processDetails :: HsConPatDetails GhcTc -> [(Name, Maybe Text)]
+#if __GLASGOW_HASKELL__ >= 900
+processDetails (PrefixCon _ args) = Prelude.concatMap processPat args
+#else
 processDetails (PrefixCon args) = Prelude.concatMap processPat args
+#endif
 processDetails (InfixCon arg1 arg2) = processPat arg1 <> processPat arg2
 processDetails (RecCon rec) = Prelude.concatMap processPatField (rec_flds rec)
 
 processPatField :: LHsRecField GhcTc (LPat GhcTc) -> [(Name, Maybe Text)]
 processPatField (L _ HsRecField{hsRecFieldArg = arg}) = processPat arg
 
+#if __GLASGOW_HASKELL__ >= 900
+getFilePath :: SrcSpan -> String
+getFilePath (RealSrcSpan rSSpan _) = unpackFS $ srcSpanFile rSSpan
+getFilePath (UnhelpfulSpan fs) = showSDocUnsafe $ ppr $ fs
+#else
 getFilePath :: SrcSpan -> String
 getFilePath (RealSrcSpan rSSpan) = unpackFS $ srcSpanFile rSSpan
 getFilePath (UnhelpfulSpan fs) = unpackFS fs
+#endif
 
 --   1. `HasField _ r _` where r is a variable
 
@@ -318,7 +457,11 @@ processHasField functionName (Var x) (Var hasField) = do
                         else do
                             print y
                             pure res
+#if __GLASGOW_HASKELL__ >= 900
+        (FunTy _ _ a _) -> do
+#else
         (FunTy _ a _) -> do
+#endif
             let fieldType = T.strip $ Prelude.last $ T.splitOn "->" $ pack $ showSDocUnsafe $ ppr $ varType hasField
             pure $
                 res
@@ -492,7 +635,11 @@ toLBind (Rec binds) = do
 processFieldExtraction :: Text -> Var -> Var -> Text -> IO [(Text, [FieldUsage])]
 processFieldExtraction functionName _field _type b = do
     res <- case (varType _field) of
+#if __GLASGOW_HASKELL__ >= 900
+        (FunTy _ _ a _) -> do
+#else
         (FunTy _ a _) -> do
+#endif
             let fieldType = T.strip $ Prelude.last $ T.splitOn "->" $ pack $ showSDocUnsafe $ ppr $ varType _field
             pure
                 [
@@ -560,7 +707,7 @@ toLexpr functionName (Var x) = pure mempty
 toLexpr functionName (Lit x) = pure mempty
 toLexpr functionName (Type _id) = pure mempty
 toLexpr functionName x@(App func@(App _ _) args@(Var isHasField))
-    | "$_sys$$dHasField" == pack (nameStableString $ idName isHasField) =
+    | "$_sys$$dHasField" == pack (nameStableString $ idName isHasField) = do
         processHasField functionName func args
     | otherwise = do
         processApp functionName x
@@ -586,6 +733,22 @@ processApp functionName x@(App func args) = do
     a <- toLexpr functionName args
     pure $ f <> a
 
+#if __GLASGOW_HASKELL__ >= 900
+toLAlt :: Text -> Alt Var -> IO [(Text, [FieldUsage])]
+toLAlt x (Alt a b c) = toLAlt' x (a,b,c)
+    where
+        toLAlt' :: Text -> (AltCon, [Var], CoreExpr) -> IO [(Text, [FieldUsage])]
+        toLAlt' functionName (DataAlt dataCon, val, e) = do
+            let typeName = GhcPlugins.tyConName $ GhcPlugins.dataConTyCon dataCon
+                extractingConstruct = showSDocUnsafe $ ppr $ GhcPlugins.dataConName dataCon
+                kindStr = showSDocUnsafe $ ppr $ tyConKind $ GhcPlugins.dataConTyCon dataCon
+            res <- toLexpr functionName e
+            pure $ ((map (\x -> (functionName, [FieldUsage (pack $ showSDocUnsafe $ ppr $ typeName) (pack $ extractingConstruct) (pack $ showSDocUnsafe $ ppr $ varType x) (pack $ nameStableString $ typeName) (pack $ showSDocUnsafe $ ppr x)])) val)) <> res
+        toLAlt' functionName (LitAlt lit, val, e) =
+            toLexpr functionName e
+        toLAlt' functionName (DEFAULT, val, e) =
+            toLexpr functionName e
+#else
 toLAlt :: Text -> (AltCon, [Var], CoreExpr) -> IO [(Text, [FieldUsage])]
 toLAlt functionName (DataAlt dataCon, val, e) = do
     let typeName = GhcPlugins.tyConName $ GhcPlugins.dataConTyCon dataCon
@@ -597,71 +760,10 @@ toLAlt functionName (LitAlt lit, val, e) =
     toLexpr functionName e
 toLAlt functionName (DEFAULT, val, e) =
     toLexpr functionName e
+#endif
 
 pprTyCon :: Name -> SDoc
 pprTyCon = ppr
 
 pprDataCon :: Name -> SDoc
 pprDataCon = ppr
-
-collectTypeInfoParser :: [CommandLineOption] -> ModSummary -> HsParsedModule -> Hsc HsParsedModule
-collectTypeInfoParser opts modSummary hpm = do
-    _ <- liftIO $
-        do
-            let prefixPath = case opts of
-                    [] -> "/tmp/fieldInspector/"
-                    local : _ -> local
-                moduleName' = moduleNameString $ GhcPlugins.moduleName $ ms_mod modSummary
-                modulePath = prefixPath <> msHsFilePath modSummary
-                hm_module = unLoc $ hpm_module hpm
-                path = (intercalate "/" . init . splitOn "/") modulePath
-            -- print ("generating types data for module: " <> moduleName' <> " at path: " <> path)
-            types <- toList $ parallely $ mapM (pure . getTypeInfo) (fromList $ hsmodDecls hm_module)
-            createDirectoryIfMissing True path
-            DBS.writeFile (modulePath <> ".types.parser.json") (toStrict $ encodePretty $ Map.fromList $ Prelude.concat types)
-    -- print ("generated types data for module: " <> moduleName' <> " at path: " <> path)
-    return hpm
-
-getTypeInfo :: LHsDecl GhcPs -> [(String, TypeInfo)]
-getTypeInfo (L _ (TyClD _ (DataDecl _ lname _ _ defn))) =
-    [
-        ( showSDocUnsafe (ppr lname)
-        , TypeInfo
-            { name = showSDocUnsafe (ppr lname)
-            , typeKind = "data"
-            , dataConstructors = map getDataConInfo (dd_cons defn)
-            }
-        )
-    ]
-getTypeInfo (L _ (TyClD _ (SynDecl _ lname _ _ rhs))) =
-    [
-        ( showSDocUnsafe (ppr lname)
-        , TypeInfo
-            { name = showSDocUnsafe (ppr lname)
-            , typeKind = "type"
-            , dataConstructors = [DataConInfo (showSDocUnsafe (ppr lname)) (Map.singleton "synonym" (showSDocUnsafe (ppr rhs))) []]
-            }
-        )
-    ]
-getTypeInfo _ = []
-
-getDataConInfo :: LConDecl GhcPs -> DataConInfo
-getDataConInfo (L _ ConDeclH98{con_name = lname, con_args = args}) =
-    DataConInfo
-        { dataConNames = showSDocUnsafe (ppr lname)
-        , fields = getFieldMap args
-        , sumTypes = [] -- For H98-style data constructors, sum types are not applicable
-        }
-getDataConInfo (L _ ConDeclGADT{con_names = lnames, con_res_ty = ty}) =
-    DataConInfo
-        { dataConNames = intercalate ", " (map (showSDocUnsafe . ppr) lnames)
-        , fields = Map.singleton "gadt" (showSDocUnsafe (ppr ty))
-        , sumTypes = [] -- For GADT-style data constructors, sum types can be represented by the type itself
-        }
-
-getFieldMap :: HsConDeclDetails GhcPs -> Map String String
-getFieldMap (PrefixCon args) = Map.fromList $ Prelude.zipWith (\i t -> (show i, showSDocUnsafe (ppr t))) [1 ..] args
-getFieldMap (RecCon (L _ fields)) = Map.fromList $ concatMap getRecField fields
-  where
-    getRecField (L _ (ConDeclField _ fnames t _)) = [(showSDocUnsafe (ppr fname), showSDocUnsafe (ppr t)) | L _ fname <- fnames]
-getFieldMap (InfixCon t1 t2) = Map.fromList [("field1", showSDocUnsafe (ppr t1)), ("field2", showSDocUnsafe (ppr t2))]

--- a/fieldInspector/src/FieldInspector/PluginTypes.hs
+++ b/fieldInspector/src/FieldInspector/PluginTypes.hs
@@ -54,7 +54,7 @@ import GhcPlugins (
     ModGuts (mg_binds, mg_loc, mg_module),showSDoc,
     Module (moduleName),tyConKind,
     NamedThing (getName),getDynFlags,tyConDataCons,dataConOrigArgTys,dataConName,
-    Outputable (..),dataConFieldLabels,
+    Outputable (..),dataConFieldLabels,PluginRecompile(..),
     Plugin (..),
     Var,flLabel,dataConRepType,
     coVarDetails,

--- a/fieldInspector/src/FieldInspector/PluginTypes.hs
+++ b/fieldInspector/src/FieldInspector/PluginTypes.hs
@@ -7,7 +7,31 @@
 
 module FieldInspector.PluginTypes (plugin) where
 
-import Control.Concurrent (MVar, modifyMVar, newMVar)
+#if __GLASGOW_HASKELL__ >= 900
+import Language.Haskell.Syntax.Type
+import GHC.Hs.Extension ()
+import GHC.Parser.Annotation ()
+import GHC.Utils.Outputable ()
+import qualified Data.IntMap.Internal as IntMap
+import Streamly.Prelude (fromList,mapM_,mapM,toList)
+import Streamly ( parallely)
+import GHC
+import GHC.Driver.Plugins (Plugin(..),CommandLineOption,defaultPlugin,PluginRecompile(..))
+import GHC.Driver.Env
+import GHC.Tc.Types
+import GHC.Unit.Module.ModSummary
+import GHC.Utils.Outputable (showSDocUnsafe,ppr,SDoc,Outputable)
+import GHC.Data.Bag (bagToList)
+import GHC.Types.Name hiding (varName)
+import GHC.Types.Var
+import qualified Data.Aeson.KeyMap as HM
+import GHC.Core.Opt.Monad
+import GHC.Rename.HsType
+-- import GHC.HsToCore.Docs
+import GHC.Types.Name.Reader
+
+
+#else
 import CoreMonad (CoreM, CoreToDo (CoreDoPluginPass), liftIO)
 import CoreSyn (
     AltCon (..),
@@ -17,26 +41,9 @@ import CoreSyn (
     Expr (..),
     mkStringLit
  )
-import Data.Aeson
-import Data.Aeson.Encode.Pretty (encodePretty)
-import qualified Data.ByteString as DBS
-import Data.ByteString.Lazy (toStrict)
-import Data.Int (Int64)
-import Data.List.Extra (intercalate, isSuffixOf, replace, splitOn,groupBy)
-import Data.List ( sortBy, intercalate ,foldl')
-import qualified Data.Map as Map
-import Data.Text (Text, concat, isInfixOf, pack, unpack)
-import qualified Data.Text as T
-import Data.Text.Encoding (decodeUtf8, encodeUtf8)
-import Data.Time
 import TyCoRep
 import GHC.IO (unsafePerformIO)
 import GHC.Hs
-import Data.Map (Map)
-import Data.Data
-import Data.Maybe (catMaybes)
-import Control.Monad.IO.Class (liftIO)
-import System.IO (writeFile)
 import GHC.Hs.Decls
 import GhcPlugins (
     CommandLineOption,Arg (..),
@@ -69,29 +76,51 @@ import GhcPlugins (
  )
 import Id (isExportedId,idType)
 import Name (getSrcSpan)
-import Control.Monad (forM)
 import SrcLoc
-import Streamly (parallely, serially)
-import Streamly.Prelude hiding (concatMap, init, length, map, splitOn,foldl')
-import System.Directory (createDirectoryIfMissing, removeFile)
-import System.Directory.Internal.Prelude hiding (mapM, mapM_)
 import Unique (mkUnique)
 import Var (isLocalId,varType)
-import Prelude hiding (id, mapM, mapM_)
 import FieldInspector.Types
 import TcRnTypes
 import TcRnMonad
 import DataCon
+#endif
+import Debug.Trace
+
+import FieldInspector.Types
+import Control.Concurrent (MVar, modifyMVar, newMVar)
+import Data.Aeson
+import Data.Aeson.Encode.Pretty (encodePretty)
+import qualified Data.ByteString as DBS
+import Data.ByteString.Lazy (toStrict)
+import Data.Int (Int64)
+import Data.List.Extra (intercalate, isSuffixOf, replace, splitOn,groupBy)
+import Data.List ( sortBy, intercalate ,foldl')
+import qualified Data.Map as Map
+import Data.Text (Text, concat, isInfixOf, pack, unpack)
+import qualified Data.Text as T
+import Data.Text.Encoding (decodeUtf8, encodeUtf8)
+import Data.Time
+import Data.Map (Map)
+import Data.Data
+import Data.Maybe (catMaybes)
+import Control.Monad.IO.Class (liftIO)
+import System.IO (writeFile)
+import Control.Monad (forM)
+import Streamly (parallely, serially)
+import Streamly.Prelude hiding (concatMap, init, length, map, splitOn,foldl',intercalate)
+import System.Directory (createDirectoryIfMissing, removeFile)
+import System.Directory.Internal.Prelude hiding (mapM, mapM_)
+import Prelude hiding (id, mapM, mapM_)
+import Control.Exception (evaluate)
 import qualified Data.Record.Plugin as DRP 
 import qualified Data.Record.Anon.Plugin as DRAP
 import qualified Data.Record.Plugin.HasFieldPattern as DRPH
 import qualified RecordDotPreprocessor as RDP
-import Control.Exception (evaluate)
 
 plugin :: Plugin
 plugin = (defaultPlugin{
             -- installCoreToDos = install
-        pluginRecompile = GhcPlugins.purePlugin
+        pluginRecompile = (\_ -> return NoForceRecompile)
         , parsedResultAction = collectTypeInfoParser
         })
 #if defined(ENABLE_LR_PLUGINS)
@@ -162,7 +191,7 @@ collectTypeInfoParser opts modSummary hpm = do
                 let prefixPath = case opts of
                         [] -> "/tmp/fieldInspector/"
                         local : _ -> local
-                    moduleName' = moduleNameString $ GhcPlugins.moduleName $ ms_mod modSummary
+                    moduleName' = moduleNameString $ moduleName $ ms_mod modSummary
                     modulePath = prefixPath <> msHsFilePath modSummary
                     hm_module = unLoc $ hpm_module hpm
                     path = (intercalate "/" . init . splitOn "/") modulePath
@@ -175,36 +204,91 @@ collectTypeInfoParser opts modSummary hpm = do
 
 getTypeInfo :: LHsDecl GhcPs -> [(String,TypeInfo)]
 getTypeInfo (L _ (TyClD _ (DataDecl _ lname _ _ defn))) =
-  [(showSDocUnsafe (ppr lname) ,TypeInfo
-    { name = showSDocUnsafe (ppr lname)
+  [((showSDocUnsafe' lname) ,TypeInfo
+    { name = showSDocUnsafe' lname
     , typeKind = "data"
     , dataConstructors = map getDataConInfo (dd_cons defn)
     })]
 getTypeInfo (L _ (TyClD _ (SynDecl _ lname _ _ rhs))) =
-    [(showSDocUnsafe (ppr lname),TypeInfo
-    { name = showSDocUnsafe (ppr lname)
+    [((showSDocUnsafe' lname),TypeInfo
+    { name = showSDocUnsafe' lname
     , typeKind = "type"
-    , dataConstructors = [DataConInfo (showSDocUnsafe (ppr lname)) (Map.singleton "synonym" (showSDocUnsafe (ppr rhs))) []]
+#if __GLASGOW_HASKELL__ >= 900
+    , dataConstructors = [DataConInfo (showSDocUnsafe' lname) (maybe mempty (Map.singleton "synonym" . unpackHDS) (hsTypeToString $ unLoc rhs)) []]
+#else
+    , dataConstructors = [DataConInfo (showSDocUnsafe' lname) (Map.singleton "synonym" ((showSDocUnsafe . ppr . unLoc) rhs)) []]
+#endif
     })]
 getTypeInfo _ = []
 
+instance Outputable Void where
+
 getDataConInfo :: LConDecl GhcPs -> DataConInfo
-getDataConInfo (L _ ConDeclH98{ con_name = lname, con_args = args }) =
-  DataConInfo
-    { dataConNames = showSDocUnsafe (ppr lname)
-    , fields = getFieldMap args
-    , sumTypes = [] -- For H98-style data constructors, sum types are not applicable
-    }
+getDataConInfo (L _ x@ConDeclH98{ con_name = lname, con_args = args }) =
+  Debug.Trace.trace (showSDocUnsafe $ ppr args) $
+    DataConInfo
+      { dataConNames = showSDocUnsafe' lname
+      , fields = getFieldMap args
+      , sumTypes = [] -- For H98-style data constructors, sum types are not applicable
+      }
 getDataConInfo (L _ ConDeclGADT{ con_names = lnames, con_res_ty = ty }) =
   DataConInfo
-    { dataConNames = intercalate ", " (map (showSDocUnsafe . ppr) lnames)
-    , fields = Map.singleton "gadt" (showSDocUnsafe (ppr ty))
+    { dataConNames = intercalate ", " (map (showSDocUnsafe') lnames)
+#if __GLASGOW_HASKELL__ >= 900
+    , fields = maybe (mempty) (\x -> Map.singleton "gadt" $ unpackHDS x) (hsTypeToString $ unLoc ty)
+#else
+    , fields = Map.singleton "gadt" (showSDocUnsafe $ ppr ty)
+#endif
     , sumTypes = [] -- For GADT-style data constructors, sum types can be represented by the type itself
     }
 
+#if __GLASGOW_HASKELL__ >= 900
+hsTypeToString :: HsType GhcPs -> Maybe HsDocString
+hsTypeToString = f
+  where
+    f :: HsType GhcPs -> Maybe HsDocString
+    f (HsDocTy _ _ lds) = Just (unLoc lds)
+    f (HsBangTy _ _ (L _ (HsDocTy _ _ lds))) = Just (unLoc lds)
+    f x = Just (mkHsDocString $ showSDocUnsafe $ ppr x)
+
+extractInfixCon :: [HsType GhcPs] -> Map.Map String String
+extractInfixCon x =
+  let l = length x
+  in Map.fromList $ map (\(a,b) -> (show a , b)) $ Prelude.zip [0..l] (map f x)
+  where
+    f :: HsType GhcPs -> (String)
+    f (HsDocTy _ _ lds) = showSDocUnsafe $ ppr $ (unLoc lds)
+    f (HsBangTy _ _ (L _ (HsDocTy _ _ lds))) = showSDocUnsafe $ ppr $ (unLoc lds)
+    f x = (showSDocUnsafe $ ppr x)
+
+extractConDeclField :: [ConDeclField GhcPs] -> Map.Map String String
+extractConDeclField x = Map.fromList (go x)
+  where
+    go :: [ConDeclField GhcPs] -> [(String,String)]
+    go [] = []
+    go ((ConDeclField _ cd_fld_names cd_fld_type _):xs) =
+        [((intercalate "," $ convertRdrNameToString cd_fld_names),(showSDocUnsafe $ ppr cd_fld_type))] <> (go xs)
+
+    convertRdrNameToString x = map (showSDocUnsafe . ppr . rdrNameOcc . unLoc . reLocN . rdrNameFieldOcc . unXRec @(GhcPs)) x
+
+getFieldMap :: HsConDeclH98Details GhcPs -> Map.Map String String
+getFieldMap con_args =
+  case con_args of
+    PrefixCon _ args         -> extractInfixCon $ map (unLoc . hsScaledThing) args
+    InfixCon arg1 arg2       -> extractInfixCon $ map (unLoc . hsScaledThing) [arg1,arg2]
+    RecCon (fields)          -> extractConDeclField $ map unLoc $ (unXRec @(GhcPs)) fields
+
+#else
 getFieldMap :: HsConDeclDetails GhcPs -> Map String String
 getFieldMap (PrefixCon args) = Map.fromList $ Prelude.zipWith (\i t -> (show i, showSDocUnsafe (ppr t))) [1..] args
 getFieldMap (RecCon (L _ fields)) = Map.fromList $ concatMap getRecField fields
   where
     getRecField (L _ (ConDeclField _ fnames t _)) = [(showSDocUnsafe (ppr fname), showSDocUnsafe (ppr t)) | L _ fname <- fnames]
 getFieldMap (InfixCon t1 t2) = Map.fromList [("field1", showSDocUnsafe (ppr t1)), ("field2", showSDocUnsafe (ppr t2))]
+#endif
+
+#if __GLASGOW_HASKELL__ >= 900
+showSDocUnsafe' = showSDocUnsafe . ppr . GHC.unXRec @(GhcPs)
+#else
+showSDocUnsafe' = showSDocUnsafe . ppr
+#endif

--- a/fieldInspector/src/FieldInspector/Types.hs
+++ b/fieldInspector/src/FieldInspector/Types.hs
@@ -43,7 +43,7 @@ data DataTypeUC = DataTypeUC {
 
 data TypeVsFields = TypeVsFields {
     type_name :: Text
-    , fieldsVsExprs :: [(FieldRep)]
+    , fieldsVsExprs :: Either [(FieldRep)] [Text]
 } deriving (Show, Eq, Ord,Binary,Generic,NFData,ToJSON,FromJSON)
 
 data FieldRep = FieldRep {

--- a/fieldInspector/test/Main.hs
+++ b/fieldInspector/test/Main.hs
@@ -10,11 +10,10 @@ main = do
     print $ demo $ (A "Test suite not yet implemented." 0)
     pure ()
 
-
 data A = A {name :: String,age :: Int} 
     deriving (Generic,Show)
 
 demo :: A -> String
 demo a = 
     case a of
-        (A {name}) -> name
+        (A {name}) -> name 

--- a/flake.lock
+++ b/flake.lock
@@ -1,25 +1,65 @@
 {
   "nodes": {
-    "classyplate": {
+    "beam": {
       "flake": false,
       "locked": {
-        "lastModified": 1715166860,
-        "narHash": "sha256-kbUJ8WVT/pusDDbTX8+pnxumWtztGSeX3UMbYp6xgHA=",
-        "owner": "iamanandsingh",
-        "repo": "classyplate",
-        "rev": "2c869097df8fdbeb1da23842bf5f52366daf3893",
+        "lastModified": 1716967568,
+        "narHash": "sha256-8K7EPhhS6cUz0Qrmrwj8lJYftq8u749tD3/uTcC5nHU=",
+        "owner": "well-typed",
+        "repo": "beam",
+        "rev": "57a12e68727c027f0f1c25752f8c5704ddbe1516",
         "type": "github"
       },
       "original": {
-        "owner": "iamanandsingh",
+        "owner": "well-typed",
+        "repo": "beam",
+        "rev": "57a12e68727c027f0f1c25752f8c5704ddbe1516",
+        "type": "github"
+      }
+    },
+    "classyplate": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "haskell-flake": "haskell-flake",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1721385699,
+        "narHash": "sha256-Gof2hSQSX581LA8GGnHGjXWu5F899Cot+Id1SYxlUMY=",
+        "owner": "eswar2001",
         "repo": "classyplate",
-        "rev": "2c869097df8fdbeb1da23842bf5f52366daf3893",
+        "rev": "a360f56820df6ca5284091f318bcddcd3e065243",
+        "type": "github"
+      },
+      "original": {
+        "owner": "eswar2001",
+        "repo": "classyplate",
+        "rev": "a360f56820df6ca5284091f318bcddcd3e065243",
         "type": "github"
       }
     },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1719994518,
+        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
         "lastModified": 1717285511,
@@ -35,9 +75,45 @@
         "type": "github"
       }
     },
-    "flake-parts_2": {
+    "flake-parts_3": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_2"
+        "nixpkgs-lib": "nixpkgs-lib_3"
+      },
+      "locked": {
+        "lastModified": 1719994518,
+        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_4": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_4"
+      },
+      "locked": {
+        "lastModified": 1719994518,
+        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_5": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_5"
       },
       "locked": {
         "lastModified": 1685662779,
@@ -54,7 +130,12 @@
       }
     },
     "ghc-hasfield-plugin": {
-      "flake": false,
+      "inputs": {
+        "flake-parts": "flake-parts_4",
+        "haskell-flake": "haskell-flake_3",
+        "nixpkgs": "nixpkgs_2",
+        "systems": "systems_2"
+      },
       "locked": {
         "lastModified": 1721371073,
         "narHash": "sha256-1xTFZRE/vAHV/mLMW5rNyZH1SkkbyFqDxXZvw7JwOHo=",
@@ -72,6 +153,21 @@
     },
     "haskell-flake": {
       "locked": {
+        "lastModified": 1720977934,
+        "narHash": "sha256-k9kwz2lpUqafRUpuCMgkv4AWtHEoJPCds1ZPRkyW2XE=",
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "rev": "cd449f1c04175efdf5b553302d22916640090066",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "type": "github"
+      }
+    },
+    "haskell-flake_2": {
+      "locked": {
         "lastModified": 1719249394,
         "narHash": "sha256-ytIvs6dq1dD3eicwhmqMyhIDH52DfqhOiCpmJbjBYVI=",
         "owner": "srid",
@@ -85,7 +181,37 @@
         "type": "github"
       }
     },
-    "haskell-flake_2": {
+    "haskell-flake_3": {
+      "locked": {
+        "lastModified": 1720977934,
+        "narHash": "sha256-k9kwz2lpUqafRUpuCMgkv4AWtHEoJPCds1ZPRkyW2XE=",
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "rev": "cd449f1c04175efdf5b553302d22916640090066",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "type": "github"
+      }
+    },
+    "haskell-flake_4": {
+      "locked": {
+        "lastModified": 1721530802,
+        "narHash": "sha256-eUMmQKXjt4WQq+IBscftg/Y9bXWiOYhasfeH5Yb9Psc=",
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "rev": "f8f38ecd259338167cc0c85fd541479297a315af",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "type": "github"
+      }
+    },
+    "haskell-flake_5": {
       "locked": {
         "lastModified": 1686160859,
         "narHash": "sha256-UE+0TQHyPxF8jhbLEeqvNQAy7B79bBix/rpFrf5nsn0=",
@@ -101,18 +227,26 @@
       }
     },
     "large-records": {
-      "flake": false,
+      "inputs": {
+        "beam": "beam",
+        "flake-parts": "flake-parts_3",
+        "ghc-hasfield-plugin": "ghc-hasfield-plugin",
+        "haskell-flake": "haskell-flake_4",
+        "nixpkgs": "nixpkgs_3",
+        "systems": "systems_3"
+      },
       "locked": {
-        "lastModified": 1719932869,
-        "narHash": "sha256-1J/II2BUtOGQ5Sywx7Un8I3+oVHNXeDzzt/mXBN0FZ4=",
-        "owner": "well-typed",
+        "lastModified": 1721562622,
+        "narHash": "sha256-4XivoIvlVl7UyVCyZneeLIvyKBbRIvDEOEnJBxnZp+c=",
+        "owner": "eswar2001",
         "repo": "large-records",
-        "rev": "5018da3d52c434b4fa11e5e1f2af2c23b2d9aa55",
+        "rev": "b60bcb312c7d55f1d638aa1a5143696e6586e76d",
         "type": "github"
       },
       "original": {
-        "owner": "well-typed",
+        "owner": "eswar2001",
         "repo": "large-records",
+        "rev": "b60bcb312c7d55f1d638aa1a5143696e6586e76d",
         "type": "github"
       }
     },
@@ -134,6 +268,18 @@
     },
     "nixpkgs-lib": {
       "locked": {
+        "lastModified": 1719876945,
+        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+      }
+    },
+    "nixpkgs-lib_2": {
+      "locked": {
         "lastModified": 1717284937,
         "narHash": "sha256-lIbdfCsf8LMFloheeE6N31+BMIeixqyQWbSr2vk79EQ=",
         "type": "tarball",
@@ -144,7 +290,31 @@
         "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
       }
     },
-    "nixpkgs-lib_2": {
+    "nixpkgs-lib_3": {
+      "locked": {
+        "lastModified": 1719876945,
+        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+      }
+    },
+    "nixpkgs-lib_4": {
+      "locked": {
+        "lastModified": 1719876945,
+        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+      }
+    },
+    "nixpkgs-lib_5": {
       "locked": {
         "dir": "lib",
         "lastModified": 1685564631,
@@ -164,54 +334,146 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1686582075,
-        "narHash": "sha256-vtflsfKkHtF8IduxDNtbme4cojiqvlvjp5QNYhvoHXc=",
+        "lastModified": 1698266953,
+        "narHash": "sha256-jf72t7pC8+8h8fUslUYbWTX5rKsRwOzRMX8jJsGqDXA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7e63eed145566cca98158613f3700515b4009ce3",
+        "rev": "75a52265bda7fd25e06e3a67dee3f0354e73243c",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "rev": "75a52265bda7fd25e06e3a67dee3f0354e73243c",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1698266953,
+        "narHash": "sha256-jf72t7pC8+8h8fUslUYbWTX5rKsRwOzRMX8jJsGqDXA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "75a52265bda7fd25e06e3a67dee3f0354e73243c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "75a52265bda7fd25e06e3a67dee3f0354e73243c",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1698266953,
+        "narHash": "sha256-jf72t7pC8+8h8fUslUYbWTX5rKsRwOzRMX8jJsGqDXA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "75a52265bda7fd25e06e3a67dee3f0354e73243c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "75a52265bda7fd25e06e3a67dee3f0354e73243c",
+        "type": "github"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1698266953,
+        "narHash": "sha256-jf72t7pC8+8h8fUslUYbWTX5rKsRwOzRMX8jJsGqDXA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "75a52265bda7fd25e06e3a67dee3f0354e73243c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "75a52265bda7fd25e06e3a67dee3f0354e73243c",
         "type": "github"
       }
     },
     "references": {
       "inputs": {
-        "flake-parts": "flake-parts_2",
-        "haskell-flake": "haskell-flake_2",
-        "nixpkgs": "nixpkgs_2"
+        "flake-parts": "flake-parts_5",
+        "haskell-flake": "haskell-flake_5",
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1715784802,
-        "narHash": "sha256-15TEa3cQi1a+pu+oQtaCHYoWMgwJV44OSfohtdWxmLM=",
-        "owner": "iamanandsingh",
+        "lastModified": 1721387508,
+        "narHash": "sha256-R0aCMdXbWCqztrRFZyRYBYKOdbE+Ky5DA+BZZ58B7uk=",
+        "owner": "eswar2001",
         "repo": "references",
-        "rev": "8366257fbeb4f63e1ec0347c9fe5f203ba6fdebc",
+        "rev": "d0d2223ac9d1d10a4af9434d295e2c64edc043cd",
         "type": "github"
       },
       "original": {
-        "owner": "iamanandsingh",
+        "owner": "eswar2001",
         "repo": "references",
-        "rev": "8366257fbeb4f63e1ec0347c9fe5f203ba6fdebc",
+        "rev": "d0d2223ac9d1d10a4af9434d295e2c64edc043cd",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
         "classyplate": "classyplate",
-        "flake-parts": "flake-parts",
-        "ghc-hasfield-plugin": "ghc-hasfield-plugin",
-        "haskell-flake": "haskell-flake",
+        "flake-parts": "flake-parts_2",
+        "haskell-flake": "haskell-flake_2",
         "large-records": "large-records",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_4",
         "references": "references",
-        "systems": "systems"
+        "systems": "systems_4"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_4": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -3,17 +3,17 @@
     "classyplate": {
       "flake": false,
       "locked": {
-        "lastModified": 1678370822,
-        "narHash": "sha256-8AJ/55ShKCe49MEcyMqzJ3ADjs5dvtuTIhuTTq2q5nQ=",
-        "owner": "Chaitanya-nair",
+        "lastModified": 1715166860,
+        "narHash": "sha256-kbUJ8WVT/pusDDbTX8+pnxumWtztGSeX3UMbYp6xgHA=",
+        "owner": "iamanandsingh",
         "repo": "classyplate",
-        "rev": "46f5e0e7073e1d047f70473bf3c75366a613bfeb",
+        "rev": "2c869097df8fdbeb1da23842bf5f52366daf3893",
         "type": "github"
       },
       "original": {
-        "owner": "Chaitanya-nair",
+        "owner": "iamanandsingh",
         "repo": "classyplate",
-        "rev": "46f5e0e7073e1d047f70473bf3c75366a613bfeb",
+        "rev": "2c869097df8fdbeb1da23842bf5f52366daf3893",
         "type": "github"
       }
     },
@@ -56,17 +56,17 @@
     "ghc-hasfield-plugin": {
       "flake": false,
       "locked": {
-        "lastModified": 1658487566,
-        "narHash": "sha256-pZ6kFNfRtBWWqJ3zZSJhZQz7hcdgTdpkqUbzRCuRSl8=",
-        "owner": "juspay",
+        "lastModified": 1721371073,
+        "narHash": "sha256-1xTFZRE/vAHV/mLMW5rNyZH1SkkbyFqDxXZvw7JwOHo=",
+        "owner": "eswar2001",
         "repo": "ghc-hasfield-plugin",
-        "rev": "d82ac5a6c0ad643eebe2b9b32c91f6523d3f30dc",
+        "rev": "c932ebc0d7e824129bb70c8a078f3c68feed85c9",
         "type": "github"
       },
       "original": {
-        "owner": "juspay",
+        "owner": "eswar2001",
         "repo": "ghc-hasfield-plugin",
-        "rev": "d82ac5a6c0ad643eebe2b9b32c91f6523d3f30dc",
+        "rev": "c932ebc0d7e824129bb70c8a078f3c68feed85c9",
         "type": "github"
       }
     },
@@ -103,33 +103,32 @@
     "large-records": {
       "flake": false,
       "locked": {
-        "lastModified": 1719312727,
-        "narHash": "sha256-NLs4yiUh4vNf4sqOQUUTCr0Fpld1y6ZyZJNhqSTzAI0=",
-        "owner": "eswar2001",
+        "lastModified": 1719932869,
+        "narHash": "sha256-1J/II2BUtOGQ5Sywx7Un8I3+oVHNXeDzzt/mXBN0FZ4=",
+        "owner": "well-typed",
         "repo": "large-records",
-        "rev": "e393f4501d76a98b4482b0a5b35d120ae70e5dd3",
+        "rev": "5018da3d52c434b4fa11e5e1f2af2c23b2d9aa55",
         "type": "github"
       },
       "original": {
-        "owner": "eswar2001",
+        "owner": "well-typed",
         "repo": "large-records",
-        "rev": "e393f4501d76a98b4482b0a5b35d120ae70e5dd3",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1643795778,
-        "narHash": "sha256-sBxYgXu+4JTpXPu3c1QGl2a2zzzDJj4VNsVatF1sEIY=",
+        "lastModified": 1698266953,
+        "narHash": "sha256-jf72t7pC8+8h8fUslUYbWTX5rKsRwOzRMX8jJsGqDXA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "43e3b6af08f29c4447a6073e3d5b86a4f45dd420",
+        "rev": "75a52265bda7fd25e06e3a67dee3f0354e73243c",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "43e3b6af08f29c4447a6073e3d5b86a4f45dd420",
+        "rev": "75a52265bda7fd25e06e3a67dee3f0354e73243c",
         "type": "github"
       }
     },
@@ -179,23 +178,6 @@
         "type": "github"
       }
     },
-    "record-dot-preprocessor": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1644582826,
-        "narHash": "sha256-BXprRyjI4ZTG+Orz858xmttiC8O0yuubaaKmeRAL/UY=",
-        "owner": "ndmitchell",
-        "repo": "record-dot-preprocessor",
-        "rev": "99452d27f35ea1ff677be9af570d834e8fab4caf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ndmitchell",
-        "repo": "record-dot-preprocessor",
-        "rev": "99452d27f35ea1ff677be9af570d834e8fab4caf",
-        "type": "github"
-      }
-    },
     "references": {
       "inputs": {
         "flake-parts": "flake-parts_2",
@@ -203,17 +185,17 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1686714318,
-        "narHash": "sha256-Ogy9S6cF/8WNfpcQ1k65rPjjTfWlH15Jp5JeraYaAQQ=",
-        "owner": "eswar2001",
+        "lastModified": 1715784802,
+        "narHash": "sha256-15TEa3cQi1a+pu+oQtaCHYoWMgwJV44OSfohtdWxmLM=",
+        "owner": "iamanandsingh",
         "repo": "references",
-        "rev": "35912f3cc72b67fa63a8d59d634401b79796469e",
+        "rev": "8366257fbeb4f63e1ec0347c9fe5f203ba6fdebc",
         "type": "github"
       },
       "original": {
-        "owner": "eswar2001",
+        "owner": "iamanandsingh",
         "repo": "references",
-        "rev": "35912f3cc72b67fa63a8d59d634401b79796469e",
+        "rev": "8366257fbeb4f63e1ec0347c9fe5f203ba6fdebc",
         "type": "github"
       }
     },
@@ -225,7 +207,6 @@
         "haskell-flake": "haskell-flake",
         "large-records": "large-records",
         "nixpkgs": "nixpkgs",
-        "record-dot-preprocessor": "record-dot-preprocessor",
         "references": "references",
         "systems": "systems"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -153,11 +153,11 @@
     },
     "haskell-flake": {
       "locked": {
-        "lastModified": 1720977934,
-        "narHash": "sha256-k9kwz2lpUqafRUpuCMgkv4AWtHEoJPCds1ZPRkyW2XE=",
+        "lastModified": 1721530802,
+        "narHash": "sha256-eUMmQKXjt4WQq+IBscftg/Y9bXWiOYhasfeH5Yb9Psc=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "cd449f1c04175efdf5b553302d22916640090066",
+        "rev": "f8f38ecd259338167cc0c85fd541479297a315af",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,19 +1,21 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/43e3b6af08f29c4447a6073e3d5b86a4f45dd420";
+    nixpkgs.url = "github:nixos/nixpkgs/75a52265bda7fd25e06e3a67dee3f0354e73243c";
     systems.url = "github:nix-systems/default";
     flake-parts.url = "github:hercules-ci/flake-parts";
     haskell-flake.url = "github:srid/haskell-flake";
     classyplate.flake = false;
-    classyplate.url = "github:Chaitanya-nair/classyplate/46f5e0e7073e1d047f70473bf3c75366a613bfeb";
     references.flake = true;
-    references.url = "github:eswar2001/references/35912f3cc72b67fa63a8d59d634401b79796469e";
     ghc-hasfield-plugin.flake = false;
-    large-records.flake = false;
-    ghc-hasfield-plugin.url = "github:juspay/ghc-hasfield-plugin/d82ac5a6c0ad643eebe2b9b32c91f6523d3f30dc";
-    large-records.url = "github:eswar2001/large-records/e393f4501d76a98b4482b0a5b35d120ae70e5dd3";
-    record-dot-preprocessor.url = "github:ndmitchell/record-dot-preprocessor/99452d27f35ea1ff677be9af570d834e8fab4caf";
-    record-dot-preprocessor.flake = false;
+    classyplate.url = "github:iamanandsingh/classyplate/2c869097df8fdbeb1da23842bf5f52366daf3893";
+    references.url = "github:iamanandsingh/references/8366257fbeb4f63e1ec0347c9fe5f203ba6fdebc";
+    large-records.url = "github:well-typed/large-records";
+    # references.url = "github:eswar2001/references/35912f3cc72b67fa63a8d59d634401b79796469e";
+    # classyplate.url = "github:Chaitanya-nair/classyplate/46f5e0e7073e1d047f70473bf3c75366a613bfeb";
+    ghc-hasfield-plugin.url = "github:eswar2001/ghc-hasfield-plugin/c932ebc0d7e824129bb70c8a078f3c68feed85c9";
+    # large-records.url = "github:eswar2001/large-records/e393f4501d76a98b4482b0a5b35d120ae70e5dd3";
+    # record-dot-preprocessor.url = "github:ndmitchell/record-dot-preprocessor/99452d27f35ea1ff677be9af570d834e8fab4caf";
+    # record-dot-preprocessor.flake = false;
   };
   outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
@@ -36,7 +38,8 @@
           # (defined by `defaults.packages` option).
           #
           projectFlakeName = "spider";
-          basePackages = pkgs.haskell.packages.ghc8107;
+          # basePackages = pkgs.haskell.packages.ghc8107;
+          basePackages = pkgs.haskell.packages.ghc92;
           imports = [
             inputs.references.haskellFlakeProjectModules.output
           ];
@@ -46,9 +49,12 @@
             large-records.source = inputs.large-records + /large-records;
             large-generics.source = inputs.large-records + /large-generics;
             large-anon.source = inputs.large-records + /large-anon;
-            ghc-tcplugin-api.source = "0.7.1.0";
             typelet.source = inputs.large-records + /typelet;
-            record-dot-preprocessor.source = inputs.record-dot-preprocessor;
+            # text.source = "2.0";
+            # Cabal-syntax.source = "3.8.1.0";
+            # fourmolu.source = "3.8.1.0";
+            # record-dot-preprocessor.source = inputs.record-dot-preprocessor;
+            # record-dot-preprocessor.source = "0.2.14";
           };
           settings = {
             #  aeson = {
@@ -58,7 +64,13 @@
             #    haddock = false;
             #    broken = false;
             #  };
-              sheriff.check = false;
+            # primitive-checked = {
+            #     broken = false;
+            #     jailbreak = true;
+            # };
+            ghc-hasfield-plugin.check = false;
+            ghc-hasfield-plugin.jailbreak = true;
+            sheriff.check = false;
           };
 
           devShell = {

--- a/flake.nix
+++ b/flake.nix
@@ -4,18 +4,11 @@
     systems.url = "github:nix-systems/default";
     flake-parts.url = "github:hercules-ci/flake-parts";
     haskell-flake.url = "github:srid/haskell-flake";
-    classyplate.flake = false;
-    references.flake = true;
-    ghc-hasfield-plugin.flake = false;
-    classyplate.url = "github:iamanandsingh/classyplate/2c869097df8fdbeb1da23842bf5f52366daf3893";
-    references.url = "github:iamanandsingh/references/8366257fbeb4f63e1ec0347c9fe5f203ba6fdebc";
-    large-records.url = "github:well-typed/large-records";
-    # references.url = "github:eswar2001/references/35912f3cc72b67fa63a8d59d634401b79796469e";
-    # classyplate.url = "github:Chaitanya-nair/classyplate/46f5e0e7073e1d047f70473bf3c75366a613bfeb";
-    ghc-hasfield-plugin.url = "github:eswar2001/ghc-hasfield-plugin/c932ebc0d7e824129bb70c8a078f3c68feed85c9";
-    # large-records.url = "github:eswar2001/large-records/e393f4501d76a98b4482b0a5b35d120ae70e5dd3";
-    # record-dot-preprocessor.url = "github:ndmitchell/record-dot-preprocessor/99452d27f35ea1ff677be9af570d834e8fab4caf";
-    # record-dot-preprocessor.flake = false;
+    classyplate.url = "github:eswar2001/classyplate/a360f56820df6ca5284091f318bcddcd3e065243";
+    references.url = "github:eswar2001/references/d0d2223ac9d1d10a4af9434d295e2c64edc043cd";
+    large-records = { 
+      url = "github:eswar2001/large-records/b60bcb312c7d55f1d638aa1a5143696e6586e76d";
+    };
   };
   outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
@@ -37,25 +30,20 @@
           # Note that local packages are automatically included in `packages`
           # (defined by `defaults.packages` option).
           #
+          # defaults.enable = false;
+          # devShell.tools = hp: with hp; {
+          #   inherit cabal-install;
+          #   inherit hp;
+          # };
           projectFlakeName = "spider";
           # basePackages = pkgs.haskell.packages.ghc8107;
           basePackages = pkgs.haskell.packages.ghc92;
           imports = [
             inputs.references.haskellFlakeProjectModules.output
+            inputs.classyplate.haskellFlakeProjectModules.output
+            inputs.large-records.haskellFlakeProjectModules.output
           ];
-          packages = {
-            classyplate.source = inputs.classyplate;
-            ghc-hasfield-plugin.source = inputs.ghc-hasfield-plugin;
-            large-records.source = inputs.large-records + /large-records;
-            large-generics.source = inputs.large-records + /large-generics;
-            large-anon.source = inputs.large-records + /large-anon;
-            typelet.source = inputs.large-records + /typelet;
-            # text.source = "2.0";
-            # Cabal-syntax.source = "3.8.1.0";
-            # fourmolu.source = "3.8.1.0";
-            # record-dot-preprocessor.source = inputs.record-dot-preprocessor;
-            # record-dot-preprocessor.source = "0.2.14";
-          };
+          packages = {          };
           settings = {
             #  aeson = {
             #    check = false;
@@ -68,9 +56,8 @@
             #     broken = false;
             #     jailbreak = true;
             # };
-            ghc-hasfield-plugin.check = false;
-            ghc-hasfield-plugin.jailbreak = true;
             sheriff.check = false;
+            references.check = false;
           };
 
           devShell = {
@@ -79,7 +66,7 @@
 
             # Programs you want to make available in the shell.
             # Default programs can be disabled by setting to 'null'
-            # tools = hp: { fourmolu = hp.fourmolu; ghcid = null; };
+            # tools = hp: { fourmolu = null; ghcid = null; };
 
             hlsCheck.enable = pkgs.stdenv.isDarwin; # On darwin, sandbox is disabled, so HLS can use the network.
           };


### PR DESCRIPTION
changes in the following libs.
- classyplate
- references
- large-records

Added `__GLASGOW_HASKELL__` check for GHC version. in the following plugins.