### PR TITLE
Added key lookup tracker plugin support

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -7,3 +7,4 @@ packages:
   ./dc
   ./endpoints
   ./warner
+  ./keyLookupTracker

--- a/keyLookupTracker/.gitignore
+++ b/keyLookupTracker/.gitignore
@@ -1,0 +1,7 @@
+dist-*
+result
+test/dumps
+test/out*
+cabal.project.local
+.juspay/tmp*
+.tmp*

--- a/keyLookupTracker/CHANGELOG.md
+++ b/keyLookupTracker/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for code-checker
+
+## 0.1.0.0 -- 2024-12-30
+
+* First version. Tracks key lookups in HashMaps.

--- a/keyLookupTracker/DOC.md
+++ b/keyLookupTracker/DOC.md
@@ -1,0 +1,5 @@
+### lookupFinder plugin
+
+#### What it does?
+
+The `keyLookupTracker` plugin is designed to analyze, track, and log keys accessed through lookup functions (e.g., HM.lookup) in HashMaps within Haskell codebases

--- a/keyLookupTracker/LICENSE
+++ b/keyLookupTracker/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2024 Juspay
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/keyLookupTracker/README.MD
+++ b/keyLookupTracker/README.MD
@@ -1,0 +1,14 @@
+
+# Haskell Code Checker Plugin - Sheriff
+
+## Overview
+
+The `keyLookupTracker` plugin is designed to analyze, track, and log keys accessed through lookup functions (e.g., HM.lookup) in HashMaps within Haskell codebases
+
+## Usage
+
+Add this to your ghc-options in cabal and mention `keyLookupTracker` in build-depends
+
+```
+-fplugin=keyLookupTracker.Plugin
+```

--- a/keyLookupTracker/lookupFinder.cabal
+++ b/keyLookupTracker/lookupFinder.cabal
@@ -1,0 +1,94 @@
+cabal-version:      3.0
+name:               keyLookupTracker
+version:            0.1.0.0
+synopsis:           A type checker plugin to Tracks key lookups.
+license:            MIT
+license-file:       LICENSE
+author:             harshith.ak-juspay
+maintainer:         harshith.ak@juspay.in
+category:           Development
+build-type:         Simple
+extra-doc-files:    CHANGELOG.md
+
+Flag Dev
+  Description: Use ghc options to dump ASTs in dev mode
+  Default:     True
+  Manual:      True
+
+common common-options
+  build-depends:       base
+  ghc-options:         -Wall
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wincomplete-patterns
+                       -Wcompat
+                       -Widentities
+                       -Wredundant-constraints
+                       -fhide-source-paths
+
+  default-language:    Haskell2010
+  default-extensions:  DeriveGeneric
+                       GeneralizedNewtypeDeriving
+                       InstanceSigs
+                       LambdaCase
+                       OverloadedStrings
+                       RecordWildCards
+                       ScopedTypeVariables
+                       StandaloneDeriving
+                       TypeApplications
+                       CPP
+
+library
+    import:              common-options
+    exposed-modules:    
+        KeyLookupTracker.Plugin
+    other-modules:
+    build-depends:
+                bytestring
+                , containers
+                , filepath
+                , ghc
+                , ghc-exactprint
+                , unordered-containers
+                , uniplate
+                , references
+                , classyplate
+                , aeson
+                , directory
+                , extra
+                , yaml
+                , text
+                , aeson-pretty
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite keyLookupTracker-test
+    import:           common-options
+
+    default-language: Haskell2010
+    type:             exitcode-stdio-1.0
+
+    hs-source-dirs:   test
+
+    main-is:          Main.hs
+    other-modules:
+
+    build-depends:
+        , keyLookupTracker
+        , aeson
+        , text
+        , containers
+        , bytestring
+        , aeson-pretty
+        , extra
+        , record-dot-preprocessor
+        , record-hasfield
+        , lens >= 4.0
+        , unordered-containers
+    if flag(Dev)
+        ghc-options: 
+            -fplugin=KeyLookupTracker.Plugin 
+    else
+        ghc-options: 
+    
+    default-extensions: DataKinds

