### PR TITLE
Add support for function signature blocked, wildcard character & rule allowed modules

### DIFF
--- a/sheriff/.juspay/sheriffRules.yaml
+++ b/sheriff/.juspay/sheriffRules.yaml
@@ -98,7 +98,7 @@ rules:
       - Use `throwExceptionV2` or `throwExceptionV4` function from `TestUtils` module.
     fn_rule_exceptions: []
     fn_rule_ignore_modules: []
-    fn_rule_allowed_modules:
+    fn_rule_check_modules:
       - "Test1"
     
   # We should get error for usage of any function with Number type
@@ -118,7 +118,7 @@ rules:
       - Contact senior dev for the solution.
     fn_rule_exceptions: []
     fn_rule_ignore_modules: []
-    fn_rule_allowed_modules:
+    fn_rule_check_modules:
       - Test1
 
   # - db_rule_name: "DBRuleTest"

--- a/sheriff/.juspay/sheriffRules.yaml
+++ b/sheriff/.juspay/sheriffRules.yaml
@@ -83,7 +83,44 @@ rules:
     fn_rule_exceptions: []
     fn_rule_ignore_modules:
       - TestUtils
-      
+
+  # We should get the errors for below functions two times only in Test1
+  - fn_rule_name: Test Allowed Modules
+    fn_name:
+      - throwExceptionV2
+      - TestUtils.throwExceptionV4
+    arg_no: 0
+    fns_blocked_in_arg: []
+    types_blocked_in_arg: []
+    types_to_check_in_arg: []
+    fn_rule_fixes:
+      - You are not allowed to use helper function `throwException` from `TestUtils` module.
+      - Use `throwExceptionV2` or `throwExceptionV4` function from `TestUtils` module.
+    fn_rule_exceptions: []
+    fn_rule_ignore_modules: []
+    fn_rule_allowed_modules:
+      - "Test1"
+    
+  # We should get error for usage of any function with Number type
+  - fn_rule_name: Test Functions usage blocked having any function name with given signature
+    fn_name:
+      - "*"
+    arg_no: 0
+    fn_sigs_blocked:
+      - Number -> TestUtils1.Number -> * # Should not throw Error
+      - Number -> Number -> Number # Should throw Error
+      - TestUtils.Number -> TestUtils.Number -> TestUtils.Number # Should throw Error
+      - Maybe (Either (Maybe (Int)) (Maybe (Int))) -> Number -> Number -> Number # Should throw Error
+    fns_blocked_in_arg: []
+    types_blocked_in_arg: []
+    types_to_check_in_arg: []
+    fn_rule_fixes:
+      - Contact senior dev for the solution.
+    fn_rule_exceptions: []
+    fn_rule_ignore_modules: []
+    fn_rule_allowed_modules:
+      - Test1
+
   # - db_rule_name: "DBRuleTest"
   #   table_name: "TxnRiskCheck"
   #   indexed_cols_names: 
@@ -122,12 +159,25 @@ rules:
   # - fn_rule_name: "LogRule"
   #   fn_name: "logError"
   #   arg_no: 2
-  #   fns_blocked_in_arg: [["show", 1, ["EnumTypes", "Integer", "Double", "Float", "Int64", "Int", "Bool", "Number", "(,)", "[]", "Maybe"]], ["encode", 1, []], ["encodeJSON", 1, []]]
+  #   fns_blocked_in_arg:
+  #     - 
+  #       - "show"
+  #       - 1
+  #       - ["EnumTypes", "Integer", "Double", "Float", "Int64", "Int", "Bool", "Number", "(,)", "[]", "Maybe"]
+  #     - 
+  #       - "encode"
+  #       - 1
+  #       - [] 
+  #     - 
+  #       - "encodeJSON"
+  #       - 1
+  #       - []
   #   types_blocked_in_arg: []
   #   types_to_check_in_arg: ["Text", "String", "Char", "[Char]", "Maybe", "(,)", "[]"]
   #   fn_rule_fixes:
   #     - "Remove `show` function call from the error location and use `L.logErrorV @Text` or `L.logDebugV @Text` or `L.logInfoV @Text` function(s) imported from `EulerHS.Language` module."
