### PR TITLE
sheriff[fix + improvement]: fix false positive for infinite recursion + support for infinite recursion in lambda case

### DIFF
--- a/sheriff/CHANGELOG.md
+++ b/sheriff/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Revision history for sheriff
 
+## 0.2.1.4
+* Fix function level exception not working for Function Rule
+* Fix infinite recursion being detected for top level function being called in `where` clause
+* Fix infinite recursion being detected for partial function being called inside `fmap` or any other higher order function
+* Handle infinite recursion of `LambdaCase` & `Lambda` functions for partial functions
+* Add/modify test cases to check above cases
+* Refactor partial function infinite recursion detection code for better reusability 
+
 ## 0.2.1.3
 * Fix type signature check case by avoiding constraint matching (edge case for functions with constraint cases, only in GHC 9.2.8)
 

--- a/sheriff/InfiniteRecursionPatterns.md
+++ b/sheriff/InfiniteRecursionPatterns.md
@@ -51,7 +51,7 @@ fn 10 = fn (10 :: Int)
 fn _ = -1
 ```
 
-## Pattern 6 : Infinite recursion call on partial function called as alias
+## Pattern 6 : Infinite recursion call on partial function
 for e.g. - 
 ```haskell
 fn :: Int -> Int
@@ -70,4 +70,35 @@ for e.g. -
 ```haskell
 fn :: Int -> Int
 fn = let z = "Dummy" in fn
+```
+
+## Pattern 9 : Infinite recursion in instance method based on instance type being used
+for e.g. -
+```haskell
+class TypeChanger a b where
+  changeType :: a -> b
+
+data SumType = TypeA Int | TypeB | RecType SumType
+
+instance TypeChanger String SumType where
+  changeType x = RecType $ changeType x -- Infinite recursion since types are same (TypeChanger String SumType)
+
+instance TypeChanger Integer SumType where
+  changeType = TypeA . changeType -- NOT infinite recursion since type is changed (TypeChanger Integer Int)
+```
+
+## Pattern 10 : Infinite recursion call on partial function but using lambda case (in normal function and instance methods, as first statement or let-in statement or in function composition)
+for e.g. - 
+```haskell
+fn :: String -> String
+fn = \case
+  "Pattern" -> fn "Pattern" -- Infinite recursion due to same pattern
+  b         -> fn b -- Infinite recursion due to same variable
+```
+
+## Pattern 11 : Infinite recursion call on partial function but using lambda functions (in normal function and instance methods, as first statement or let-in statement or in function composition)
+for e.g. - 
+```haskell
+fn :: String -> String
+fn = \x -> fn x -- Infinite recursion due to same variable
 ```

--- a/sheriff/sheriff.cabal
+++ b/sheriff/sheriff.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               sheriff
-version:            0.2.1.3
+version:            0.2.1.4
 synopsis:           A checker plugin to throw compilation errors based on given rules; basically what a `Sheriff` does
 license:            MIT
 license-file:       LICENSE

--- a/sheriff/src/Sheriff/Patterns.hs
+++ b/sheriff/src/Sheriff/Patterns.hs
@@ -22,7 +22,7 @@ pattern PatHsIf :: LHsExpr (GhcPass p) -> LHsExpr (GhcPass p) -> LHsExpr (GhcPas
 pattern PatHsIf pred thenCl elseCl <- (HsIf _ pred thenCl elseCl)
 
 pattern PatHsWrap :: HsWrapper -> HsExpr GhcTc -> HsExpr GhcTc
-pattern PatHsWrap wrapper expr <- (XExpr (WrapExpr (HsWrap wrapper expr))) 
+pattern PatHsWrap wrapper expr = (XExpr (WrapExpr (HsWrap wrapper expr))) 
 
 pattern PatHsExpansion :: HsExpr GhcRn -> HsExpr GhcTc -> HsExpr GhcTc
 pattern PatHsExpansion orig expanded <- (XExpr (ExpansionExpr (HsExpanded orig expanded)))
@@ -38,7 +38,8 @@ pattern PatHsIf :: LHsExpr (GhcPass p) -> LHsExpr (GhcPass p) -> LHsExpr (GhcPas
 pattern PatHsIf pred thenCl elseCl <- (HsIf _ _ pred thenCl elseCl)
 
 pattern PatHsWrap :: HsWrapper -> HsExpr (GhcPass p) -> HsExpr (GhcPass p)
-pattern PatHsWrap wrapper expr <- (HsWrap _ wrapper expr)
+pattern PatHsWrap wrapper expr <- (HsWrap _ wrapper expr) where
+        PatHsWrap wrapper expr = (HsWrap NoExtField wrapper expr)
 
 pattern PatExplicitList :: XExplicitList (GhcPass p) -> [LHsExpr (GhcPass p)] -> HsExpr (GhcPass p)
 pattern PatExplicitList typ arg <- (ExplicitList typ _ arg) where


### PR DESCRIPTION
_**Changes:**_
* Fix function level exception not working for Function Rule
* Fix infinite recursion being detected for top level function being called in `where` clause
* Fix infinite recursion being detected for partial function being called inside `fmap` or any other higher order function
* Handle infinite recursion of `LambdaCase` & `Lambda` functions for partial functions
* Add/modify test cases to check above cases
* Refactor partial function infinite recursion detection code for better reusability

Test Cases: [Infinite Recursion Test Cases](sheriff/test/SubTests/InfiniteRecursionTest.hs)
Test cases result:
<img width="619" alt="image" src="https://github.com/user-attachments/assets/d6c5b959-cca5-490b-81f8-48f9aef15c21">