--- a/keyLookupTracker/src/KeyLookupTracker/Plugin.hs
+++ b/keyLookupTracker/src/KeyLookupTracker/Plugin.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+module KeyLookupTracker.Plugin (plugin) where
+
+-- GHC imports
+
+import Control.Reference (biplateRef, (^?))
+import Data.Aeson as A
+import Data.List (nub, isInfixOf)
+import GHC hiding (exprType)
+import Prelude hiding (id)
+import Data.Generics.Uniplate.Data
+import qualified Data.ByteString as DBS
+import Data.List.Extra (intercalate, splitOn)
+import System.Directory (createDirectoryIfMissing)
+import Data.ByteString.Lazy (toStrict)
+
+#if __GLASGOW_HASKELL__ >= 900
+import GHC.Data.Bag
+import GHC.Plugins hiding ((<>), getHscEnv, purePlugin)
+import GHC.Tc.Types
+#else
+import Bag
+import ConLike
+import DsExpr
+import DsMonad
+import GhcPlugins hiding ((<>), getHscEnv, purePlugin)
+import TcEvidence
+import TcRnMonad
+import TcRnTypes
+import TcType
+import TyCoRep
+#endif
+
+plugin :: Plugin
+plugin = defaultPlugin {
+      typeCheckResultAction = keyLookupTracker
+    , pluginRecompile       = purePlugin
+    }
+
+purePlugin :: [CommandLineOption] -> IO PluginRecompile
+purePlugin _ = return NoForceRecompile
+
+keyLookupTracker :: [CommandLineOption] -> ModSummary -> TcGblEnv -> TcM TcGblEnv
+keyLookupTracker _ modSummary tcEnv = do
+  let binds = tcg_binds tcEnv
+      prefixPath = "./.juspay/lookup-finder/"
+      modulePath = prefixPath <> msHsFilePath modSummary
+      path = (intercalate "/" . init . splitOn "/") modulePath
+  liftIO $ createDirectoryIfMissing True path
+  lookupInfo <- concat <$> mapM checkBind (bagToList binds)
+  liftIO $ DBS.writeFile (modulePath <> ".json") (toStrict $ A.encode lookupInfo)
+  return tcEnv
+
+checkBind :: LHsBindLR GhcTc GhcTc -> TcM [(String, [String])]
+checkBind (L _ (FunBind{..} )) = do
+  let funMatches = unLoc $ mg_alts fun_matches
+  concat <$> mapM (checkMatch (getVarNameFromIDP $ unLoc fun_id)) funMatches
+checkBind (L _ (AbsBinds {abs_binds = binds})) =
+  concat <$> (mapM checkBind $ bagToList binds)
+checkBind _ = pure []
+
+checkMatch :: String -> LMatch GhcTc (LHsExpr GhcTc) -> TcM [(String, [String])]
+checkMatch coreFn (L _ (Match _ _ _ grhss)) = do
+  let whereBinds = (grhssLocalBinds grhss) ^? biplateRef :: [HsExpr GhcTc]
+      nonWhereBinds = (grhssGRHSs grhss) ^? biplateRef :: [HsExpr GhcTc]
+  list <- nub <$> concat <$> mapM loopOverExpr (nonWhereBinds <> whereBinds)
+  pure [(coreFn ,list)]
+
+loopOverExpr :: HsExpr GhcTc -> TcM [String]
+loopOverExpr expr =
+  pure $ if "lookup" `isInfixOf` (showS expr)
+    then
+      case expr of
+        (HsApp _ a (L _ (HsOverLit _ (OverLit _ _ (HsApp _ _ (L _ (HsLit _ lit))))))) -> [showS lit]
+        _ -> []
+    else []
+
+getVarNameFromIDP :: IdP GhcTc -> String
+getVarNameFromIDP var = occNameString . occName $ var
+
+showS :: (Outputable a) => a -> String
+showS = showSDocUnsafe . ppr

--- a/keyLookupTracker/test/Main.hs
+++ b/keyLookupTracker/test/Main.hs
@@ -1,0 +1,30 @@
+-- {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE OverloadedStrings #-}
+-- {-# OPTIONS_GHC -ddump-tc-ast #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Main (main) where
+
+import Data.Text as T
+import Prelude
+import qualified Data.HashMap.Strict as HM
+
+main :: IO ()
+main = putStrLn "Test suite not yet implemented."
+
+getLookupFlows :: Maybe Text
+getLookupFlows = 
+  let (hm :: HM.HashMap Text Text) = HM.insert "DE" "def" $  HM.insert "CD" "cde" $ HM.insert "BC" "bcd" $ HM.insert "AB" "abc" HM.empty
+      name = HM.lookup "AB" hm
+      nameInFix = "BC" `HM.lookup` hm
+      keys = ak hm
+      key1 = Prelude.map ("CD" `HM.lookup` ) [hm]
+  in nameInFix
+
+  where
+    ak hm = (HM.lookup "DE") <$> [hm]
+


### PR DESCRIPTION
We need to analyze and track key lookups in Haskell programs.  Created new plugin which analyze and tracks the lookup key.