-  #     - "Make sure that there is `ToJSON` instance on the value we are logging.", "You may use tuples for combining string and objects. For e.g., (\"Failed to fetch object: \" :: Text, obj)"
+  #     - "Make sure that there is `ToJSON` instance on the value we are logging."
+  #     - "You may use tuples for combining string and objects. For e.g., (\"Failed to fetch object: \" :: Text, obj)"
   #   fn_rule_exceptions: []
   #   fn_rule_ignore_modules: []
 

--- a/sheriff/CHANGELOG.md
+++ b/sheriff/CHANGELOG.md
@@ -1,5 +1,10 @@
-# Revision history for code-checker
+# Revision history for sheriff
+
+## 0.2.0.0
+* Add allowed modules list for function rule
+* Add support for wilcard character "*" in function rules
+* Add support for blocking functions with a particular type signature (Signature only)
+* Add test rules in sheriff rules
 
 ## 0.1.0.0 -- 2024-03-20
-
 * First version. Basic rules based compilation error.

--- a/sheriff/CHANGELOG.md
+++ b/sheriff/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision history for sheriff
 
+## 0.2.0.1
+* Add derived signature from the arg types for Signature Check rules
+
 ## 0.2.0.0
 * Add allowed modules list for function rule
 * Add support for wilcard character "*" in function rules

--- a/sheriff/DOC.md
+++ b/sheriff/DOC.md
@@ -52,7 +52,7 @@ Any additional rules for a package can be provided as `yaml` file. The path to t
 >   fn_rule_ignore_modules:
 >     - ModuleT
 >     - ModuleP
->   fn_rule_allowed_modules:
+>   fn_rule_check_modules:
 >     - ModuleA
 >     - ModuleB
 >```

--- a/sheriff/DOC.md
+++ b/sheriff/DOC.md
@@ -21,8 +21,8 @@ Any additional rules for a package can be provided as `yaml` file. The path to t
 >   fn_name: "<Function Name: can be Qualified as \"A.fn1\" or Unqualified as \"fn1\">"
 >   arg_no: 1
 >   fns_blocked_in_arg:
->     - ModuleA.dummyFn
->     - dummyFn2
+>     - [ModuleA.dummyFn, 0, []]
+>     - [dummyFn2, 0, []]
 >   types_blocked_in_arg:
 >     - String
 >     - Text
@@ -52,6 +52,9 @@ Any additional rules for a package can be provided as `yaml` file. The path to t
 >   fn_rule_ignore_modules:
 >     - ModuleT
 >     - ModuleP
+>   fn_rule_allowed_modules:
+>     - ModuleA
+>     - ModuleB
 >```
 
 > Structure of DB Rules:

--- a/sheriff/README.MD
+++ b/sheriff/README.MD
@@ -8,7 +8,9 @@ It supports the following rules as of now
 1. Blocking certain type of argument to a function call :- Give a particular argument number `arg_no` and list of types to be blocked in that argument `types_blocked_in_arg`
 2. Blocking use of certain function in an argument to a function call :- Give a particular argument number `arg_no` and list of functions to be blocked in argument. <br>_Note: The function presence will be checked and blocked only if the type of the argument is in list of `types_to_check_in_arg`_
 3. Blocking use of a particular function in the code (specify argument number `arg_no` as `0` in the rule).
-4. Blocking querying in DB on non-indexed columns (indexed columns are provided in a yaml file)
+4. Blocking all or particular functions with given type signature
+5. Applying rules to all or particular set of modules
+6. Blocking querying in DB on non-indexed columns (indexed columns are provided in a yaml file)
 
 This tool is useful for developers to enforce better coding practices and prevent use of some specific unsafe function in the code.
 

--- a/sheriff/sheriff.cabal
+++ b/sheriff/sheriff.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               sheriff
-version:            0.2.0.0
+version:            0.2.0.1
 synopsis:           A checker plugin to throw compilation errors based on given rules; basically what a `Sheriff` does
 license:            MIT
 license-file:       LICENSE

--- a/sheriff/sheriff.cabal
+++ b/sheriff/sheriff.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               sheriff
-version:            0.1.0.0
+version:            0.2.0.0
 synopsis:           A checker plugin to throw compilation errors based on given rules; basically what a `Sheriff` does
 license:            MIT
 license-file:       LICENSE

