### PR TITLE
sheriff[Fix]: Wrong detection of infinite recursion

### DIFF
--- a/sheriff/CHANGELOG.md
+++ b/sheriff/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision history for sheriff
 
+## 0.2.1.2
+* Add type signature check for self recursive function calls (edge cases for instance calls)
+
 ## 0.2.1.1
 * Add module name check for self recursive function calls
 * Add top level module name resolving for instance functions

--- a/sheriff/CHANGELOG.md
+++ b/sheriff/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for sheriff
 
+## 0.2.1.1
+* Add module name check for self recursive function calls
+* Add top level module name resolving for instance functions
+* Add test cases for calling function with same name but from different module
+* Add State based flow implementation for infinite recursion detection
+
 ## 0.2.1.0
 * Add infinite recursion rule
 * Add test suite for infinite recursion rule detection

--- a/sheriff/CHANGELOG.md
+++ b/sheriff/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision history for sheriff
 
+## 0.2.1.3
+* Fix type signature check case by avoiding constraint matching (edge case for functions with constraint cases, only in GHC 9.2.8)
+
 ## 0.2.1.2
 * Add type signature check for self recursive function calls (edge cases for instance calls)
 

--- a/sheriff/sheriff.cabal
+++ b/sheriff/sheriff.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               sheriff
-version:            0.2.1.0
+version:            0.2.1.1
 synopsis:           A checker plugin to throw compilation errors based on given rules; basically what a `Sheriff` does
 license:            MIT
 license-file:       LICENSE
@@ -60,6 +60,7 @@ library
         , classyplate
         , aeson
         , directory
+        , mtl
         , extra
         , yaml
         , text

--- a/sheriff/sheriff.cabal
+++ b/sheriff/sheriff.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               sheriff
-version:            0.2.1.2
+version:            0.2.1.3
 synopsis:           A checker plugin to throw compilation errors based on given rules; basically what a `Sheriff` does
 license:            MIT
 license-file:       LICENSE

--- a/sheriff/sheriff.cabal
+++ b/sheriff/sheriff.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               sheriff
-version:            0.2.1.1
+version:            0.2.1.2
 synopsis:           A checker plugin to throw compilation errors based on given rules; basically what a `Sheriff` does
 license:            MIT
 license-file:       LICENSE

--- a/sheriff/src/Sheriff/CommonTypes.hs
+++ b/sheriff/src/Sheriff/CommonTypes.hs
@@ -47,7 +47,7 @@ data TypeData = TextTy String | NestedTy [TypeData]
 
 data SimpleTcExpr = 
     SimpleVar Var
-  | SimpleFnNameVar Var -- Just for lenient checking
+  | SimpleFnNameVar Var Type -- Just for checking function Variable
   | SimpleList [SimpleTcExpr]
   | SimpleAliasPat SimpleTcExpr SimpleTcExpr
   | SimpleTuple [SimpleTcExpr]
@@ -59,7 +59,7 @@ data SimpleTcExpr =
 instance Outputable SimpleTcExpr where
   ppr simpleTcExpr = case simpleTcExpr of
     SimpleVar v -> "SimpleVar " $$ ppr v
-    SimpleFnNameVar v -> "SimpleFnNameVar " $$ ppr v
+    SimpleFnNameVar v ty -> "SimpleFnNameVar " $$ ppr v $$ ppr ty
     SimpleList ls -> "SimpleList " $$ ppr ls
     SimpleAliasPat p1 p2 -> "SimpleAliasPat "
     SimpleTuple ls -> "SimpleTuple " $$ ppr ls
@@ -73,7 +73,7 @@ instance Eq SimpleTcExpr where
   (==) (SimpleAliasPat pat1 pat2)   pat                          = pat1 == pat || pat2 == pat
   (==) pat                          (SimpleAliasPat pat1 pat2)   = pat1 == pat || pat2 == pat
   (==) (SimpleVar var1)             (SimpleVar var2)             = var1 == var2