--- a/sheriff/src/Sheriff/Plugin.hs
+++ b/sheriff/src/Sheriff/Plugin.hs
@@ -216,7 +216,7 @@ noGivenFunctionCallExpansion :: String -> LHsExpr GhcTc -> Bool
 noGivenFunctionCallExpansion fnName expr = case expr of
   (L loc (PatHsWrap _ expr)) -> noGivenFunctionCallExpansion fnName (L loc expr)
   _ -> case getFnNameWithAllArgs expr of
-        Just (lVar, _) -> matchFnNames (getFnNameWithModuleName lVar) fnName -- (getOccString . varName . unLoc $ lVar) == fnName
+        Just (lVar, _) -> matchNamesWithModuleName (getLocatedVarNameWithModuleName lVar) fnName -- (getOccString . varName . unLoc $ lVar) == fnName
         Nothing -> False
 
 -- Simplifies few things and handles some final transformations
@@ -253,14 +253,14 @@ checkAndApplyRule ruleT opts ap = case ruleT of
           True  -> validateDBRule rule opts (showS tblName) exprs ap
           False -> pure []
       _ -> pure []
-  FunctionRuleT rule@(FunctionRule _ ruleFnNames arg_no _ _ _ _ _ _) -> do
+  FunctionRuleT rule@(FunctionRule _ ruleFnNames arg_no _ _ _ _ _ _ _ _) -> do
     let res = getFnNameWithAllArgs ap
     case res of
       Nothing                   -> pure []
       Just (fnLocatedVar, args) -> do
-        let fnName    = getFnNameWithModuleName fnLocatedVar
+        let fnName    = getLocatedVarNameWithModuleName fnLocatedVar
             fnLHsExpr = mkLHsVar fnLocatedVar
-        case (find (\ruleFnName -> matchFnNames fnName ruleFnName && length args >= arg_no) ruleFnNames) of
+        case (find (\ruleFnName -> matchNamesWithModuleName fnName ruleFnName && length args >= arg_no) ruleFnNames) of
           Just ruleFnName  -> validateFunctionRule rule opts ruleFnName fnName fnLHsExpr args ap 
           Nothing -> pure []
   GeneralRuleT rule -> pure [] --TODO: Add handling of general rule
@@ -288,8 +288,13 @@ Part-2 Validation
 -- Function to check if given function rule is violated or not
 validateFunctionRule :: FunctionRule -> PluginOpts -> String -> String -> LHsExpr GhcTc -> [LHsExpr GhcTc] -> LHsExpr GhcTc -> TcM ([(LHsExpr GhcTc, Violation)])
 validateFunctionRule rule opts ruleFnName fnName fnNameExpr args expr = do
-  if (arg_no rule) == 0 -- considering arg 0 as the case for blocking the whole function occurence
+  if arg_no rule == 0 && fn_sigs_blocked rule == [] -- considering arg 0 as the case for blocking the whole function occurence
     then pure [(fnNameExpr, FnUseBlocked ruleFnName rule)]
+  else if arg_no rule == 0
+    then do
+      typ <- getHsExprTypeWithResolver (logTypeDebugging opts) fnNameExpr
+      let typList = getHsExprTypeAsTypeDataList typ
+      pure . concat $ fmap (\ruleFnSig -> if matchFnSignatures typList ruleFnSig then [(fnNameExpr, FnSigBlocked ruleFnName ruleFnSig rule)] else []) (fn_sigs_blocked rule)
   else do
     let matches = drop ((arg_no rule) - 1) args
     if length matches == 0
@@ -333,7 +338,7 @@ validateType argTyp typs = showS argTyp `elem` typs
 
 -- Get List of blocked functions used inside a HsExpr; Uses `getBlockedFnsList` 
 getBlockedFnsList :: PluginOpts -> LHsExpr GhcTc -> FunctionRule -> TcM [(LHsExpr GhcTc, String, String)] 
-getBlockedFnsList opts arg rule@(FunctionRule _ _ arg_no fnsBlocked _ _ _ _ _) = do
+getBlockedFnsList opts arg rule@(FunctionRule _ _ arg_no _ fnsBlocked _ _ _ _ _ _) = do
   let argHsExprs = traverseAst arg :: [LHsExpr GhcTc]
       fnApps = filter isFunApp argHsExprs
   when (logDebugInfo opts) $ liftIO $ do
@@ -350,7 +355,7 @@ getBlockedFnsList opts arg rule@(FunctionRule _ _ arg_no fnsBlocked _ _ _ _ _) =
         showOutputable res
       case res of
         Nothing -> pure Nothing
-        Just (fnNameVar, args) -> isPresentInBlockedFnList expr fnsBlocked (getFnNameWithModuleName fnNameVar) args
+        Just (fnNameVar, args) -> isPresentInBlockedFnList expr fnsBlocked (getLocatedVarNameWithModuleName fnNameVar) args
     
     isPresentInBlockedFnList :: LHsExpr GhcTc -> FnsBlockedInArg -> String -> [LHsExpr GhcTc] -> TcM (Maybe (LHsExpr GhcTc, String, String))
     isPresentInBlockedFnList expr [] _ _ = pure Nothing
@@ -358,7 +363,7 @@ getBlockedFnsList opts arg rule@(FunctionRule _ _ arg_no fnsBlocked _ _ _ _ _) =
       when (logDebugInfo opts) $ liftIO $ do
         print "isPresentInBlockedFnList"
         print (ruleFnName, ruleArgNo, ruleAllowedTypes)
-      case matchFnNames fnName ruleFnName && length fnArgs >= ruleArgNo of
+      case matchNamesWithModuleName fnName ruleFnName && length fnArgs >= ruleArgNo of
         False -> isPresentInBlockedFnList expr ls fnName fnArgs
         True  -> do
           let reqArg = head $ drop (ruleArgNo - 1) fnArgs