-  (==) (SimpleFnNameVar var1)       (SimpleFnNameVar var2)       = nameOccName (varName var1) == nameOccName (varName var2)
+  (==) (SimpleFnNameVar var1 ty1)   (SimpleFnNameVar var2 ty2)   = nameOccName (varName var1) == nameOccName (varName var2)
   (==) (SimpleList pat1)            (SimpleList pat2)            = pat1 == pat2
   (==) (SimpleTuple pat1)           (SimpleTuple pat2)           = pat1 == pat2
   (==) (SimpleDataCon mbVar1 pat1)  (SimpleDataCon mbVar2 pat2)  = mbVar1 == mbVar2 && pat1 == pat2

--- a/sheriff/src/Sheriff/Patterns.hs
+++ b/sheriff/src/Sheriff/Patterns.hs
@@ -15,8 +15,8 @@ import TyCoRep
 #endif
 
 #if __GLASGOW_HASKELL__ >= 900
-pattern PatFunTy :: Type -> Type -> Type
-pattern PatFunTy ty1 ty2 <- (FunTy _ _ ty1 ty2)
+pattern PatFunTy :: AnonArgFlag -> Type -> Type -> Type
+pattern PatFunTy anonArgFlag ty1 ty2 <- (FunTy anonArgFlag _ ty1 ty2)
 
 pattern PatHsIf :: LHsExpr (GhcPass p) -> LHsExpr (GhcPass p) -> LHsExpr (GhcPass p) -> HsExpr (GhcPass p)
 pattern PatHsIf pred thenCl elseCl <- (HsIf _ pred thenCl elseCl)
@@ -31,8 +31,8 @@ pattern PatExplicitList :: (XExplicitList (GhcPass p)) -> [LHsExpr (GhcPass p)] 
 pattern PatExplicitList typ arg = (ExplicitList typ arg)
 
 #else
-pattern PatFunTy :: Type -> Type -> Type
-pattern PatFunTy ty1 ty2 <- (FunTy _ ty1 ty2)
+pattern PatFunTy :: AnonArgFlag -> Type -> Type -> Type
+pattern PatFunTy anonArgFlag ty1 ty2 <- (FunTy anonArgFlag ty1 ty2)
 
 pattern PatHsIf :: LHsExpr (GhcPass p) -> LHsExpr (GhcPass p) -> LHsExpr (GhcPass p) -> HsExpr (GhcPass p)
 pattern PatHsIf pred thenCl elseCl <- (HsIf _ _ pred thenCl elseCl)

--- a/sheriff/src/Sheriff/Plugin.hs
+++ b/sheriff/src/Sheriff/Plugin.hs
@@ -19,6 +19,7 @@ import Sheriff.Utils
 import Control.Applicative ((<|>))
 import Control.Monad (foldM, when)
 import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.State
 import Data.Aeson as A
 import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.Bool (bool)
@@ -37,7 +38,9 @@ import Prelude hiding (id, writeFile, appendFile)
 import System.Directory (createDirectoryIfMissing, getHomeDirectory)
 
 #if __GLASGOW_HASKELL__ >= 900
+import GHC.Core.Class
 import GHC.Core.ConLike
+import GHC.Core.InstEnv
 import GHC.Core.TyCo.Rep
 import GHC.Data.Bag
 import GHC.HsToCore.Monad
@@ -51,10 +54,12 @@ import GHC.Types.Annotations
 import qualified GHC.Utils.Outputable as OP
 #else
 import Bag
+import Class
 import ConLike
 import DsExpr
 import DsMonad
 import GhcPlugins hiding ((<>), getHscEnv, purePlugin)
+import InstEnv
 import qualified Outputable as OP
 import TcEvidence
 import TcRnMonad
@@ -103,6 +108,15 @@ Stage - 3 ERRORS AND IO
 
 -}
 
+{-
+  TODO: 
+    1. Generalize the custom state monad and run things with context available to all functions
+    2. Reuse the same type for implicit param and state (for interusability)
+    3. Add helper functions to set in implicit params from state
+    4. Change module name matching to direct variable matching by means of transforming to top most level
+-}
+
+type SheriffTcM = StateT (HM.HashMap NameModuleValue NameModuleValue) TcM
 
 sheriff :: [CommandLineOption] -> ModSummary -> TcGblEnv -> TcM TcGblEnv
 sheriff opts modSummary tcEnv = do
@@ -110,7 +124,7 @@ sheriff opts modSummary tcEnv = do
   let moduleName' = moduleNameString $ moduleName $ ms_mod modSummary
       pluginOpts@PluginOpts{..} = decodeAndUpdateOpts opts defaultPluginOpts
 
-  let ?pluginOpts = PluginCommonOpts moduleName' pluginOpts
+  let ?pluginOpts = PluginCommonOpts moduleName' HM.empty pluginOpts
 
   -- parse the yaml file from the path given
   parsedYaml <- liftIO $ parseYAMLFile indexedKeysPath
@@ -153,15 +167,20 @@ sheriff opts modSummary tcEnv = do
                                     _ -> False
       infRule = case find isInfiniteRecursionRule globalRules of
                   Just (InfiniteRecursionRuleT r) -> r
-                  _ -> infiniteRecursionRuleT
+                  _ -> defaultInfiniteRecursionRuleT
 
   when logDebugInfo $ liftIO $ print globalRules
   when logDebugInfo $ liftIO $ print globalExceptionRules
 
   -- STAGE-2
+  -- Get Instance declarations and add class name to module name binding in initial state
+  insts <- tcg_insts . env_gbl <$> getEnv
+  let namesModTuple = fmap (\inst -> (is_dfun_name inst, getModuleName . className . is_cls $ inst)) insts
+      nameModMap = foldr (\(name, modname) r -> HM.insert (NMV_Name name) (NMV_Module modname) r) HM.empty namesModTuple
+  
   rawErrors <- concat <$> (mapM (loopOverModBinds finalSheriffRules) $ bagToList $ tcg_binds tcEnv)