@@ -647,8 +652,11 @@ mkFnBlockedInArgErrorInfo opts lOutsideExpr@(L _ outsideExpr) lInsideExpr@(L _ i
 -- Check if a rule is allowed on current module
 isAllowedOnCurrentModule :: String -> Rule -> Bool
 isAllowedOnCurrentModule moduleName rule = 
-  let ignoreModules = getRuleIgnoreModules rule
-  in moduleName `notElem` ignoreModules
+  let ignoredModules = getRuleIgnoreModules rule
+      allowedModules = getRuleAllowedModules rule
+      isCurrentModuleAllowed = any (matchNamesWithAsterisk moduleName) allowedModules
+      isCurrentModuleIgnored = any (matchNamesWithAsterisk moduleName) ignoredModules
+  in isCurrentModuleAllowed && not isCurrentModuleIgnored
 
 -- Create GHC compilation error from CompileError
 mkGhcCompileError :: CompileError -> (SrcSpan, OP.SDoc)

--- a/sheriff/src/Sheriff/Rules.hs
+++ b/sheriff/src/Sheriff/Rules.hs
@@ -50,58 +50,58 @@ logArgNo :: ArgNo
 logArgNo = 2
 
 logRule1 :: Rule
-logRule1 = FunctionRuleT $ FunctionRule "LogRule" ["logErrorT"] logArgNo stringifierFns [] textTypesToCheck logRuleSuggestions [] []
+logRule1 = FunctionRuleT $ FunctionRule "LogRule" ["logErrorT"] logArgNo [] stringifierFns [] textTypesToCheck logRuleSuggestions [] [] ["*"]
 
 logRule2 :: Rule
-logRule2 = FunctionRuleT $ FunctionRule "LogRule" ["logErrorV"] logArgNo stringifierFns [] textTypesToCheck logRuleSuggestions [] []
+logRule2 = FunctionRuleT $ FunctionRule "LogRule" ["logErrorV"] logArgNo [] stringifierFns [] textTypesToCheck logRuleSuggestions [] [] ["*"]
 
 logRule3 :: Rule
-logRule3 = FunctionRuleT $ FunctionRule "LogRule" ["logError"] logArgNo stringifierFns [] textTypesToCheck logRuleSuggestions [] []
+logRule3 = FunctionRuleT $ FunctionRule "LogRule" ["logError"] logArgNo [] stringifierFns [] textTypesToCheck logRuleSuggestions [] [] ["*"]
 
 logRule4 :: Rule
-logRule4 = FunctionRuleT $ FunctionRule "LogRule" ["logInfoT"] logArgNo stringifierFns [] textTypesToCheck logRuleSuggestions [] []
+logRule4 = FunctionRuleT $ FunctionRule "LogRule" ["logInfoT"] logArgNo [] stringifierFns [] textTypesToCheck logRuleSuggestions [] [] ["*"]
 
 logRule5 :: Rule
-logRule5 = FunctionRuleT $ FunctionRule "LogRule" ["logInfoV"] logArgNo stringifierFns [] textTypesToCheck logRuleSuggestions [] []
+logRule5 = FunctionRuleT $ FunctionRule "LogRule" ["logInfoV"] logArgNo [] stringifierFns [] textTypesToCheck logRuleSuggestions [] [] ["*"]
 
 logRule6 :: Rule
-logRule6 = FunctionRuleT $ FunctionRule "LogRule" ["logInfo"] logArgNo stringifierFns [] textTypesToCheck logRuleSuggestions [] []
+logRule6 = FunctionRuleT $ FunctionRule "LogRule" ["logInfo"] logArgNo [] stringifierFns [] textTypesToCheck logRuleSuggestions [] [] ["*"]
 
 logRule7 :: Rule
-logRule7 = FunctionRuleT $ FunctionRule "LogRule" ["logDebugT"] logArgNo stringifierFns [] textTypesToCheck logRuleSuggestions [] []
+logRule7 = FunctionRuleT $ FunctionRule "LogRule" ["logDebugT"] logArgNo [] stringifierFns [] textTypesToCheck logRuleSuggestions [] [] ["*"]
 
 logRule8 :: Rule
-logRule8 = FunctionRuleT $ FunctionRule "LogRule" ["logDebugV"] logArgNo stringifierFns [] textTypesToCheck logRuleSuggestions [] []
+logRule8 = FunctionRuleT $ FunctionRule "LogRule" ["logDebugV"] logArgNo [] stringifierFns [] textTypesToCheck logRuleSuggestions [] [] ["*"]
 
 logRule9 :: Rule
-logRule9 = FunctionRuleT $ FunctionRule "LogRule" ["logDebug"] logArgNo stringifierFns [] textTypesToCheck logRuleSuggestions [] []
+logRule9 = FunctionRuleT $ FunctionRule "LogRule" ["logDebug"] logArgNo [] stringifierFns [] textTypesToCheck logRuleSuggestions [] [] ["*"]
 
 logRule10 :: Rule
-logRule10 = FunctionRuleT $ FunctionRule "LogRule" ["logErrorWithCategory"] logArgNo stringifierFns [] textTypesToCheck logRuleSuggestions [] []
+logRule10 = FunctionRuleT $ FunctionRule "LogRule" ["logErrorWithCategory"] logArgNo [] stringifierFns [] textTypesToCheck logRuleSuggestions [] [] ["*"]
 
 logRule11 :: Rule
-logRule11 = FunctionRuleT $ FunctionRule "LogRule" ["logErrorWithCategoryV"] logArgNo stringifierFns [] textTypesToCheck logRuleSuggestions [] []
+logRule11 = FunctionRuleT $ FunctionRule "LogRule" ["logErrorWithCategoryV"] logArgNo [] stringifierFns [] textTypesToCheck logRuleSuggestions [] [] ["*"]
 
 logRule12 :: Rule
-logRule12 = FunctionRuleT $ FunctionRule "LogRule" ["forkErrorLog"] logArgNo stringifierFns [] textTypesToCheck logRuleSuggestions [] []
+logRule12 = FunctionRuleT $ FunctionRule "LogRule" ["forkErrorLog"] logArgNo [] stringifierFns [] textTypesToCheck logRuleSuggestions [] [] ["*"]
 
 logRule13 :: Rule
-logRule13 = FunctionRuleT $ FunctionRule "LogRule" ["forkInfoLog"] logArgNo stringifierFns [] textTypesToCheck logRuleSuggestions [] []
+logRule13 = FunctionRuleT $ FunctionRule "LogRule" ["forkInfoLog"] logArgNo [] stringifierFns [] textTypesToCheck logRuleSuggestions [] [] ["*"]
 
 logRule14 :: Rule
-logRule14 = FunctionRuleT $ FunctionRule "LogRule" ["debugLog"] logArgNo stringifierFns [] textTypesToCheck logRuleSuggestions [] []
+logRule14 = FunctionRuleT $ FunctionRule "LogRule" ["debugLog"] logArgNo [] stringifierFns [] textTypesToCheck logRuleSuggestions [] [] ["*"]
 
 logRule15 :: Rule
-logRule15 = FunctionRuleT $ FunctionRule "LogRule" ["warnLog"] logArgNo stringifierFns [] textTypesToCheck logRuleSuggestions [] []
+logRule15 = FunctionRuleT $ FunctionRule "LogRule" ["warnLog"] logArgNo [] stringifierFns [] textTypesToCheck logRuleSuggestions [] [] ["*"]
 
 logRule16 :: Rule
-logRule16 = FunctionRuleT $ FunctionRule "LogRule" ["logWarningT"] logArgNo stringifierFns [] textTypesToCheck logRuleSuggestions [] []
+logRule16 = FunctionRuleT $ FunctionRule "LogRule" ["logWarningT"] logArgNo [] stringifierFns [] textTypesToCheck logRuleSuggestions [] [] ["*"]
 
 logRule17 :: Rule
-logRule17 = FunctionRuleT $ FunctionRule "LogRule" ["logWarningV"] logArgNo stringifierFns [] textTypesToCheck logRuleSuggestions [] []
+logRule17 = FunctionRuleT $ FunctionRule "LogRule" ["logWarningV"] logArgNo [] stringifierFns [] textTypesToCheck logRuleSuggestions [] [] ["*"]
 
 logRule18 :: Rule
-logRule18 = FunctionRuleT $ FunctionRule "LogRule" ["logWarning"] logArgNo stringifierFns [] textTypesToCheck logRuleSuggestions [] []
+logRule18 = FunctionRuleT $ FunctionRule "LogRule" ["logWarning"] logArgNo [] stringifierFns [] textTypesToCheck logRuleSuggestions [] [] ["*"]
 
 showRuleExceptions :: Rules
 showRuleExceptions = [
@@ -145,13 +145,13 @@ showRuleExceptions = [
   ]
 
 showRule :: Rule
-showRule = FunctionRuleT $ FunctionRule "ShowRule" ["show"] 1 stringifierFns textTypesBlocked textTypesToCheck showRuleSuggestions showRuleExceptions []
+showRule = FunctionRuleT $ FunctionRule "ShowRule" ["show"] 1 [] stringifierFns textTypesBlocked textTypesToCheck showRuleSuggestions showRuleExceptions [] ["*"]
 
 noUseRule :: Rule
-noUseRule = FunctionRuleT $ FunctionRule "NoDecodeUtf8Rule" ["$text-1.2.4.1$Data.Text.Encoding$decodeUtf8"] 0 [] [] [] ["You might want to use some other wrapper function."] [] []
+noUseRule = FunctionRuleT $ FunctionRule "NoDecodeUtf8Rule" ["$text-1.2.4.1$Data.Text.Encoding$decodeUtf8"] 0 [] [] [] [] ["You might want to use some other wrapper function."] [] [] ["*"]
 
 noKVDBRule :: Rule
-noKVDBRule = FunctionRuleT $ FunctionRule "ART KVDB Rule" ["runKVDB"] 0 [] [] [] ["You might want to use some other wrapper function from `EulerHS.Extra.Redis` module.", "For e.g. - rExists, rDel, rGet, rExpire, etc."] [] []
+noKVDBRule = FunctionRuleT $ FunctionRule "ART KVDB Rule" ["runKVDB"] 0 [] [] [] [] ["You might want to use some other wrapper function from `EulerHS.Extra.Redis` module.", "For e.g. - rExists, rDel, rGet, rExpire, etc."] [] [] ["*"]
 
 dbRule :: Rule
 dbRule = DBRuleT $ DBRule "NonIndexedDBRule" "TxnRiskCheck" [NonCompositeKey "partitionKey"] dbRuleSuggestions []

--- a/sheriff/src/Sheriff/Types.hs
+++ b/sheriff/src/Sheriff/Types.hs
@@ -172,7 +172,7 @@ data FunctionRule =
       fn_rule_fixes          :: Suggestions,
       fn_rule_exceptions     :: Rules,
       fn_rule_ignore_modules :: Modules,
-      fn_rule_allowed_modules  :: Modules
+      fn_rule_check_modules  :: Modules
     }
   deriving (Show, Eq)  
 
@@ -188,8 +188,8 @@ instance FromJSON FunctionRule where
                 fn_rule_fixes <- o .: "fn_rule_fixes"
                 fn_rule_exceptions <- o .: "fn_rule_exceptions"
                 fn_rule_ignore_modules <- o .: "fn_rule_ignore_modules"
-                fn_rule_allowed_modules <- o .:? "fn_rule_allowed_modules" .!= ["*"]
-                return (FunctionRule {fn_rule_name = fn_rule_name, fn_name = fn_name, arg_no = arg_no, fn_sigs_blocked = fn_sigs_blocked, fns_blocked_in_arg = fns_blocked_in_arg, types_blocked_in_arg = types_blocked_in_arg, types_to_check_in_arg = types_to_check_in_arg, fn_rule_fixes = fn_rule_fixes, fn_rule_exceptions = fn_rule_exceptions, fn_rule_ignore_modules = fn_rule_ignore_modules, fn_rule_allowed_modules = fn_rule_allowed_modules })
+                fn_rule_check_modules <- o .:? "fn_rule_check_modules" .!= ["*"]
+                return (FunctionRule {fn_rule_name = fn_rule_name, fn_name = fn_name, arg_no = arg_no, fn_sigs_blocked = fn_sigs_blocked, fns_blocked_in_arg = fns_blocked_in_arg, types_blocked_in_arg = types_blocked_in_arg, types_to_check_in_arg = types_to_check_in_arg, fn_rule_fixes = fn_rule_fixes, fn_rule_exceptions = fn_rule_exceptions, fn_rule_ignore_modules = fn_rule_ignore_modules, fn_rule_check_modules = fn_rule_check_modules })
 
 data DBRule =
   DBRule 
@@ -366,9 +366,9 @@ getRuleIgnoreModules rule = case rule of
   FunctionRuleT fnRule -> fn_rule_ignore_modules fnRule
   _ -> []
 
-getRuleAllowedModules :: Rule -> Modules
-getRuleAllowedModules rule = case rule of 
-  FunctionRuleT fnRule -> fn_rule_allowed_modules fnRule
+getRuleCheckModules :: Rule -> Modules
+getRuleCheckModules rule = case rule of 
+  FunctionRuleT fnRule -> fn_rule_check_modules fnRule
   _ -> []
 
 noSuggestion :: Suggestions

--- a/sheriff/test/Test1.hs
+++ b/sheriff/test/Test1.hs
@@ -251,13 +251,17 @@ main = do
     logError "tag" $ show temp5
     logError "tag" $ show temp6
     
-    let (TU.Number sRes) = num1 TU.-? num2
-        (TU.Number aRes) = num1 TU.+? num2
+    let (TU.Number sRes) = num1 `TU.subtractNumber` num2
+        (TU.Number aRes) = TU.addNumber num1 num2
         (TU.Number mRes) = (TU.*?) Nothing num1 num2
+        (TU.Number n1) = TU.fstArg num1 num2
+        (TU.Number n2) = TU.sndArg num1 num2
 
     print sRes
     print aRes
     print mRes
+    print n1
+    print n2
 
     runKVDB -- Should be error
 

--- a/sheriff/test/Test1.hs
+++ b/sheriff/test/Test1.hs
@@ -165,6 +165,12 @@ obC3T1 = T.pack $ show obC3
 obC3T2 :: Text
 obC3T2 = encodeJSON obC3
 
+num1 :: TU.Number
+num1 = TU.Number 20
+
+num2 :: TU.Number
+num2 = TU.Number 10
+
 -- Test Case 1: Text inside logErrorT (No error should be raised by plugin)
 -- Test Case 2: Text inside logErrorV (An error should be raised by plugin)
 -- Test Case 3: Object inside logErrorV (No error should be generated)
@@ -245,6 +251,14 @@ main = do
     logError "tag" $ show temp5
     logError "tag" $ show temp6
     
+    let (TU.Number sRes) = num1 TU.-? num2
+        (TU.Number aRes) = num1 TU.+? num2
+        (TU.Number mRes) = (TU.*?) Nothing num1 num2
+
+    print sRes
+    print aRes
+    print mRes
+
     runKVDB -- Should be error
 
     logDebugT "validateMandate" $ "effective limit is: " <> T.pack (show 10) <> ", custom limit for key: " <> " is " <> T.pack (show (Just ("Hello" :: Text)))

--- a/sheriff/test/TestUtils.hs
+++ b/sheriff/test/TestUtils.hs
@@ -2,6 +2,8 @@ module TestUtils where
 
 import Data.Text
 
+newtype Number = Number Int
+
 throwException :: Text -> ()
 throwException _ = ()
 
@@ -16,3 +18,21 @@ throwExceptionV3 = throwExceptionV2
 
 throwExceptionV4 :: Text -> ()
 throwExceptionV4 = throwException
+
+addNumber :: Number -> Number -> Number
+addNumber (Number a) (Number b) = Number (a + b)
+
+subtractNumber :: Number -> Number -> Number
+subtractNumber (Number a) (Number b) = Number (a - b)
+
+multiplyNumber :: Number -> Number -> Number
+multiplyNumber (Number a) (Number b) = Number (a * b)
+
+(+?) :: Number -> Number -> Number
+(+?) = addNumber
+
+(-?) :: Number -> Number -> Number
+(-?) = subtractNumber
+
+(*?) :: Maybe (Either (Maybe Int) (Maybe Int)) -> Number -> Number -> Number
+(*?) _ = multiplyNumber

--- a/sheriff/test/TestUtils.hs
+++ b/sheriff/test/TestUtils.hs
@@ -36,3 +36,9 @@ multiplyNumber (Number a) (Number b) = Number (a * b)
 
 (*?) :: Maybe (Either (Maybe Int) (Maybe Int)) -> Number -> Number -> Number
 (*?) _ = multiplyNumber
+
+fstArg :: a -> a -> a
+fstArg a1 a2 = a1
+
+sndArg :: a -> a -> a
+sndArg a1 a2 = a2


### PR DESCRIPTION
* Add allowed modules list for function rule (by default all modules are allowed)
* Add support for wildcard character "*" in function rules
* Add support for blocking functions with a particular type signature (Signature only) (by default no signature check)
* Add test rules in sheriff rules

Example rule for above changes:
```yaml
# We should get the errors for below functions two times only in Test1
  - fn_rule_name: Test Allowed Modules
    fn_name:
      - throwExceptionV2
      - TestUtils.throwExceptionV4
    arg_no: 0
    fns_blocked_in_arg: []
    types_blocked_in_arg: []
    types_to_check_in_arg: []
    fn_rule_fixes:
      - You are not allowed to use helper function `throwException` from `TestUtils` module.
      - Use `throwExceptionV2` or `throwExceptionV4` function from `TestUtils` module.
    fn_rule_exceptions: []
    fn_rule_ignore_modules: []
    fn_rule_allowed_modules:
      - "Test1"
    
  # We should get error for usage of any function with Number type
  - fn_rule_name: Test Functions usage blocked having any function name with given signature
    fn_name:
      - "*"
    arg_no: 0
    fn_sigs_blocked:
      - Number -> TestUtils1.Number -> * # Should not throw Error
      - Number -> Number -> Number # Should throw Error
      - TestUtils.Number -> TestUtils.Number -> TestUtils.Number # Should throw Error
      - Maybe (Either (Maybe (Int)) (Maybe (Int))) -> Number -> Number -> Number # Should throw Error
    fns_blocked_in_arg: []
    types_blocked_in_arg: []
    types_to_check_in_arg: []
    fn_rule_fixes:
      - Contact senior dev for the solution.
    fn_rule_exceptions: []
    fn_rule_ignore_modules: []
    fn_rule_allowed_modules:
      - Test1
```

Example output:
<img width="1014" alt="image" src="https://github.com/user-attachments/assets/216705f1-eb8a-446c-91e8-9b34eae84b11">