-  rawInfiniteRecursionErrors <- concat <$> (mapM (checkInfiniteRecursion True infRule) $ bagToList $ tcg_binds tcEnv)
-
+  (rawInfiniteRecursionErrors, _) <- flip runStateT nameModMap $ concat <$> (mapM (checkInfiniteRecursion True infRule) $ bagToList $ tcg_binds tcEnv)
+  
   -- STAGE-3
   errors <- mapM (mkCompileError moduleName') (rawErrors <> rawInfiniteRecursionErrors)
 
@@ -169,7 +188,7 @@ sheriff opts modSummary tcEnv = do
       groupedErrors = groupBy (\a b -> src_span a == src_span b) sortedErrors
       filteredErrorsForRuleLevelExceptions = fmap (\x -> let errorRulesInCurrentGroup = fmap getRuleFromCompileError x in filter (\err -> not $ (getRuleExceptionsFromCompileError err) `hasAny` errorRulesInCurrentGroup) x) groupedErrors
       filteredErrorsForGlobalExceptions = concat $ filter (\x -> not $ (\err -> (getRuleFromCompileError err) `elem` globalExceptionRules) `any` x) filteredErrorsForRuleLevelExceptions
-      filteredErrors = nub $ filter (\x -> getRuleFromCompileError x `elem` globalRules) filteredErrorsForGlobalExceptions -- Filter errors to take only rules since we might have some individual rule level errors in this list
+      filteredErrors = nub $ filter (\x -> getRuleFromCompileError x `elem` (InfiniteRecursionRuleT infRule : globalRules)) filteredErrorsForGlobalExceptions -- Filter errors to take only rules since we might have some individual rule level errors in this list
 
   if throwCompilationError
     then addErrs $ map mkGhcCompileError filteredErrors
@@ -184,18 +203,20 @@ sheriff opts modSummary tcEnv = do
 --------------------------- Infinite Recursion Detection Logic ---------------------------
 {-
 
-  1. Check if bind is FunBind, then get the function `var`
-  2. Get all the match groups from the match (One match group is single definition for a function, a function may have multiple match groups)
-  3. For each match group, perform below steps:
-    3.1 Get the Pattern matches
-    3.2 Transform pattern matches into common type `SimpleTcExpr`
-    3.3 Append function name var to the beginning to complete the transformation
-    3.4 Fetch all the HsExpr from the match group's guarded rhs (includes where clause)
-    3.5 Filter out FunApp from all the HsExpr
-    3.6 Simplify for ($) operator and transform to `SimpleTcExpr`
-    3.7 Check if any of the `SimpleTcExpr` representation of HsExpr is same as `SimpleTcExpr` representation of pattern matches
-    3.8 Fetch all the FunBinds from the guarded rhs
-    3.9 Recur for each fun bind and repeat from step 1 
+  1. Check if bind is AbsBind, add a mapping from mono to poly Var and recurse for binds
+  2. Check if bind is VarBind, add mappings for child HsVar to VarId and update state
+  3. Check if bind is FunBind, then get the function `var`
+  4. Get all the match groups from the match (One match group is single definition for a function, a function may have multiple match groups)
+  5. For each match group, perform below steps:
+    5.1 Get the Pattern matches
+    5.2 Transform pattern matches into common type `SimpleTcExpr`
+    5.3 Append function name var to the beginning to complete the transformation
+    5.4 Fetch all the HsExpr from the match group's guarded rhs (includes where clause)
+    5.5 Filter out FunApp from all the HsExpr
+    5.6 Simplify for ($) operator and transform to `SimpleTcExpr`
+    5.7 Check if any of the `SimpleTcExpr` representation of HsExpr is same as `SimpleTcExpr` representation of pattern matches
+    5.8 Fetch all the FunBinds from the guarded rhs
+    5.9 Recur for each fun bind and repeat from step 1 
 
 TODO: (Optimizations)
   1. Traverse a functions's body HsExpr once only and traverse the list/tree manually filtering based on location for local function binds
@@ -213,24 +234,39 @@ TODO: (Extending Patterns)
 
 
 -- Function to check if the AST has deterministic infinite recursion
-checkInfiniteRecursion :: (HasPluginOpts PluginOpts) => Bool -> InfiniteRecursionRule -> LHsBindLR GhcTc GhcTc -> TcM [(LHsExpr GhcTc, Violation)]
+checkInfiniteRecursion :: (HasPluginOpts PluginOpts) => Bool -> InfiniteRecursionRule -> LHsBindLR GhcTc GhcTc -> SheriffTcM [(LHsExpr GhcTc, Violation)]
 checkInfiniteRecursion recurseForBinds rule (L _ ap@(FunBind{fun_id = funVar, fun_matches = matches})) = do
+  currNameModMap <- get
+  let ?pluginOpts = ?pluginOpts {nameModuleMap = currNameModMap}
   errs <- mapM (checkAndVerifyAlt recurseForBinds rule funVar) (fmap unLoc . unLoc $ mg_alts matches)
   pure $ concat errs
-checkInfiniteRecursion recurseForBinds rule (L _ ap@(AbsBinds{abs_binds = binds})) = do
-  list <- mapM (checkInfiniteRecursion recurseForBinds rule) $ bagToList binds
-  pure (concat list)
+checkInfiniteRecursion recurseForBinds rule (L _ ap@(AbsBinds{abs_binds = binds, abs_exports = bindVars})) = do
+  let mbVar = case bindVars of
+                x : _ -> Just $ (varName $ abe_poly x, varName $ abe_mono x)
+                _ -> Nothing
+  currNameModMap <- get
+  let updatedNameModMap = maybe currNameModMap (\(poly, mono) -> HM.insert (NMV_Name mono) (NMV_Name poly) currNameModMap) mbVar
+  put updatedNameModMap
+  list <- mapM (\x -> checkInfiniteRecursion recurseForBinds rule x) $ bagToList binds
+  pure $ concat list
+checkInfiniteRecursion recurseForBinds rule (L loc ap@(VarBind{var_id = varId, var_rhs = rhs})) = do
+  let currVarName = varName varId
+      childHsVar = fmap varName (traverseAst rhs)
+  currNameModMap <- get
+  let updatedNameModMap = foldr (\childVar r -> HM.insert (NMV_Name childVar) (NMV_Name currVarName) r) currNameModMap childHsVar
+  put updatedNameModMap
+  pure []
 checkInfiniteRecursion _ _ _ = pure []
 
 -- Helper function to verify if any of the body HsExpr results in infinite recursion
-checkAndVerifyAlt :: (HasPluginOpts PluginOpts) => Bool -> InfiniteRecursionRule -> LIdP GhcTc -> Match GhcTc (LHsExpr GhcTc) -> TcM [(LHsExpr GhcTc, Violation)]
+checkAndVerifyAlt :: (HasPluginOpts PluginOpts) => Bool -> InfiniteRecursionRule -> LIdP GhcTc -> Match GhcTc (LHsExpr GhcTc) -> SheriffTcM [(LHsExpr GhcTc, Violation)]
 checkAndVerifyAlt recurseForBinds rule ap@(L loc fnVar) match = do
   let argsInFnDefn = m_pats match
       currentFnNameWithModule = getVarNameWithModuleName fnVar
       ignoredFunctions = infinite_recursion_rule_ignore_functions rule
       trfArgsInFnDefn = fmap (trfPatToSimpleTcExpr . unLoc) argsInFnDefn
       finalTrfArgsInFnDefn = (SimpleFnNameVar fnVar) : trfArgsInFnDefn
-  argLenByTy <- length <$> getHsExprTypeAsTypeDataList <$> getHsExprType False (mkLHsVar $ getLocated ap loc)
+  argLenByTy <- lift $ length <$> getHsExprTypeAsTypeDataList <$> getHsExprType False (mkLHsVar $ getLocated ap loc)
   let isPartialFn = length argsInFnDefn /= argLenByTy - 1
       (hsExprs :: [LHsExpr GhcTc]) = 
         if isPartialFn then traverseAst (foldr getLastStmt [] $ grhssGRHSs (m_grhss match))
@@ -238,7 +274,7 @@ checkAndVerifyAlt recurseForBinds rule ap@(L loc fnVar) match = do
       (funApps :: [LHsExpr GhcTc]) = filter (\expr -> isFunApp expr || isHsVar expr) hsExprs
       (simplifiedFnApps :: [(Located Var, (LHsExpr GhcTc, [LHsExpr GhcTc]))]) = HM.toList $ foldr (\x r -> maybe r (\(lVar, args) -> HM.insertWith (\newArgs oldArgs -> if length newArgs >= length oldArgs then newArgs else oldArgs) lVar (x, args) r) $ getFnNameWithAllArgs x) HM.empty funApps
       (trfSimplifiedFunApps :: [(LHsExpr GhcTc, [SimpleTcExpr])]) = fmap trfSimplifiedFunApp simplifiedFnApps 
-      currentFnErrors = map (\(lhsExpr, _) -> (lhsExpr, InfiniteRecursionDetected rule)) $ filter (\x -> (any (\ignoredFnName -> matchNamesWithModuleName currentFnNameWithModule ignoredFnName AsteriskInSecond) ignoredFunctions == False) && (snd x == finalTrfArgsInFnDefn)) trfSimplifiedFunApps 
+      currentFnErrors = map (\(lhsExpr, _) -> (lhsExpr, InfiniteRecursionDetected rule)) $ filter (\x -> (any (\ignoredFnName -> matchNamesWithModuleName currentFnNameWithModule ignoredFnName AsteriskInSecond) ignoredFunctions == False) && (snd x === finalTrfArgsInFnDefn)) trfSimplifiedFunApps 
         
   -- Process sub binds if further recursion allowed
   subBindsErrors <- 

--- a/sheriff/src/Sheriff/Plugin.hs
+++ b/sheriff/src/Sheriff/Plugin.hs
@@ -285,11 +285,13 @@ checkAndVerifyAlt recurseForBinds rule ap@(L loc fnVar) match = do
         concat <$> mapM (checkInfiniteRecursion False rule) subBinds
       else pure []
   
-  when (logTypeDebugging . pluginOpts $ ?pluginOpts) $ 
+  when (logDebugInfo . pluginOpts $ ?pluginOpts) $ 
     liftIO $ do
-      showOutputable simplifiedFnApps >> putStrLn "***"
-      showOutputable trfSimplifiedFunApps >> putStrLn "***"
-      showOutputable finalTrfArgsInFnDefn >> putStrLn "\n"
+      putStrLn (showS loc <> " :: " <> showS fnVar) >> putStrLn "***"
+      print (getHsExprTypeAsTypeDataList fnVarTyp) >> putStrLn "***"
+      let tyL = concat $ fmap (foldr (\x r -> case x of; SimpleFnNameVar v ty -> (v, ty) : r; _ -> r;) [] . snd) trfSimplifiedFunApps
+      mapM (\(v, t) -> putStrLn $ showS v <> " ::: " <> show (getHsExprTypeAsTypeDataList t)) tyL
+      putStrLn "******"
 
   pure (currentFnErrors <> subBindsErrors)
   where

--- a/sheriff/src/Sheriff/Rules.hs
+++ b/sheriff/src/Sheriff/Rules.hs
@@ -27,10 +27,10 @@ showRule :: Rule
 showRule = FunctionRuleT $ FunctionRule "ShowRule" ["show"] 1 [] stringifierFns textTypesBlocked textTypesToCheck showRuleSuggestions showRuleExceptions [] ["*"] []
 
 infiniteRecursionRule :: Rule
-infiniteRecursionRule = InfiniteRecursionRuleT infiniteRecursionRuleT
+infiniteRecursionRule = InfiniteRecursionRuleT defaultInfiniteRecursionRuleT
 
-infiniteRecursionRuleT :: InfiniteRecursionRule 
-infiniteRecursionRuleT = defaultInfiniteRecursionRule {infinite_recursion_rule_name = "Infinite Recursion", infinite_recursion_rule_fixes = ["Remove the infinite recursion.", "Add a base case check.", "Pass the modified value to function arguments."]}
+defaultInfiniteRecursionRuleT :: InfiniteRecursionRule 
+defaultInfiniteRecursionRuleT = defaultInfiniteRecursionRule {infinite_recursion_rule_name = "Infinite Recursion", infinite_recursion_rule_fixes = ["Remove the infinite recursion.", "Add a base case check.", "Pass the modified value to function arguments."]}
 
 noKVDBRule :: Rule
 noKVDBRule = FunctionRuleT $ FunctionRule "ART KVDB Rule" ["runKVDB"] 0 [] [] [] [] ["You might want to use some other wrapper function from `EulerHS.Extra.Redis` module.", "For e.g. - rExists, rDel, rGet, rExpire, etc."] [] [] ["*"] []

--- a/sheriff/src/Sheriff/Utils.hs
+++ b/sheriff/src/Sheriff/Utils.hs
@@ -449,5 +449,5 @@ trfLHsExprToSimpleTcExpr (L loc hsExpr) = case hsExpr of
 #endif
 
 instance StrictEq SimpleTcExpr where
-  (===) (SimpleFnNameVar var1) (SimpleFnNameVar var2) = (getModuleNameWithNMV (varName var1) == getModuleNameWithNMV (varName var2)) && (getVarName var1 == getVarName var2)
-  (===) var1                   var2                   = (var1 == var2)
+  (===) (SimpleFnNameVar var1 ty1) (SimpleFnNameVar var2 ty2) = (getModuleNameWithNMV (varName var1) == getModuleNameWithNMV (varName var2)) && (getVarName var1 == getVarName var2) && (getHsExprTypeAsTypeDataList ty1 == getHsExprTypeAsTypeDataList ty2)
+  (===) var1                       var2                       = (var1 == var2)

--- a/sheriff/test/SubTests/InfiniteRecursionTest.hs
+++ b/sheriff/test/SubTests/InfiniteRecursionTest.hs
@@ -165,6 +165,15 @@ pattern22 = pattern22 -- STE :: Should Throw Error
 toJSON :: (A.ToJSON a) => a -> A.Value
 toJSON = A.toJSON -- Should NOT Throw Error
 
+pattern23 :: (Num a) => a -> a
+pattern23 numVal = pattern23 numVal -- STE :: Should throw error
+
+pattern24 :: forall a. (Num a) => a -> a
+pattern24 numVal = pattern24 numVal -- STE :: Should throw error
+
+pattern25 :: forall a. a -> a
+pattern25 numVal = pattern25 numVal -- STE :: Should throw error
+
 class TypeChanger a b where
   changeType :: a -> b
 

--- a/sheriff/test/SubTests/InfiniteRecursionTest.hs
+++ b/sheriff/test/SubTests/InfiniteRecursionTest.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 
 module SubTests.InfiniteRecursionTest where
 
@@ -37,7 +40,7 @@ pattern1 x = do
 -- Self recursive variable
 pattern2 :: String -> String
 pattern2 _ = 
- let x = x <> "Dummy" in x -- STE :: Should Throw Error since infinite self recursive variable usage
+ let sameVal = sameVal <> "Dummy" in sameVal -- STE :: Should Throw Error since infinite self recursive variable usage
 
 -- Self recursive function
 pattern3 :: String -> String
@@ -161,6 +164,18 @@ pattern22 = pattern22 -- STE :: Should Throw Error
 -- Same function name but from different module
 toJSON :: (A.ToJSON a) => a -> A.Value
 toJSON = A.toJSON -- Should NOT Throw Error
+
+class TypeChanger a b where
+  changeType :: a -> b
+
+instance TypeChanger Integer Int where
+  changeType = fromIntegral -- Should not throw error since no recursion
+
+instance TypeChanger Integer SumType where
+  changeType = TypeA . changeType -- Should NOT throw Error since type is changed
+
+instance TypeChanger Integer Integer where
+  changeType = changeType -- STE :: Should throw Error
 
 main :: IO ()
 main = do

--- a/sheriff/test/SubTests/InfiniteRecursionTest.hs
+++ b/sheriff/test/SubTests/InfiniteRecursionTest.hs
@@ -154,6 +154,14 @@ pattern21 =
       y = "Hello"
   in pattern21 -- STE :: Should Throw Error
 
+-- Self recursive straight away
+pattern22 :: Int
+pattern22 = pattern22 -- STE :: Should Throw Error
+
+-- Same function name but from different module
+toJSON :: (A.ToJSON a) => a -> A.Value
+toJSON = A.toJSON -- Should NOT Throw Error
+
 main :: IO ()
 main = do
   pure ()


### PR DESCRIPTION
Issues:
1. Module name matching was not being done, so functions with same name but different module were being detected as infinite recursion
2. Post module name matching, instances methods declaration were not having the exact module name for original class definition from where the instance method actually comes.
3. Functions with same name and module but with different type signatures (different instances being selected based on type) were being detected as infinite recursion
4. Post adding type signature matching, ghc-9.2.8 was adding function constraints in the type signature while ghc-8.10.7 was not adding it. Due to this, infinite recursion was not being detected for ghc-9.2.8 in such cases due to type signature mismatch.

Changes Done:
* Add module name check for self recursive function calls
* Add top level module name resolving for instance functions
* Add test cases for calling function with same name but from different module
* Add State based flow implementation for infinite recursion detection
* Add type signature check for self recursive function calls (edge cases for instance calls)
* Fix type signature check case by avoiding constraint matching 