### PR TITLE
Adding plugin for catching ID law failures

### DIFF
--- a/api-contract/.gitignore
+++ b/api-contract/.gitignore
@@ -3,3 +3,4 @@ result
 dist-newstyle
 result
 tmp*
+.juspay

--- a/api-contract/api-contract.cabal
+++ b/api-contract/api-contract.cabal
@@ -19,6 +19,11 @@ flag enable-isolation
   default:           False
   manual:            True
 
+Flag TestMode
+  Description: Use ghc options to dump ASTs in dev mode
+  Default:     False
+  Manual:      True
+
 common warnings
     if flag(enable-isolation)
         cpp-options:     -DENABLE_ISOLATION
@@ -29,6 +34,8 @@ library
     exposed-modules:
         ApiContract.Plugin
         , ApiContract.Types
+        , ApiContract.JsonIdLaw
+        , ApiContract.JsonIdLaw.Types
     -- other-modules:
     -- other-extensions:
     build-depends:
@@ -70,6 +77,47 @@ library
     hs-source-dirs:   src
     default-language: Haskell2010
 
+common common-options
+  build-depends:       base
+  ghc-options:         -Werror
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wincomplete-patterns
+                       -Wcompat
+                       -Widentities
+                       -Wredundant-constraints
+                       -fhide-source-paths
+  default-language:    Haskell2010
+  default-extensions:  DeriveGeneric
+                       GeneralizedNewtypeDeriving
+                       InstanceSigs
+                       LambdaCase
+                       OverloadedStrings
+                       RecordWildCards
+                       ScopedTypeVariables
+                       StandaloneDeriving
+                       TypeApplications
+                       CPP
+
+common test-common-options
+    import:           common-options
+    default-language: Haskell2010
+    hs-source-dirs:   test
+    build-depends:
+          aeson
+        , text
+    if flag(TestMode)
+        ghc-options:
+            -fkeep-going
+            -fplugin=ApiContract.Plugin
+            -fplugin-opt=ApiContract.Plugin:{"path":"./.juspay/api-contract/","port":4444,"host":"::1","log":false,"tc_funcs":false,"api_contract":false,"id_law_check":true,"id_law_exceptions_path":"./.juspay/jsonIdLawExceptions.yaml"}
+            -dumpdir=.juspay/tmp/jsonIdLaw/ -ddump-to-file -ddump-parsed-ast -ddump-tc-ast
+    else
+        ghc-options: 
+            -fkeep-going
+            -fplugin=ApiContract.Plugin
+            -fplugin-opt=ApiContract.Plugin:{"path":"./.juspay/api-contract/","port":4444,"host":"::1","log":false,"tc_funcs":false,"api_contract":false,"id_law_check":true,"id_law_exceptions_path":"./.juspay/jsonIdLawExceptions.yaml"}
+
 test-suite api-contract-test
     import:           warnings
     default-language: Haskell2010
@@ -86,3 +134,17 @@ test-suite api-contract-test
         , record-hasfield
         , text
         , newtype
+
+test-suite json-id-law-test
+    import:           test-common-options
+    default-language: Haskell2010
+    hs-source-dirs:   test
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    other-modules:
+        IdLawTest.IDLawAllTestCases
+        -- , IdLawTest.BadMissingOnEncode
+    build-depends:
+        api-contract
+        , newtype
+        , vector

--- a/api-contract/src/ApiContract/JsonIdLaw.hs
+++ b/api-contract/src/ApiContract/JsonIdLaw.hs
@@ -1,0 +1,1745 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+
+module ApiContract.JsonIdLaw
+  ( collectJsonIdLaw
+  , checkJsonIdLaw
+  ) where
+
+#if __GLASGOW_HASKELL__ >= 900
+import GHC
+import GHC.Data.Bag (bagToList)
+import GHC.Core.Class (className, classMethods)
+import GHC.Core.ConLike (conLikeName)
+import GHC.Core.DataCon (dataConFieldLabels, dataConName)
+import GHC.Core.InstEnv (ClsInst(..))
+import GHC.Core.TyCo.Rep
+import GHC.Core.TyCon (tyConDataCons, isAlgTyCon, isClassTyCon, isPromotedDataCon, isTcTyCon, tyConName, TyCon)
+import GHC.Core.Type
+import GHC.Driver.Env
+import GHC.Driver.Plugins (CommandLineOption)
+import GHC.Tc.Types
+import GHC.Tc.Utils.Monad (TcM)
+import qualified GHC.Tc.Utils.Monad as TCError
+import GHC.Hs.Expr (HsWrap(..), XXExprGhcTc(..), HsExpansion(..))
+import GHC.Types.Name hiding (varName)
+import GHC.Types.Name.Reader (RdrName(..), rdrNameOcc)
+import GHC.Types.SrcLoc
+import GHC.Unit.Module.ModSummary
+import GHC.Unit.Module (moduleNameString)
+import GHC.Unit.Types
+import GHC.Utils.Outputable (Outputable(..), showSDocUnsafe, ppr, docToSDoc)
+import qualified GHC.Utils.Ppr as Pretty
+import GHC.Types.FieldLabel (flLabel)
+import GHC.Data.FastString (unpackFS, mkFastString)
+#else
+import GHC hiding (typeKind)
+import Bag (bagToList)
+import Class (className, classMethods)
+import ConLike (conLikeName)
+import DataCon (dataConFieldLabels, dataConName, tyConDataCons)
+import InstEnv (ClsInst(..))
+import TyCoRep
+import TyCon
+import Type
+import GhcPlugins hiding ((<>), varName)
+import TcRnTypes (TcGblEnv(..), TcM)
+import qualified TcRnMonad as TCError
+import Name (nameOccName, occNameString, nameModule, nameModule_maybe)
+import RdrName (RdrName(..), rdrNameOcc)
+import SrcLoc
+import Outputable (Outputable(..), showSDocUnsafe, ppr)
+import qualified Pretty
+import FieldLabel (flLabel)
+import FastString (unpackFS)
+#endif
+
+import Control.Applicative ((<|>))
+import Control.Concurrent.MVar (MVar, newMVar, readMVar, modifyMVar_)
+import Control.Monad (foldM, when, unless, guard)
+import Control.Monad.IO.Class (liftIO)
+import qualified Data.Aeson as A
+import Data.Bool (bool)
+import Data.Data (Data)
+import Data.Char (toLower)
+import Data.List (foldl', nub, sort, isInfixOf)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe, isJust, fromJust, mapMaybe, catMaybes, listToMaybe)
+import qualified Data.Set as Set
+import Data.Set (Set)
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.Text.Encoding (decodeUtf8, encodeUtf8)
+import qualified Data.ByteString.Lazy as BL
+import GHC.IO (unsafePerformIO)
+import GHC.Generics (Generic)
+import System.Environment (lookupEnv)
+import Control.Reference (biplateRef, (^?))
+import Data.Generics.Uniplate.Data ()
+import qualified Data.Yaml as YAML
+import ApiContract.JsonIdLaw.Types
+import ApiContract.Types (CliOptions(..))
+
+#if __GLASGOW_HASKELL__ >= 900
+unXRecTc :: XRec GhcTc a -> a
+unXRecTc = GHC.unXRec @GhcTc
+#else
+unXRecTc :: LHsExpr GhcTc -> HsExpr GhcTc
+unXRecTc (L _ e) = e
+#endif
+
+----------------------------------------------------------------------
+-- Shared state between the parsed and type-check phases.
+----------------------------------------------------------------------
+
+-- Per type (keyed by the head type-constructor's occNameString), the info we
+-- can only recover from the parsed AST: the options/via used by TH-derived or
+-- DerivingVia instances. Plain deriving and custom instances are detected in
+-- the type-check phase.
+data ParsedSideInfo = ParsedSideInfo
+  { psiOptsEnc  :: Maybe Text
+  , psiOptsDec  :: Maybe Text
+  , psiViaEnc   :: Maybe Text
+  , psiViaDec   :: Maybe Text
+  , psiPlainEnc :: Bool
+  , psiPlainDec :: Bool
+  , psiSpan     :: SrcSpan
+  } deriving (Show)
+
+emptyParsedSideInfo :: ParsedSideInfo
+emptyParsedSideInfo = ParsedSideInfo Nothing Nothing Nothing Nothing False False noSrcSpan
+
+-- Keyed by module file path -> (type-name -> info).
+idLawStateVar :: MVar (Map String (Map Text ParsedSideInfo))
+{-# NOINLINE idLawStateVar #-}
+idLawStateVar = unsafePerformIO (newMVar Map.empty)
+
+----------------------------------------------------------------------
+-- Phase 1 (parsed): collect TH-options / via for derived instances.
+----------------------------------------------------------------------
+
+collectJsonIdLaw :: [CommandLineOption] -> ModSummary -> HsParsedModule -> Hsc HsParsedModule
+collectJsonIdLaw opts modSummary hpm = do
+  let cliOptions = parseCli opts
+  when (idLawEnabled cliOptions) $ liftIO $ do
+    let moduleKey = msHsFilePath modSummary
+        decls = hsmodDecls (unLoc (hpm_module hpm))
+    perType <- foldM (\acc -> pure . foldParsedDecl acc) Map.empty decls
+    modifyMVar_ idLawStateVar $ pure . Map.insert moduleKey perType
+  pure hpm
+
+foldParsedDecl :: Map Text ParsedSideInfo -> LHsDecl GhcPs -> Map Text ParsedSideInfo
+#if __GLASGOW_HASKELL__ >= 900
+foldParsedDecl acc (L l decl) = case decl of
+  TyClD _ (DataDecl _ _ _ _ _) -> acc
+  DerivD _ d -> handleDerivDecl acc (locA l) d
+  SpliceD _ s -> handleSpliceDecl acc (locA l) s
+  _ -> acc
+#else
+foldParsedDecl acc (L l decl) = case decl of
+  TyClD _ (DataDecl _ _ _ _ _) -> acc
+  DerivD _ d -> handleDerivDecl acc l d
+  SpliceD _ s -> handleSpliceDecl acc l s
+  _ -> acc
+#endif
+
+handleDerivDecl :: Map Text ParsedSideInfo -> SrcSpan -> DerivDecl GhcPs -> Map Text ParsedSideInfo
+handleDerivDecl acc l (DerivDecl{deriv_type = sigTy, deriv_strategy = mStrat}) =
+  case extractClassAndType sigTy of
+    Nothing -> acc
+    Just (cls, ty) -> case (cls, mStrat) of
+      ("ToJSON", Just (L _ (ViaStrategy viaTy))) -> insertField ty (\psi -> psi{psiViaEnc = Just (pprText viaTy), psiSpan = l}) acc
+      ("FromJSON", Just (L _ (ViaStrategy viaTy))) -> insertField ty (\psi -> psi{psiViaDec = Just (pprText viaTy), psiSpan = l}) acc
+      ("ToJSON", _) -> insertField ty (\psi -> psi{psiPlainEnc = True, psiSpan = l}) acc
+      ("FromJSON", _) -> insertField ty (\psi -> psi{psiPlainDec = True, psiSpan = l}) acc
+      _ -> acc
+
+handleSpliceDecl :: Map Text ParsedSideInfo -> SrcSpan -> SpliceDecl GhcPs -> Map Text ParsedSideInfo
+handleSpliceDecl acc l (SpliceDecl _ (L _ splice) _) =
+  case spliceSpine splice of
+    Nothing -> acc
+    Just (fnName, optsStr, tyName) ->
+      let key = T.pack tyName in
+      case fnName of
+        "deriveJSON"        -> insertField key (\psi -> psi{psiOptsEnc = Just optsStr, psiOptsDec = Just optsStr, psiSpan = l}) acc
+        "deriveToJSON"      -> insertField key (\psi -> psi{psiOptsEnc = Just optsStr, psiSpan = l}) acc
+        "deriveFromJSON"    -> insertField key (\psi -> psi{psiOptsDec = Just optsStr, psiSpan = l}) acc
+        "mkToJSON"          -> insertField key (\psi -> psi{psiOptsEnc = Just optsStr, psiSpan = l}) acc
+        "mkParseJSON"       -> insertField key (\psi -> psi{psiOptsDec = Just optsStr, psiSpan = l}) acc
+        _ -> acc
+
+#if __GLASGOW_HASKELL__ >= 900
+spliceSpine :: HsSplice GhcPs -> Maybe (String, Text, String)
+spliceSpine (HsUntypedSplice _ _ _ expr) = spineOf (unLoc expr)
+spliceSpine (HsTypedSplice _ _ _ expr) = spineOf (unLoc expr)
+spliceSpine _ = Nothing
+#else
+spliceSpine :: HsSplice GhcPs -> Maybe (String, Text, String)
+spliceSpine (HsUntypedSplice _ _ expr) = spineOf (unLoc expr)
+spliceSpine (HsTypedSplice _ _ expr) = spineOf (unLoc expr)
+spliceSpine _ = Nothing
+#endif
+
+-- Flatten a left-nested @HsApp@ spine into [head, arg1, arg2, ...].
+spineOf :: HsExpr GhcPs -> Maybe (String, Text, String)
+spineOf e = case appSpine e of
+  (HsVar _ (L _ rdr) : args) ->
+    let fnName = occNameString (rdrNameOcc rdr) in
+    if fnName `elem` deriveFns
+      then case args of
+        (optsExpr : tyExpr : _) ->
+          Just (fnName, pprText optsExpr, tyNameOfExpr tyExpr)
+        _ -> Nothing
+      else Nothing
+  _ -> Nothing
+  where
+    deriveFns = ["deriveJSON","deriveToJSON","deriveFromJSON","mkToJSON","mkParseJSON"]
+    -- Extract the type name from a TH name expression, stripping module
+    -- qualifiers so the key matches occNameString-based keys elsewhere.
+    tyNameOfExpr :: HsExpr GhcPs -> String
+    tyNameOfExpr (HsVar _ (L _ rdr')) = stripQuotes (occNameString (rdrNameOcc rdr'))
+    tyNameOfExpr other = stripQuotes (T.unpack (pprText other))
+
+appSpine :: HsExpr GhcPs -> [HsExpr GhcPs]
+appSpine (HsPar _ e) = appSpine (GHC.unXRec @GhcPs e)
+appSpine (HsApp _ f a) = appSpine (GHC.unXRec @GhcPs f) ++ [GHC.unXRec @GhcPs a]
+appSpine e = [e]
+
+-- @deriv_type@ is @HsSigWcType@; its body is @HsSigType@ whose @sig_body@ is
+-- the @HsType@. For @ToJSON T@ this is @HsAppTy ToJSON T@.
+extractClassAndType :: LHsSigWcType GhcPs -> Maybe (String, Text)
+#if __GLASGOW_HASKELL__ >= 900
+extractClassAndType sigWc =
+  case unLoc (sig_body (unLoc (hswc_body sigWc))) of
+    HsAppTy _ (L _ clsTy) (L _ argTy) -> Just (rdrTyName clsTy, pprText argTy)
+    HsQualTy _ _ (L _ (HsAppTy _ (L _ clsTy) (L _ argTy))) -> Just (rdrTyName clsTy, pprText argTy)
+    _ -> Nothing
+#else
+extractClassAndType sigWc =
+  case unLoc (hsSigType (hswc_body sigWc)) of
+    HsAppTy _ (L _ clsTy) (L _ argTy) -> Just (rdrTyName clsTy, pprText argTy)
+    HsQualTy _ _ (L _ (HsAppTy _ (L _ clsTy) (L _ argTy))) -> Just (rdrTyName clsTy, pprText argTy)
+    _ -> Nothing
+#endif
+
+rdrTyName :: HsType GhcPs -> String
+rdrTyName (HsTyVar _ _ n) = occNameString . occName . unXPs $ n
+rdrTyName t = stripQuotes (T.unpack (pprText t))
+
+insertField :: Text -> (ParsedSideInfo -> ParsedSideInfo) -> Map Text ParsedSideInfo -> Map Text ParsedSideInfo
+insertField key f m = Map.alter (Just . f . fromMaybe emptyParsedSideInfo) key m
+
+----------------------------------------------------------------------
+-- Phase 2 (type-check): collect keys, classify origins, run checks.
+----------------------------------------------------------------------
+
+checkJsonIdLaw :: [CommandLineOption] -> ModSummary -> TcGblEnv -> TcM TcGblEnv
+checkJsonIdLaw opts modSummary tcg = do
+  let cliOptions = parseCli opts
+  if not (idLawEnabled cliOptions)
+    then pure tcg
+    else do
+      let moduleKey = msHsFilePath modSummary
+          moduleSrcSpan = mkFileSrcSpan (ms_location modSummary)
+      parsedMap <- liftIO $ fromMaybe Map.empty . Map.lookup moduleKey <$> readMVar idLawStateVar
+      localKeys <- liftIO $ collectLocalKeys tcg
+      tagValues <- liftIO $ collectTagValues tcg
+      altGroups <- liftIO $ collectAltGroups tcg
+      (excTypes, excModules) <- liftIO $ loadExceptions (id_law_exceptions_path cliOptions)
+      let definedHere = definedHereTyCons tcg modSummary
+          instPresence = jsonInstancePresence tcg
+          currentMod = T.pack (moduleNameString (moduleName (tcg_mod tcg)))
+          allTypes = allTypesOfInterest parsedMap localKeys definedHere instPresence
+          typesToCheck = filter (\ty ->
+            let qKey = qualifiedKey ty tcg
+            in not (qKey `Set.member` excTypes || currentMod `Set.member` excModules))
+            allTypes
+          errs = concatMap (checkType moduleSrcSpan parsedMap localKeys tagValues altGroups definedHere instPresence) typesToCheck
+          errsNub = nub errs
+      unless (null errsNub) $ TCError.addErrs (map (\(sp,e) -> (sp, docToSDoc (Pretty.text (generateJsonIdLawError e)))) errsNub)
+      pure tcg
+
+-- | Per type (keyed by head tycon occNameString): the type's source span and
+-- record-field labels, so that a 'DerivedPlain' side's keys can be taken as
+-- the field labels.
+definedHereTyCons :: TcGblEnv -> ModSummary -> Map Text (SrcSpan, [Text])
+definedHereTyCons tcg modSummary =
+  Map.fromListWith (\(s1,a) (s2,b) -> (combineSpan s1 s2, nub (a ++ b)))
+    [ (keyOfTyCon tc, (nameSrcSpan (tyConName tc), fieldLabelsOf tc))
+    | tc <- tcsOf tcg
+    , isAlgTyCon tc
+    , not (isClassTyCon tc)
+    , tcDefinedHere modSummary tc
+    ]
+  where
+    tcsOf = filter isSafeTyCon . maybe [] id . fmap (\e -> e ^? biplateRef) . Just . tcg_tcs
+    combineSpan s1 s2 | s1 /= noSrcSpan = s1
+                      | otherwise       = s2
+
+tcDefinedHere :: ModSummary -> TyCon -> Bool
+tcDefinedHere modSummary tc = nameModule_maybe (tyConName tc) == Just (ms_mod modSummary)
+
+fieldLabelsOf :: TyCon -> [Text]
+fieldLabelsOf tc = nub
+  [ T.pack (unpackFS (flLabel fl))
+  | dc <- tyConDataCons tc
+  , fl <- dataConFieldLabels dc
+  ]
+
+-- | Which of ToJSON / FromJSON are present for each type (local or imported),
+-- from the instance environment.
+jsonInstancePresence :: TcGblEnv -> Map Text (Bool, Bool)
+jsonInstancePresence tcg =
+  Map.fromListWith (\(a,b) (c,d) -> (a||c, b||d))
+    [ (tyKey, (isTo, isFrom))
+    | inst <- tcg_insts tcg
+    , let clsName = getName (is_cls inst)
+    , isAesonClassName clsName
+    , Just tyKey <- [headTypeKeyOfInst inst]
+    , let occ = occNameString (nameOccName clsName)
+          isTo = occ == "ToJSON"
+          isFrom = occ == "FromJSON"
+    ]
+
+isAesonClassName :: Name -> Bool
+isAesonClassName n =
+  occNameString (nameOccName n) `elem` ["ToJSON","FromJSON"]
+  && maybe False (T.isInfixOf "Aeson" . T.pack . moduleNameString . moduleName) (nameModule_maybe n)
+
+headTypeKeyOfInst :: ClsInst -> Maybe Text
+headTypeKeyOfInst inst = case is_tys inst of
+  [] -> Nothing
+  ts -> Just (keyOfType (last ts))
+
+----------------------------------------------------------------------
+-- Local (custom) instance key extraction from @tcg_binds@.
+----------------------------------------------------------------------
+
+-- type occNameString key -> (encSpan, encode keys, decSpan, decode keys,
+--                              encGenericOpts, decGenericOpts, delegated enc type key)
+collectLocalKeys :: TcGblEnv -> IO (Map Text (SrcSpan, [KeyInfo], SrcSpan, [KeyInfo], Maybe Text, Maybe Text, Maybe Text))
+collectLocalKeys tcg = do
+  rows <- mapM processBind (bagToList (tcg_binds tcg))
+  pure (Map.fromListWith mergeRows (concat rows))
+  where
+    currentModName = moduleNameString (moduleName (tcg_mod tcg))
+    mergeRows (es1,ek1,ds1,dk1,go1,go2,del1) (es2,ek2,ds2,dk2,go3,go4,del2) =
+      (combineSpan es1 es2, ek1++ek2, combineSpan ds1 ds2, dk1++dk2, go1 `plusOpt` go3, go2 `plusOpt` go4, del1 <|> del2)
+    combineSpan s1 s2 | s1 /= noSrcSpan = s1
+                      | otherwise       = s2
+    plusOpt Nothing x = x
+    plusOpt x _ = x
+
+    processBind :: LHsBindLR GhcTc GhcTc -> IO [(Text, (SrcSpan, [KeyInfo], SrcSpan, [KeyInfo], Maybe Text, Maybe Text, Maybe Text))]
+#if __GLASGOW_HASKELL__ >= 900
+    processBind (L l (FunBind _ id' matches _)) = methodKeys (locA l) id' matches
+    processBind (L _ (AbsBinds{abs_binds = binds})) = concat <$> mapM processBind (bagToList binds)
+#else
+    processBind (L l (FunBind _ id' matches _ _)) = methodKeys l id' matches
+    processBind (L _ (AbsBinds{abs_binds = binds})) = concat <$> mapM processBind (bagToList binds)
+#endif
+    processBind _ = pure []
+
+    methodKeys :: SrcSpan -> LIdP GhcTc -> MatchGroup GhcTc (LHsExpr GhcTc) -> IO [(Text, (SrcSpan, [KeyInfo], SrcSpan, [KeyInfo], Maybe Text, Maybe Text, Maybe Text))]
+    methodKeys l id' matches = do
+      let methodName = occNameString (nameOccName (getName (unXRecTc id')))
+          ty = idType (unXRecTc id')
+          mTyKey = case methodAppliedType methodName ty of
+                     Just t -> Just (keyOfType t)
+                     Nothing -> Nothing
+      case mTyKey of
+        Nothing -> pure []
+        Just tyKey -> do
+          let matchAlts = unLoc (mg_alts matches :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)])
+              exprs = matchAlts ^? biplateRef :: [LHsExpr GhcTc]
+              side | methodName `elem` ["toJSON","toEncoding"] = EncodeSide
+                   | methodName == "parseJSON" = DecodeSide
+                   | otherwise = EncodeSide
+              mGenOpts = detectGenericDeriving matchAlts
+          case () of
+            _ | methodName `elem` ["toJSON","toEncoding"] -> do
+                  let encKeys = nub (concat
+                                    [ walkEncKeys (Just currentModName) body
+                                    | L _ m <- matchAlts, Just body <- [matchBody m] ]
+                                      ++ concat [ whereClauseKeys (Just currentModName) m
+                                                | L _ m <- matchAlts ])
+                      bodies = [ body | L _ m <- matchAlts, Just body <- [matchBody m] ]
+                      hasDel = any hasDelegation bodies
+                      hasObj = any hasObjectConstruction bodies
+                      hasCompGen = any hasCompositionGeneric bodies
+                      nonStd = hasDel || hasObj || hasCompGen
+                      finalGenOpts = mGenOpts <|> (guard nonStd >> Just "<non-standard encoding>")
+                      mDelegatedKey = if hasDel && not hasObj && null encKeys
+                                        then findDelegatedTypeKey matchAlts
+                                        else Nothing
+                  pure [(tyKey, (l, encKeys, noSrcSpan, [], finalGenOpts, Nothing, mDelegatedKey))]
+              | methodName == "parseJSON" -> do
+                  let decKeys' = concatMap (extractKeysFromExpr (Just currentModName) side . unLoc) exprs
+                      badWhereKeys = concat
+                        [ [ ki
+                          | L _ sub <- lbs ^? biplateRef :: [LHsExpr GhcTc]
+                          , ki <- extractBadWhereKeys (Just currentModName) sub
+                          ]
+                        | L _ m <- matchAlts
+                        , let lbs = grhssLocalBinds (matchGRHSs m)
+                        ]
+                      decKeys = nub (filter (\k -> kiKey k `notElem` map kiKey badWhereKeys) decKeys')
+                      bodies = [ body | L _ m <- matchAlts, Just body <- [matchBody m] ]
+                      hasDecDel = any hasDecDelegation bodies
+                      hasCompGen = any hasCompositionGeneric bodies
+                      hasLocalCall = any (hasLocalFuncCall currentModName) (matchAlts ^? biplateRef :: [LHsExpr GhcTc])
+                      nonStdDec = hasDecDel || hasCompGen || hasLocalCall
+                      finalDecGenOpts = mGenOpts <|> (guard (nonStdDec && null decKeys) >> Just "<non-standard decoding>")
+                  pure [(tyKey, (noSrcSpan, [], l, decKeys, Nothing, finalDecGenOpts, Nothing))]
+              | otherwise -> pure []
+
+methodAppliedType :: String -> Type -> Maybe Type
+#if __GLASGOW_HASKELL__ >= 900
+methodAppliedType "toJSON"      (FunTy _ _ arg _) = Just arg
+methodAppliedType "toEncoding"  (FunTy _ _ arg _) = Just arg
+methodAppliedType "parseJSON"   (FunTy _ _ _ res) = lastTypeArg res
+#else
+methodAppliedType "toJSON"      (FunTy _ arg _) = Just arg
+methodAppliedType "toEncoding"  (FunTy _ arg _) = Just arg
+methodAppliedType "parseJSON"   (FunTy _ _ res) = lastTypeArg res
+#endif
+methodAppliedType _ _ = Nothing
+
+lastTypeArg :: Type -> Maybe Type
+lastTypeArg (TyConApp _ ts) | not (null ts) = Just (last ts)
+lastTypeArg (AppTy _ t) = Just t
+lastTypeArg _ = Nothing
+
+keyOfType :: Type -> Text
+keyOfType (TyConApp tc _) = keyOfTyCon tc
+keyOfType (AppTy t _) = keyOfType t
+keyOfType _ = ""
+
+keyOfTyCon :: TyCon -> Text
+keyOfTyCon tc = T.pack (occNameString (nameOccName (tyConName tc)))
+
+----------------------------------------------------------------------
+-- Tag-value extraction for sum-type constructor tag checks.
+----------------------------------------------------------------------
+
+-- | Per type: (encoder tag values, decoder tag values,
+--   encoder constructor→tag map, decoder catch-all constructor,
+--   encoder constructors, decoder constructors).
+type TagValueMap = Map Text (Set Text, Set Text, Map Text Text, Maybe Text, Set Text, Set Text)
+
+-- | Per type: map from decode key to set of alternative decode keys
+--   that appear together in a @<|>@ fallback expression.
+type AltGroupMap = Map Text (Map Text (Set Text))
+
+-- | Walk @tcg_binds@ to extract tag values from toJSON/parseJSON method bodies.
+-- Encoder tags: the VALUE in @"tag" .= value"@ or @String "VALUE"@.
+-- Decoder tags: string-literal patterns in @case tag of "X" -> ...; _ -> ...@.
+-- Also tracks constructor correlation: for each encoder match alternative,
+-- maps the constructor name (from the pattern) to its tag value. For the
+-- decoder, records the constructor returned by the catch-all @_@ branch
+-- (if any), so we can verify round-trip correctness.
+collectTagValues :: TcGblEnv -> IO TagValueMap
+collectTagValues tcg = do
+  rows <- mapM processBind (bagToList (tcg_binds tcg))
+  pure (Map.fromListWith mergeRows (concat rows))
+  where
+    currentModName = moduleNameString (moduleName (tcg_mod tcg))
+    mergeRows (e1,d1,c1,ca1,ec1,dc1) (e2,d2,c2,ca2,ec2,dc2) =
+      (Set.union e1 e2, Set.union d1 d2, Map.union c1 c2, ca1 <|> ca2, Set.union ec1 ec2, Set.union dc1 dc2)
+
+    processBind :: LHsBindLR GhcTc GhcTc -> IO [(Text, (Set Text, Set Text, Map Text Text, Maybe Text, Set Text, Set Text))]
+#if __GLASGOW_HASKELL__ >= 900
+    processBind (L l (FunBind _ id' matches _)) = methodTags (locA l) id' matches
+    processBind (L _ (AbsBinds{abs_binds = binds})) = concat <$> mapM processBind (bagToList binds)
+#else
+    processBind (L l (FunBind _ id' matches _ _)) = methodTags l id' matches
+    processBind (L _ (AbsBinds{abs_binds = binds})) = concat <$> mapM processBind (bagToList binds)
+#endif
+    processBind _ = pure []
+
+    methodTags :: SrcSpan -> LIdP GhcTc -> MatchGroup GhcTc (LHsExpr GhcTc) -> IO [(Text, (Set Text, Set Text, Map Text Text, Maybe Text, Set Text, Set Text))]
+    methodTags _ id' matches = do
+      let methodName = occNameString (nameOccName (getName (unXRecTc id')))
+          ty = idType (unXRecTc id')
+          mTyKey = case methodAppliedType methodName ty of
+                     Just t -> Just (keyOfType t)
+                     Nothing -> Nothing
+      case mTyKey of
+        Nothing -> pure []
+        Just tyKey -> do
+          let matchAlts = unLoc (mg_alts matches :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)])
+              exprs = matchAlts ^? biplateRef :: [LHsExpr GhcTc]
+          case () of
+            _ | methodName `elem` ["toJSON","toEncoding"] ->
+                  let (encTags, encConToTag, encCons) = collectEncTags matchAlts
+                  in pure [(tyKey, (encTags, Set.empty, encConToTag, Nothing, encCons, Set.empty))]
+              | methodName == "parseJSON" ->
+                  let (decTagsCase, mCatchAllCase) = collectDecTags exprs
+                      (decTagsMatch, mCatchAllMatch) = collectDecMatchTags matchAlts
+                      decTags = Set.union decTagsCase decTagsMatch
+                      mCatchAllCon = mCatchAllCase <|> mCatchAllMatch
+                      decCons = collectDecCons currentModName matchAlts
+                  in pure [(tyKey, (Set.empty, decTags, Map.empty, mCatchAllCon, Set.empty, decCons))]
+              | otherwise -> pure []
+
+-- | Walk @tcg_binds@ to extract @<|>@ fallback key groups from parseJSON bodies.
+-- For each type, returns a map from each decode key to the set of OTHER decode
+-- keys that appear as alternatives in a @<|>@ expression (direct or via @liftA2@).
+collectAltGroups :: TcGblEnv -> IO AltGroupMap
+collectAltGroups tcg = do
+  rows <- mapM processBind (bagToList (tcg_binds tcg))
+  pure (Map.fromListWith (Map.unionWith Set.union) (concat rows))
+  where
+    processBind :: LHsBindLR GhcTc GhcTc -> IO [(Text, Map Text (Set Text))]
+#if __GLASGOW_HASKELL__ >= 900
+    processBind (L _ (FunBind _ id' matches _)) = pure (methodAlts id' matches)
+    processBind (L _ (AbsBinds{abs_binds = binds})) = concat <$> mapM processBind (bagToList binds)
+#else
+    processBind (L _ (FunBind _ id' matches _ _)) = pure (methodAlts id' matches)
+    processBind (L _ (AbsBinds{abs_binds = binds})) = concat <$> mapM processBind (bagToList binds)
+#endif
+    processBind _ = pure []
+
+    methodAlts id' matches =
+      let methodName = occNameString (nameOccName (getName (unXRecTc id')))
+          ty = idType (unXRecTc id')
+          mTyKey = case methodAppliedType methodName ty of
+                     Just t -> Just (keyOfType t)
+                     Nothing -> Nothing
+      in case mTyKey of
+           Nothing -> []
+           Just tyKey | methodName == "parseJSON" ->
+             let matchAlts = unLoc (mg_alts matches :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)])
+                 exprs = matchAlts ^? biplateRef :: [LHsExpr GhcTc]
+                 groups = concatMap (findAltGroups . unLoc) exprs
+                 keyMap = buildAltMap groups
+             in [(tyKey, keyMap)]
+           _ -> []
+
+-- | Find @<|>@ fallback groups in an expression. Returns a list of
+--   key-groups, where each group is a list of decode keys that are
+--   alternatives for each other.
+findAltGroups :: HsExpr GhcTc -> [[Text]]
+findAltGroups e0 = go 0 (peelWrap e0)
+  where
+    go depth e
+      | depth > 10 = []
+      | otherwise = case appSpineTc e of
+      -- Chained <|>: spine has one or more <|> operators (possibly with
+      -- dictionary arguments interspersed). Collect all non-operator
+      -- elements that have decode keys.
+      sp@(h : _) | isAltOp h ->
+        let nonOps = filter (not . isAltOp) sp
+            allKeys = concatMap decodeKeysIn nonOps
+        in if length nonOps >= 2 && not (null allKeys)
+             then [allKeys]
+             else concatMap (go (depth + 1) . peelWrap) (take 2 (drop 1 nonOps))
+      -- liftA2 (<|>) e1 e2 — spine is [liftA2, <|>, e1, e2]
+      (h : altOp : a1 : a2 : _) | isLiftA2 h, isAltOp altOp ->
+        let keys1 = decodeKeysIn a1
+            keys2 = decodeKeysIn a2
+        in if not (null keys1) && not (null keys2)
+             then [keys1 ++ keys2]
+             else []
+      -- foldr1 (liftA2 (<|>)) [e1, e2, ...] or foldr1 (<|>) [e1, e2, ...]
+      -- spine is [foldr1, opStuff..., ExplicitList [...]  (with dict args)
+      (h : rest) | isFoldr1 h
+        , hasAltOpInSpine (h : rest)
+        , listExpr <- [x | x <- rest, isExplicitList x]
+        , not (null listExpr)
+        -> let allKeys = concatMap (decodeKeysIn . peelWrap) (concatMap listElements listExpr)
+           in if not (null allKeys) then [allKeys] else []
+      -- Recurse into first two args of the spine (skip head + dict args)
+      (_ : a1 : rest) -> concatMap (go (depth + 1) . peelWrap) (take 2 (a1 : rest))
+      _ -> []
+
+    isLiftA2 h = case opName h of
+      Just ("liftA2", mmod) -> maybe True (\m -> "Control.Applicative" `isInfixOf` m || "GHC.Base" `isInfixOf` m) mmod
+      _ -> False
+
+    isAltOp h = case opName h of
+      Just ("<|>", mmod) -> maybe True (\m -> any (`isInfixOf` m) ["Control.Applicative", "Control.Alternative", "GHC.Base"]) mmod
+      _ -> False
+
+    isFoldr1 h = case opName h of
+      Just ("foldr1", _) -> True
+      _ -> False
+
+    hasAltOpInSpine = any (\x -> isAltOp x || isLiftA2 x)
+
+    isExplicitList x = case peelWrap x of
+      ExplicitList _ _ -> True
+      _ -> False
+
+    listElements x = case peelWrap x of
+      ExplicitList _ xs -> map unXRecTc xs
+      _ -> []
+
+    decodeKeysIn e = extractKeys e
+      where
+        extractKeys expr =
+          let ks = [ kiKey ki | ki <- extractKeysFromExpr Nothing DecodeSide expr ]
+          in if not (null ks) then ks
+             else case peelWrap expr of
+               HsApp _ f a -> extractKeys (unXRecTc f) ++ extractKeys (unXRecTc a)
+               HsPar _ p -> extractKeys (unXRecTc p)
+               _ -> []
+
+-- | Build a map from each key to the set of its alternative keys.
+buildAltMap :: [[Text]] -> Map Text (Set Text)
+buildAltMap groups =
+  Map.unionsWith Set.union
+    [ Map.fromList [(k, Set.fromList (filter (/= k) ks)) | k <- ks]
+    | ks <- groups
+    ]
+
+-- | Extract tag values from @"tag" .= value"@ in a toJSON body.
+-- This is Pattern 1 (object-based encoding), searched via 'biplateRef'
+-- so it finds @"tag" .= value@ anywhere in the body, including inside
+-- @object [...]@.
+extractEncTagObjValues :: HsExpr GhcTc -> [Text]
+extractEncTagObjValues e = case appSpineTc e of
+  (h : keyArg : valArgs) | Just (occ, Just mmod) <- opName h, isAesonMod (Just mmod), occ == ".=" ->
+    case keyString keyArg of
+      Just k | k == "tag" -> case [v | Just v <- map keyString valArgs] of
+                              (v : _) -> [v]
+                              [] -> []
+      _ -> []
+  _ -> []
+
+-- | Extract tag values from @String "VALUE"@ at the top level of a
+-- toJSON match body (Pattern 2, String-based enum encoding).
+-- Only checks the match body directly (not sub-expressions) to avoid
+-- false positives on field values like @object ["version" .= String "v1"]@.
+extractEncTagStrValues :: HsExpr GhcTc -> [Text]
+extractEncTagStrValues e = case appSpineTc e of
+  (h : args) | Just (occ, mmod) <- conLikeOpName h, occ == "String", isAesonMod' mmod ->
+    case [v | Just v <- map keyString args] of
+      (v : _) -> [v]
+      [] -> []
+  _ -> []
+
+-- | Like 'opName' but for 'HsConLikeOut' (data constructor applications
+-- after typechecking). Returns (occNameString, moduleString) of the
+-- constructor.
+conLikeOpName :: HsExpr GhcTc -> Maybe (String, Maybe String)
+conLikeOpName e0 = case peelWrap e0 of
+  HsConLikeOut _ cl -> Just (occNameString (nameOccName (conLikeName cl)), moduleNameString . moduleName <$> nameModule_maybe (conLikeName cl))
+  _ -> Nothing
+
+-- | Extract tag values from a pattern (string-literal patterns only).
+patTag :: Pat GhcTc -> [Text]
+#if __GLASGOW_HASKELL__ >= 900
+patTag (NPat _ (L _ ol) _ _) = case ol of
+  OverLit{ol_val = HsIsString _ fs} -> [T.pack (unpackFS fs)]
+  _ -> []
+patTag (LitPat _ (HsString _ fs)) = [T.pack (unpackFS fs)]
+#else
+patTag (NPat _ (L _ ol) _ _) = case ol of
+  OverLit{ol_val = HsIsString _ fs} -> [T.pack (unpackFS fs)]
+  _ -> []
+patTag (LitPat _ (HsString _ fs)) = [T.pack (unpackFS fs)]
+#endif
+patTag _ = []
+
+-- | Extract the constructor name from a 'ConPat' pattern (typechecked AST).
+-- Peels through 'ParPat' (parenthesized patterns). Returns 'Nothing' for
+-- non-constructor patterns (wildcards, variables, etc.).
+patConName :: Pat GhcTc -> Maybe Text
+#if __GLASGOW_HASKELL__ >= 900
+patConName (ParPat _ p) = patConName (unXRecTc p)
+patConName (ConPat _ lcon _) = Just (T.pack (occNameString (nameOccName (conLikeName (unLoc lcon)))))
+#else
+patConName (ParPat _ p) = patConName (unLoc p)
+patConName (ConPatOut _ lcon _ _ _ _ _) = Just (T.pack (occNameString (nameOccName (conLikeName (unLoc lcon)))))
+#endif
+patConName _ = Nothing
+
+-- | Check whether a pattern is a wildcard ('WildPat').
+-- Peels through 'ParPat' for robustness.
+isWildPat :: Pat GhcTc -> Bool
+#if __GLASGOW_HASKELL__ >= 900
+isWildPat (ParPat _ p) = isWildPat (unXRecTc p)
+#else
+isWildPat (ParPat _ p) = isWildPat (unLoc p)
+#endif
+isWildPat (WildPat _) = True
+isWildPat _ = False
+
+-- | Find the first data-constructor name in an expression (via
+-- 'HsConLikeOut').  Uses 'appSpineTc' (not @biplateRef@) because
+-- @WrapExpr@ is opaque to Uniplate after typechecking.
+-- Returns 'Nothing' when the RHS is @fail ...@ or otherwise contains
+-- no constructor application.
+rhsConName :: HsExpr GhcTc -> Maybe Text
+rhsConName e = listToMaybe
+  [ T.pack occ
+  | h <- appSpineTc e
+  , Just (occ, _) <- [conLikeOpName h]
+  ]
+
+-- | Get the body expression of a 'Match' (first GRHS, unguarded).
+matchBody :: Match GhcTc (LHsExpr GhcTc) -> Maybe (HsExpr GhcTc)
+#if __GLASGOW_HASKELL__ >= 900
+matchBody (Match _ _ _ grhss) =
+#else
+matchBody (Match _ _ grhss) =
+#endif
+  case grhssGRHSs grhss of
+    (L _ (GRHS _ _ body) : _) -> Just (unLoc body)
+    [] -> Nothing
+
+-- | Like 'matchBody' but returns the located expression (for biplateRef).
+matchBodyL :: Match GhcTc (LHsExpr GhcTc) -> Maybe (LHsExpr GhcTc)
+#if __GLASGOW_HASKELL__ >= 900
+matchBodyL (Match _ _ _ grhss) =
+#else
+matchBodyL (Match _ _ grhss) =
+#endif
+  case grhssGRHSs grhss of
+    (L _ (GRHS _ _ body) : _) -> Just body
+    [] -> Nothing
+
+-- | Walk an encoder body expression collecting JSON keys.
+-- Descends into lambdas (to catch conditional keys like
+-- @maybe [] (\fee -> ["flat_fee" .= fee]) val@), but when inside a lambda,
+-- does NOT descend into 'ExplicitList' (to avoid false positives from
+-- sub-object keys in @map (\(k,v) -> object ["key" .= ...])@).
+walkEncKeys :: Maybe String -> HsExpr GhcTc -> [KeyInfo]
+walkEncKeys mCurrentMod e0 = go False e0
+  where
+    go inLambda e =
+      extractKeysFromExpr mCurrentMod EncodeSide e
+      ++ case peelWrap e of
+           HsLam _ mg ->
+             let alts = unLoc (mg_alts mg :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)])
+             in concat [ go True body | L _ m <- alts, Just body <- [matchBody m] ]
+           HsApp _ f a -> if inLambda then [] else go False (unXRecTc f) ++ go False (unXRecTc a)
+           HsPar _ p -> go inLambda (unXRecTc p)
+#if __GLASGOW_HASKELL__ >= 900
+           ExplicitList _ xs -> if inLambda
+                                  then concatMap (extractKeysFromExpr mCurrentMod EncodeSide . unXRecTc) xs
+                                  else concatMap (go False . unXRecTc) xs
+           HsIf _ a b c -> go False (unXRecTc a) ++ go False (unXRecTc b) ++ go False (unXRecTc c)
+           HsDo _ _ stmts -> if inLambda then [] else concatMap (stmtKeys . unXRecTc) (unXRecTc stmts)
+#else
+           ExplicitList _ xs -> if inLambda
+                                  then concatMap (extractKeysFromExpr mCurrentMod EncodeSide . unLoc) xs
+                                  else concatMap (go False . unLoc) xs
+           HsIf _ a b c -> go False (unLoc a) ++ go False (unLoc b) ++ maybe [] (go False . unLoc) c
+           HsDo _ stmts -> if inLambda then [] else concatMap (stmtKeys . unLoc) stmts
+#endif
+           HsCase _ _ mg ->
+             let alts = unLoc (mg_alts mg :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)])
+             in concat [ go inLambda body | L _ m <- alts, Just body <- [matchBody m] ]
+           _ -> []
+
+    stmtKeys (BodyStmt _ e _ _) = go False (unXRecTc e)
+    stmtKeys _ = []
+
+-- | Walk a decoder body expression collecting JSON keys.
+-- Similar to 'walkEncKeys' but for 'DecodeSide': descends into
+-- lambdas, do-blocks (including 'BindStmt'), case alternatives,
+-- and if-then-else.  Does NOT descend into @where@-clause helpers
+-- (those are local definitions, not part of the match body).
+walkDecKeys :: Maybe String -> HsExpr GhcTc -> [KeyInfo]
+walkDecKeys mCurrentMod e0 = go e0
+  where
+    go e =
+      extractKeysFromExpr mCurrentMod DecodeSide e
+      ++ case peelWrap e of
+           HsLam _ mg ->
+             let alts = unLoc (mg_alts mg :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)])
+             in concat [ go body | L _ m <- alts, Just body <- [matchBody m] ]
+           HsApp _ f a -> go (unXRecTc f) ++ go (unXRecTc a)
+           HsPar _ p -> go (unXRecTc p)
+           OpApp _ a _ b -> go (unXRecTc a) ++ go (unXRecTc b)
+           HsLet _ _ body -> go (unXRecTc body)
+#if __GLASGOW_HASKELL__ >= 900
+           HsIf _ a b c -> go (unXRecTc a) ++ go (unXRecTc b) ++ go (unXRecTc c)
+           HsDo _ _ stmts -> concatMap (stmtKeys . unXRecTc) (unXRecTc stmts)
+#else
+           HsIf _ a b c -> go (unLoc a) ++ go (unLoc b) ++ maybe [] (go . unLoc) c
+           HsDo _ stmts -> concatMap (stmtKeys . unLoc) stmts
+#endif
+           HsCase _ _ mg ->
+             let alts = unLoc (mg_alts mg :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)])
+             in concat [ go body | L _ m <- alts, Just body <- [matchBody m] ]
+           _ -> []
+    stmtKeys (BodyStmt _ e _ _) = go (unXRecTc e)
+    stmtKeys (BindStmt _ _ e) = go (unXRecTc e)
+    stmtKeys _ = []
+
+-- | Extract encoder keys from @where@-clause helper functions.
+-- Helpers like @source' (Just v) = ["source" .= v]@ produce @.=@ calls
+-- with string-literal keys that are invisible to 'walkEncKeys' because
+-- they're in the @where@ binds, not the match body.
+-- Uses 'biplateRef' on the local binds to find all expressions, then
+-- calls 'extractKeysFromExpr' on each to find @.=@ calls.
+whereClauseKeys :: Maybe String -> Match GhcTc (LHsExpr GhcTc) -> [KeyInfo]
+whereClauseKeys mCurrentMod m =
+  let lbs = grhssLocalBinds (matchGRHSs m)
+  in [ k | L _ sub <- lbs ^? biplateRef :: [LHsExpr GhcTc]
+         , ki <- extractKeysFromExpr mCurrentMod EncodeSide sub
+         , let k = ki
+     ]
+
+-- | Extract decoder keys from @where@-clause helper functions.
+-- Extracts keys from Aeson operators (@.:@, @.:?@, @.:!@, @.:|@), KeyMap
+-- lookups, AND local helper calls with 2+ arguments where the first arg is a
+-- variable (e.g., @parseNonEmptyField o "key"@).  This avoids false positives
+-- like @missingFieldError "insertId"@ (single string arg, no Object).
+whereClauseDecKeys :: Maybe String -> Match GhcTc (LHsExpr GhcTc) -> [KeyInfo]
+whereClauseDecKeys mCurrentMod m =
+  let lbs = grhssLocalBinds (matchGRHSs m)
+  in [ k | L _ sub <- lbs ^? biplateRef :: [LHsExpr GhcTc]
+         , ki <- extractWhereClauseDecKeys mCurrentMod sub
+         , let k = ki
+     ]
+
+-- | Extract decoder keys from a where-clause expression.  Recognises:
+-- 1. Aeson operators (@.:@, @.:?@, @.:!@, @.:|@) with string-literal keys
+-- 2. KeyMap lookups (@AKM.lookup (AK.fromText "key")@)
+-- 3. Local/same-module helper calls with 2+ args where the first arg is a
+--    variable (likely an Object), e.g. @parseNonEmptyField o "key"@
+-- 4. Cross-module helper calls with 2+ args where the second arg is a
+--    variable, e.g. @readNumberAsMoney "amount" o@
+extractWhereClauseDecKeys :: Maybe String -> HsExpr GhcTc -> [KeyInfo]
+extractWhereClauseDecKeys mCurrentMod e0 = case appSpineTc e0 of
+  (h : args) | Just (occ, mmod) <- opName h, occ == "lookup", isAesonMod mmod ->
+    case [k | Just k <- map deepKeyString args] of
+      (k : _) -> [KeyInfo k Nothing True]
+      [] -> []
+  (h : args) | Just (occ, Just mmod) <- opName h, isAesonMod (Just mmod)
+            , occ `elem` [".:", ".:?", ".:!", ".:|"] ->
+    let strArgs = case [k | Just k <- map keyString args] of (k:_) -> [k]; [] -> []
+    in [KeyInfo k Nothing (occ `elem` [".:?",".:!",".:|"]) | k <- strArgs]
+  (h : args) | Just (_, mmod) <- opName h
+            , isLocalHelper mmod
+            , length args >= 2
+            , isVarArg (head args)
+            -> let strArgs = case [k | Just k <- map keyString args] of (k:_) -> [k]; [] -> []
+               in [KeyInfo k Nothing False | k <- strArgs]
+  (h : args) | Just (_, mmod) <- opName h
+            , not (isAesonMod mmod)
+            , not (isTextUtilMod mmod)
+            , not (isLocalHelper mmod)
+            , length args >= 2
+            , isVarArg (args !! 1)
+            -> let strArgs = case [k | Just k <- map keyString args] of (k:_) -> [k]; [] -> []
+               in [KeyInfo k Nothing False | k <- strArgs]
+  _ -> []
+  where
+    isLocalHelper Nothing = True
+    isLocalHelper (Just m) = maybe False (== m) mCurrentMod
+
+-- | Extract keys from where-clause expressions that are likely false
+-- positives: local/same-module helper calls with fewer than 2 arguments
+-- or where the first arg is not a variable.  These are things like
+-- @missingFieldError "insertId"@ (1 string arg, no Object) that are NOT
+-- JSON key reads but get picked up by 'extractKeysFromExpr'.
+extractBadWhereKeys :: Maybe String -> HsExpr GhcTc -> [KeyInfo]
+extractBadWhereKeys mCurrentMod e0 = case appSpineTc e0 of
+  (h : args) | Just (_, mmod) <- opName h
+            , isLocalHelper mmod
+            , not (length args >= 2 && isVarArg (head args))
+            -> let strArgs = case [k | Just k <- map keyString args] of (k:_) -> [k]; [] -> []
+               in [KeyInfo k Nothing False | k <- strArgs]
+  _ -> []
+  where
+    isLocalHelper Nothing = True
+    isLocalHelper (Just m) = maybe False (== m) mCurrentMod
+-- (e.g., @parseJSON obj = (JweDeserialized <$> parseJSON obj) <|> ...@).
+-- When the decoder delegates and has no @.:@/@.:?@ calls, the key set is
+-- unknown (not empty).
+hasDecDelegation :: HsExpr GhcTc -> Bool
+hasDecDelegation e = case appSpineTc e of
+  (h : _) | Just (occ, mmod) <- opName h, occ == "parseJSON", isAesonMod' mmod -> True
+  _ -> case peelWrap e of
+    HsApp _ f a -> hasDecDelegation (unXRecTc f) || hasDecDelegation (unXRecTc a)
+    HsPar _ p -> hasDecDelegation (unXRecTc p)
+    _ -> False
+
+-- | Check whether an encoder body uses non-standard JSON construction
+-- (e.g. @toJSON someValue@, @Object (insert ...)@) that produces keys
+-- the plugin cannot statically extract.  When the encoder has zero @.=@
+-- calls but uses these constructs, the key set is /unknown/ (not empty).
+--
+-- 'hasDelegation' fires for @toJSON@ applied to a variable/constructor
+-- (delegation to another type's 'ToJSON'), NOT for @toJSON@ applied to a
+-- list/tuple (value encoding that produces no keyed object).
+--
+-- 'hasObjectConstruction' fires for the @Object@ constructor from aeson.
+--
+-- Both recursively descend into 'HsLet', 'HsCase', 'HsApp', and 'HsPar'.
+hasDelegation :: HsExpr GhcTc -> Bool
+hasDelegation = hasNonStd checkDelegation
+  where
+    checkDelegation e = any check (appSpineTc e)
+      where
+        check h = case opName h of
+          Just (occ, mmod) | occ `elem` ["toJSON", "toEncoding"]
+                          , not (occ `elem` ["genericToJSON", "genericToEncoding"])
+                          , isAesonMod' mmod ->
+              case drop 1 (appSpineTc e) of
+                (arg : _) -> isDelegation arg
+                [] -> False
+          _ -> False
+    isDelegation arg = case peelWrap arg of
+      HsVar _ _ -> True
+      HsConLikeOut _ _ -> True
+      HsPar _ p -> isDelegation (unXRecTc p)
+      _ -> False
+
+hasObjectConstruction :: HsExpr GhcTc -> Bool
+hasObjectConstruction = hasNonStd checkObject
+  where
+    checkObject e = any check (appSpineTc e)
+      where
+        check h = case conLikeOpName h of
+          Just ("Object", mmod) -> isAesonMod' mmod
+          _ -> False
+
+hasNonStdJSON :: HsExpr GhcTc -> Bool
+hasNonStdJSON e = hasDelegation e || hasObjectConstruction e
+
+-- | Detect composition with a recognized generic encoding/decoding function
+-- where the OTHER side is a key-transforming function, e.g.:
+--   camelCaseToSnakeCase <<< defaultEncode
+--   snakeCaseToCamelCase >>> defaultDecode
+-- In these cases the actual JSON keys are transformed by the outer function
+-- and cannot be statically determined from the field labels alone.
+hasCompositionGeneric :: HsExpr GhcTc -> Bool
+hasCompositionGeneric e0 = case appSpineTc (peelWrap e0) of
+  (h : args) | Just (occ, _) <- opName h
+             , occ `elem` ["<<<", "."]
+             , (_ : inner : _) <- args
+             -> isGenericFn (peelWrap inner)
+  (h : args) | Just (occ, _) <- opName h
+             , occ `elem` [">>>"]
+             , (inner : _) <- args
+             -> isGenericFn (peelWrap inner)
+  _ -> False
+  where
+    isGenericFn expr = case appSpineTc expr of
+      (h' : _) | Just (occ', _) <- opName h' ->
+        occ' `elem` ["genericToJSON","genericToEncoding","genericParseJSON",
+                     "defaultEncode","defaultEncodeJSON","defaultDecode","defaultDecodeJSON",
+                     "defaultEncodeOmitNothingOpts",
+                     "genericEncode","genericDecode",
+                     "genericEncodeModel","genericDecodeModel",
+                     "genericEncodeJSON","genericDecodeJSON"]
+      _ -> False
+
+-- Shared recursive walker for the above checks.
+hasNonStd :: (HsExpr GhcTc -> Bool) -> HsExpr GhcTc -> Bool
+hasNonStd check e = check e || go (peelWrap e)
+  where
+    go expr = check expr || case peelWrap expr of
+#if __GLASGOW_HASKELL__ >= 900
+      HsLet _ lbs body -> any go (map unLoc (lbs ^? biplateRef :: [LHsExpr GhcTc])) || go (unXRecTc body)
+      HsCase _ _ mg -> any (maybe False go . matchBody)
+                          (map unLoc (unLoc (mg_alts mg :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)])))
+#else
+      HsLet _ lbs body -> any go (map unLoc (lbs ^? biplateRef :: [LHsExpr GhcTc])) || go (unLoc body)
+      HsCase _ _ mg -> any (maybe False go . matchBody)
+                          (map unLoc (unLoc (mg_alts mg)))
+#endif
+      HsApp _ f a -> go (unXRecTc f) || go (unXRecTc a)
+      HsPar _ p -> go (unXRecTc p)
+      _ -> False
+
+-- | Find the type key of the delegated type in a @toJSON <var>@ encoder body.
+-- Walks the body (including let/case) looking for @toJSON@ applied to a
+-- variable, then extracts the variable's type and converts to a type key.
+-- Returns 'Nothing' if no such delegation is found.
+findDelegatedTypeKey :: [LMatch GhcTc (LHsExpr GhcTc)] -> Maybe Text
+findDelegatedTypeKey alts = listToMaybe
+  [ delegatedKey
+  | L _ m <- matchAlts
+  , Just body <- [matchBody m]
+  , Just delegatedKey <- [findInExpr body]
+  ]
+  where
+    matchAlts = alts
+    findInExpr e = case appSpineTc e of
+      (h : args) | Just (occ, mmod) <- opName h, occ `elem` ["toJSON", "toEncoding"]
+                 , isAesonMod' mmod ->
+          case filter (not . isDict) args of
+            (arg : _) -> case peelWrap arg of
+              HsVar _ (L _ v) -> Just (keyOfType (idType v))
+              _ -> Nothing
+            [] -> Nothing
+      _ -> go (peelWrap e)
+    isDict _ = False  -- We can't easily distinguish dict args, so we try all non-head args
+
+#if __GLASGOW_HASKELL__ >= 900
+    go (HsLet _ lbs body) = case [ findInExpr sub | L _ sub <- lbs ^? biplateRef :: [LHsExpr GhcTc] ] ++ [findInExpr (unXRecTc body)] of
+                              (Just k : _) -> Just k
+                              _ -> Nothing
+    go (HsCase _ _ mg) = listToMaybe [ k | L _ m <- unLoc (mg_alts mg :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)]), Just body <- [matchBody m], Just k <- [findInExpr body] ]
+#else
+    go (HsLet _ lbs body) = case [ findInExpr sub | L _ sub <- lbs ^? biplateRef :: [LHsExpr GhcTc] ] ++ [findInExpr (unLoc body)] of
+                              (Just k : _) -> Just k
+                              _ -> Nothing
+    go (HsCase _ _ mg) = listToMaybe [ k | L _ m <- unLoc (mg_alts mg), Just body <- [matchBody m], Just k <- [findInExpr body] ]
+#endif
+    go (HsApp _ f a) = findInExpr (unXRecTc f) <|> findInExpr (unXRecTc a)
+    go (HsPar _ p) = findInExpr (unXRecTc p)
+    go _ = Nothing
+
+-- | Collect encoder tag data from toJSON match alternatives.
+-- Returns (tag values, constructor→tag map, all encoder constructors).
+-- Pattern 1 (@"tag" .= value@): searched via 'biplateRef' anywhere in body.
+-- Pattern 2 (@String "VALUE"@): only from match body directly (not sub-expressions).
+collectEncTags :: [LMatch GhcTc (LHsExpr GhcTc)] -> (Set Text, Map Text Text, Set Text)
+collectEncTags alts =
+  let conTagPairs =
+        [ (conName, tagVal)
+        | alt <- alts
+        , let m = unLoc alt
+#if __GLASGOW_HASKELL__ >= 900
+        , (Match _ _ pats _) <- [m]
+#else
+        , (Match _ pats _) <- [m]
+#endif
+        , let ps =
+#if __GLASGOW_HASKELL__ >= 900
+                  map unXRecTc pats
+#else
+                  map unLoc pats
+#endif
+        , not (null ps)
+        , Just conName <- [patConName (head ps)]
+        , tagVal <- concatMap (extractEncTagObjValues . unLoc) ([alt] ^? biplateRef :: [LHsExpr GhcTc])
+                  ++ case matchBody m of
+                       Just body -> extractEncTagStrValues body
+                       Nothing -> []
+        ]
+      encConToTag = Map.fromList conTagPairs
+      encTags = Set.fromList (Map.elems encConToTag)
+      encCons = Set.fromList
+        [ conName
+        | alt <- alts
+        , let m = unLoc alt
+#if __GLASGOW_HASKELL__ >= 900
+        , (Match _ _ pats _) <- [m]
+#else
+        , (Match _ pats _) <- [m]
+#endif
+        , let ps =
+#if __GLASGOW_HASKELL__ >= 900
+                  map unXRecTc pats
+#else
+                  map unLoc pats
+#endif
+        , not (null ps)
+        , Just conName <- [patConName (head ps)]
+        ]
+  in (encTags, encConToTag, encCons)
+
+-- | Collect decoder tag data from parseJSON body expressions.
+-- Returns (tag values, catch-all constructor name if @_ -> Constructor@).
+collectDecTags :: [LHsExpr GhcTc] -> (Set Text, Maybe Text)
+collectDecTags exprs =
+  let allAlts = concatMap (decCaseAlts . unLoc) exprs
+      decTagSet = Set.fromList (concatMap fst allAlts)
+      mCatchAll = listToMaybe [con | (_, Just con) <- allAlts]
+  in (decTagSet, mCatchAll)
+  where
+    decCaseAlts :: HsExpr GhcTc -> [([Text], Maybe Text)]
+    decCaseAlts e0 = case peelWrap e0 of
+#if __GLASGOW_HASKELL__ >= 900
+      HsCase _ _ mg -> map decAltData (map unLoc (unLoc (mg_alts mg :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)])))
+      HsLamCase _ mg -> map decAltData (map unLoc (unLoc (mg_alts mg :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)])))
+#else
+      HsCase _ _ mg -> map decAltData (map unLoc (unLoc (mg_alts mg)))
+      HsLamCase _ mg -> map decAltData (map unLoc (unLoc (mg_alts mg)))
+#endif
+      _ -> []
+
+    decAltData :: Match GhcTc (LHsExpr GhcTc) -> ([Text], Maybe Text)
+#if __GLASGOW_HASKELL__ >= 900
+    decAltData m@(Match _ _ pats _) =
+#else
+    decAltData m@(Match _ pats _) =
+#endif
+      let ps =
+#if __GLASGOW_HASKELL__ >= 900
+              map unXRecTc pats
+#else
+              map unLoc pats
+#endif
+          tags = concatMap patTag ps
+          mCatchCon = case ps of
+            (pat0 : _) | isWildPat pat0 ->
+              case matchBody m of
+                Just body -> rhsConName body
+                Nothing -> Nothing
+            _ -> Nothing
+      in (tags, mCatchCon)
+
+-- | Collect decoder tag data from parseJSON's match-level patterns.
+-- Handles direct pattern matching like @parseJSON (String "GPMF") = pure GPMF@
+-- where the string value is in the function argument pattern, not in a @case@
+-- expression inside the body.
+-- Returns (tag values, catch-all constructor name if @_ -> Constructor@).
+collectDecMatchTags :: [LMatch GhcTc (LHsExpr GhcTc)] -> (Set Text, Maybe Text)
+collectDecMatchTags alts =
+  let results = map (decMatchAltData . unLoc) alts
+      decTagSet = Set.fromList (concatMap fst results)
+      mCatchAll = listToMaybe [con | (_, Just con) <- results]
+  in (decTagSet, mCatchAll)
+  where
+    decMatchAltData :: Match GhcTc (LHsExpr GhcTc) -> ([Text], Maybe Text)
+#if __GLASGOW_HASKELL__ >= 900
+    decMatchAltData m@(Match _ _ pats _) =
+#else
+    decMatchAltData m@(Match _ pats _) =
+#endif
+      let ps =
+#if __GLASGOW_HASKELL__ >= 900
+              map unXRecTc pats
+#else
+              map unLoc pats
+#endif
+          patTags = concatMap conPatStringTag ps
+          guardTags = concatMap (grhsGuardStrings . unLoc) (grhssGRHSs (matchGRHSs m))
+          mCatchCon = case ps of
+            (pat0 : _) | isWildPat pat0 ->
+              case matchBody m of
+                Just body -> rhsConName body
+                Nothing -> Nothing
+            _ -> Nothing
+      in (patTags ++ guardTags, mCatchCon)
+
+-- | Collect decoder constructor names from parseJSON's match alternatives.
+-- Uses 'biplateRef' to find all sub-expressions, then checks each one's
+-- 'appSpineTc' head for 'HsConLikeOut' (which 'biplateRef' can't find directly
+-- because 'WrapExpr' is opaque to Uniplate, but 'appSpineTc' peels it).
+collectDecCons :: String -> [LMatch GhcTc (LHsExpr GhcTc)] -> Set Text
+collectDecCons currentModName alts =
+  let exprs = alts ^? biplateRef :: [LHsExpr GhcTc]
+      cons = Set.fromList
+        [ T.pack occ
+        | L _ sub <- exprs
+        , h <- take 1 (appSpineTc sub)
+        , Just (occ, _) <- [conLikeOpName h]
+        ]
+  in if any (hasLocalFuncCall currentModName) exprs then Set.empty else cons
+
+-- | Check if an expression is a call to a same-module function
+-- (excluding 'parseJSON' itself).  Used to detect decoder delegation
+-- to local helpers like @parsePaymentMethodInfo@.
+hasLocalFuncCall :: String -> LHsExpr GhcTc -> Bool
+hasLocalFuncCall currentModName (L _ e) = case appSpineTc e of
+  (h' : _) | Just (occ', mmod') <- opName h' ->
+    case mmod' of
+      Just m -> m == currentModName && occ' /= "parseJSON"
+      Nothing -> False
+  _ -> False
+
+-- | Extract string literals from a GRHS's guard statements.
+-- Catches strings used in guard conditions like @| map toUpper s == "INFINITY"@.
+grhsGuardStrings :: GRHS GhcTc (LHsExpr GhcTc) -> [Text]
+#if __GLASGOW_HASKELL__ >= 900
+grhsGuardStrings (GRHS _ guards _) =
+#else
+grhsGuardStrings (GRHS _ guards _) =
+#endif
+  concatMap (stmtStrings . unLoc) guards
+  where
+    stmtStrings (BodyStmt _ e _ _) = exprStrings (unXRecTc e)
+    stmtStrings _ = []
+    exprStrings e = case peelWrap e of
+      HsLit _ (HsString _ fs) -> [T.pack (unpackFS fs)]
+      HsOverLit _ OverLit{ol_val = HsIsString _ fs} -> [T.pack (unpackFS fs)]
+      HsApp _ f a -> exprStrings (unXRecTc f) ++ exprStrings (unXRecTc a)
+      HsPar _ p -> exprStrings (unXRecTc p)
+      _ -> []
+
+-- | Get the GRHSs from a Match.
+matchGRHSs :: Match GhcTc (LHsExpr GhcTc) -> GRHSs GhcTc (LHsExpr GhcTc)
+#if __GLASGOW_HASKELL__ >= 900
+matchGRHSs (Match _ _ _ grhss) = grhss
+#else
+matchGRHSs (Match _ _ grhss) = grhss
+#endif
+
+-- | Extract a string tag from a @String "VALUE"@ constructor pattern.
+-- Peels through 'ParPat'. Returns @[]@ for non-@String@ constructor patterns
+-- or when the argument is not a string literal.
+conPatStringTag :: Pat GhcTc -> [Text]
+#if __GLASGOW_HASKELL__ >= 900
+conPatStringTag (ParPat _ p) = conPatStringTag (unXRecTc p)
+conPatStringTag (ConPat _ lcon details)
+#else
+conPatStringTag (ParPat _ p) = conPatStringTag (unLoc p)
+conPatStringTag (ConPatOut _ lcon _ _ _ _ details)
+#endif
+  | Just ("String", mmod) <- conLikeInfo
+  , isAesonMod' mmod
+  = case details of
+#if __GLASGOW_HASKELL__ >= 900
+      PrefixCon _ args -> concatMap (patTag . unXRecTc) args
+      InfixCon a1 a2 -> concatMap (patTag . unXRecTc) [a1, a2]
+#else
+      PrefixCon args -> concatMap (patTag . unLoc) args
+      InfixCon a1 a2 -> concatMap (patTag . unLoc) [a1, a2]
+#endif
+      _ -> []
+  | otherwise = []
+  where
+    conLikeInfo = case
+#if __GLASGOW_HASKELL__ >= 900
+      conLikeName (unLoc lcon)
+#else
+      conLikeName (unLoc lcon)
+#endif
+      of n -> Just (occNameString (nameOccName n), moduleNameString . moduleName <$> nameModule_maybe n)
+conPatStringTag p@(NPat _ _ _ _) = patTag p
+conPatStringTag p@(LitPat _ _) = patTag p
+conPatStringTag _ = []
+
+-- Walk an expression collecting JSON keys. On the typechecked AST, aeson
+-- operators like @.=@/@.:@ are /applications/ (with dictionary arguments), so
+-- we flatten the left-nested @HsApp@ spine and take the string-literal
+-- argument as the JSON key.
+--
+-- We also handle /local helpers/ (e.g. @toE "key" val@ defined in a @where@
+-- clause): when the head of the spine is a local variable (no associated
+-- module), we collect its string-literal arguments as keys. This is generic
+-- and catches any local function that wraps @.=@/@.:@ without hard-coding
+-- specific names. Imported functions are excluded (they have modules).
+-- Top-level functions defined in the /same module/ are also treated as local
+-- helpers (their module matches @currentMod@).
+extractKeysFromExpr :: Maybe String -> Side -> HsExpr GhcTc -> [KeyInfo]
+extractKeysFromExpr mCurrentMod side e0 = case appSpineTc e0 of
+  -- Aeson KeyMap lookup: AKM.lookup (AK.fromText "key") o (decode side).
+  -- The key is inside a fromText wrapper, so we use deepKeyString.
+  (h : args) | Just (occ, mmod) <- opName h, occ == "lookup", isAesonMod mmod, side == DecodeSide ->
+    case [k | Just k <- map deepKeyString args] of
+      (k : _) -> [KeyInfo k Nothing True]
+      [] -> []
+  -- Known aeson operators: .= (encode), .:/.:?/.:!/.:| (decode)
+  (h : args) | Just (occ, Just mmod) <- opName h, isAesonMod (Just mmod) ->
+    let strArgs = case [k | Just k <- map keyString args] of (k:_) -> [k]; [] -> []
+    in if occ == ".=" && side == EncodeSide
+         then [KeyInfo k Nothing False | k <- strArgs]
+         else if occ `elem` [".:", ".:?", ".:!", ".:|"] && side == DecodeSide
+           then [KeyInfo k Nothing (occ `elem` [".:?",".:!",".:|"]) | k <- strArgs]
+           else []
+  -- Local helpers (no module) or same-module top-level functions:
+  -- collect string-literal arguments as keys.
+  -- Also recognize cross-module helper functions on the decoder side
+  -- that take a string key and an Object argument (e.g. readNumberAsMoney "amount" o).
+  (h : args) | Just (occ, mmod) <- opName h
+             , not (occ `elem` ["<>", "$", ".", "<<<", ">>>", "<|>", ">>=", ">>", "=<<", "++", ">", "<", ">=", "<=", "==", "/=", "&&", "||", "*"])
+             , isLocalHelper mmod
+               || (not (isAesonMod mmod) && not (isTextUtilMod mmod) && length args >= 2 && isVarArg (args !! 1))
+             -> let strArgs = case [k | Just k <- map keyString args] of (k:_) -> [k]; [] -> []
+                in [KeyInfo k Nothing False | k <- strArgs]
+  -- Tuple syntax in encoder: ("key", value) inside object [...]
+  [e] | side == EncodeSide, Just k <- tupleFirstKey e -> [KeyInfo k Nothing False]
+  _ -> []
+  where
+    isLocalHelper Nothing = True
+    isLocalHelper (Just m) = maybe False (== m) mCurrentMod
+
+-- | Check if an expression is a variable reference (HsVar).
+isVarArg :: HsExpr GhcTc -> Bool
+isVarArg arg = case peelWrap arg of
+  HsVar _ _ -> True
+  _ -> False
+
+-- | Check if a module is a text utility module (Data.Text, Text.Read,
+-- Data.List, etc.) whose functions' string arguments are prefixes,
+-- patterns, or delimiters — NOT JSON keys.
+isTextUtilMod :: Maybe String -> Bool
+isTextUtilMod Nothing = False
+isTextUtilMod (Just m) = any (`isInfixOf` m)
+  ["Data.Text", "Text.Read", "Data.List", "Data.Char", "Data.String", "Data.Time", "Data.Semigroup"]
+
+-- | Like 'keyString' but also unwraps @fromText "key"@ applications.
+-- Used to recognise keys passed as @AK.fromText "key"@ to 'lookup'.
+deepKeyString :: HsExpr GhcTc -> Maybe Text
+deepKeyString e = case keyString e of
+  Just k -> Just k
+  Nothing -> case appSpineTc e of
+    (h : args) | Just (occ, mmod) <- opName h
+               , occ == "fromText"
+               , isAesonMod mmod
+               , (arg : _) <- args
+               -> keyString arg
+    _ -> Nothing
+
+-- Flatten a left-nested @HsApp@ into @[head, arg1, arg2, ...]@, peeling
+-- typechecker wrappers at every step. The result elements are unwrapped
+-- @HsExpr GhcTc@ values.
+appSpineTc :: HsExpr GhcTc -> [HsExpr GhcTc]
+appSpineTc e0 = go (peelWrap e0)
+  where
+    go (HsApp _ f a) = go (peelWrap (unXRecTc f)) ++ [unXRecTc a]
+    go e = [e]
+
+-- | Peel typechecker wrappers (@HsWrap@) so we can pattern match the
+-- underlying expression. Representation differs between GHC 9 and 8.
+#if __GLASGOW_HASKELL__ >= 900
+peelWrap :: HsExpr GhcTc -> HsExpr GhcTc
+peelWrap (XExpr (WrapExpr (HsWrap _ e))) = peelWrap e
+peelWrap (XExpr (ExpansionExpr (HsExpanded _ e))) = peelWrap e
+peelWrap (HsPar _ e) = peelWrap (unXRecTc e)
+peelWrap (ExprWithTySig _ e _) = peelWrap (unXRecTc e)
+peelWrap e = e
+#else
+peelWrap :: HsExpr GhcTc -> HsExpr GhcTc
+peelWrap (HsWrap _ _ e) = peelWrap e
+peelWrap (ExprWithTySig _ e _) = peelWrap (unLoc e)
+peelWrap e = e
+#endif
+
+opName :: HsExpr GhcTc -> Maybe (String, Maybe String)
+opName e0 = case peelWrap e0 of
+  HsVar _ (L _ v) ->
+    let n = getName v in Just (occNameString (nameOccName n), moduleNameString . moduleName <$> nameModule_maybe n)
+  _ -> Nothing
+
+isAesonMod :: Maybe String -> Bool
+isAesonMod Nothing = True
+isAesonMod (Just m) = "Aeson" `isInfixOf` m
+
+keyString :: HsExpr GhcTc -> Maybe Text
+keyString e0 = case peelWrap e0 of
+  HsLit _ (HsString _ fs) -> Just (T.pack (unpackFS fs))
+  HsOverLit _ ol -> case ol of
+    OverLit{ol_val = HsIsString _ fs} -> Just (T.pack (unpackFS fs))
+    _ -> Nothing
+  _ -> Nothing
+
+-- | Extract the first element of a tuple expression @("key", value)@
+-- as a 'Text' key. Returns 'Nothing' if the expression is not a tuple
+-- or the first element is not a string literal.
+tupleFirstKey :: HsExpr GhcTc -> Maybe Text
+tupleFirstKey e0 = case peelWrap e0 of
+  ExplicitTuple _ args _ -> case args of
+    (Present _ e : _) -> keyString (unXRecTc e)
+    _ -> Nothing
+  _ -> Nothing
+
+-- | Detect calls to @genericToJSON@/@@genericToEncoding@/@@genericParseJSON@ in
+-- the method body and return the pretty-printed 'Options' argument (if any).
+-- Returns @Nothing@ if no generic-deriving function is called.
+-- We can't use @biplateRef@ because @WrapExpr@ (an @XXExpr@ extension) is
+-- opaque to Uniplate.  Instead, we walk the match RHSs manually.
+detectGenericDeriving :: [LMatch GhcTc (LHsExpr GhcTc)] -> Maybe Text
+detectGenericDeriving matches =
+  case [opts | m <- matches, Just opts <- [checkMatch m]] of
+    (opts : _) -> Just opts
+    []         -> Nothing
+  where
+    checkMatch :: LMatch GhcTc (LHsExpr GhcTc) -> Maybe Text
+#if __GLASGOW_HASKELL__ >= 900
+    checkMatch m = case unLoc m of
+      Match _ _ _ (GRHSs _ grhss _) -> case grhss of
+        (L _ (GRHS _ _ body) : _) -> findGenericCall (unLoc body)
+        [] -> Nothing
+      _ -> Nothing
+#else
+    checkMatch m = case unLoc m of
+      Match _ _ (GRHSs _ grhss _) -> case grhss of
+        (L _ (GRHS _ _ body) : _) -> findGenericCall (unLoc body)
+        [] -> Nothing
+      _ -> Nothing
+#endif
+
+findGenericCall :: HsExpr GhcTc -> Maybe Text
+findGenericCall e0 = go (peelWrap e0)
+  where
+    go expr = case appSpineTc expr of
+      (h : args) | Just (occ, mmod) <- opName h
+                 , occ `elem` ["genericToJSON","genericToEncoding","genericParseJSON",
+                               "defaultEncode","defaultEncodeJSON","defaultDecode","defaultDecodeJSON",
+                               "defaultEncodeOmitNothingOpts",
+                               "genericEncode","genericDecode",
+                               "genericEncodeModel","genericDecodeModel",
+                               "genericEncodeJSON","genericDecodeJSON"]
+                 , isAesonMod' mmod
+                       || occ `elem` ["defaultEncode","defaultEncodeJSON","defaultDecode","defaultDecodeJSON",
+                                     "defaultEncodeOmitNothingOpts",
+                                     "genericEncode","genericDecode",
+                                     "genericEncodeModel","genericDecodeModel",
+                                     "genericEncodeJSON","genericDecodeJSON"]
+                  -> case args of
+                       (optsExpr : _) -> Just (pprText optsExpr)
+                       [] -> Just "defaultOptions"
+      -- Handle left composition: f <<< g  (i.e. f . g)
+      -- The outer function (first arg) transforms the output of the inner;
+      -- if it's a key-transforming function (e.g. camelCaseToSnakeCase),
+      -- the actual keys are NOT the field labels.  Only the first argument
+      -- is searched, so camelCaseToSnakeCase <<< defaultEncode returns
+      -- Nothing (keys unknown), while defaultDecode <<< convertIntToStrings
+      -- still finds defaultDecode.
+      (h : args) | Just (occ, _) <- opName h
+                 , occ `elem` ["<<<", "."]
+                 , (firstArg : _) <- args
+                 -> go (peelWrap firstArg)
+      -- Handle right composition: f >>> g  (i.e. g . f)
+      -- The outer function (last arg) is the generic decoder;
+      -- the inner function (first arg) pre-processes the input.
+      -- Only the last argument is searched.
+      (h : args) | Just (occ, _) <- opName h
+                 , occ `elem` [">>>"]
+                 , not (null args)
+                 -> go (peelWrap (last args))
+      -- Handle alternative: f <|> g
+      -- Both branches parse the same type, so we pick the first branch
+      -- that yields a recognized generic function.
+      (h : args) | Just (occ, _) <- opName h
+                 , occ `elem` ["<|>"]
+                 -> listToMaybe (mapMaybe (go . peelWrap) args)
+      -- Handle ($) operator: after typechecking, @$@ is plain HsApp,
+      -- so @genericParseJSON $ opts@ becomes appSpine [($), genericParseJSON, opts].
+      -- If the second element is a recognized generic function, return the
+      -- options (third element).
+      (h : fn : optsExpr : _) | Just (occ, _) <- opName h
+                             , occ == "$"
+                             , isJust (go (peelWrap fn))
+                             -> Just (pprText optsExpr)
+      _ -> case peelWrap expr of
+             HsCase _ _ mg ->
+               case mapMaybe (\m -> case matchBody (unLoc m) of Just body -> go (peelWrap body); Nothing -> Nothing)
+                             (unLoc (mg_alts mg :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)])) of
+                 (opts : _) -> Just opts
+                 [] -> Nothing
+             OpApp _ f _ a ->
+               case go (peelWrap (unXRecTc f)) of
+                 Just _ -> Just (pprText a)
+                 Nothing -> go (peelWrap (unXRecTc a))
+             _ -> Nothing
+
+isAesonMod' :: Maybe String -> Bool
+isAesonMod' Nothing = False
+isAesonMod' (Just m) = "Aeson" `isInfixOf` m
+
+----------------------------------------------------------------------
+-- | When the encoder delegates via @toJSON <var>@, look up the delegated
+-- type's encoder keys in @localKeys@.  Returns @Just keys@ if the delegated
+-- type's @toJSON@ is also defined in the same module (and has extractable
+-- keys), or @Nothing@ if not found / keys are unknown.
+resolveDelegatedKeys :: Maybe Text -> Map Text (SrcSpan,[KeyInfo],SrcSpan,[KeyInfo],Maybe Text,Maybe Text,Maybe Text) -> Maybe [KeyInfo]
+resolveDelegatedKeys Nothing _ = Nothing
+resolveDelegatedKeys (Just delegatedKey) localKeys =
+  case Map.lookup delegatedKey localKeys of
+    Just (_, delEncKeys, _, _, delGenOpts, _, _)
+      | null delEncKeys -> Nothing  -- delegated type also has no keys
+      | isJust delGenOpts -> Nothing  -- delegated type is generic, keys unknown
+      | otherwise -> Just delEncKeys
+    Nothing -> Nothing
+
+-- Per-type checking.
+----------------------------------------------------------------------
+
+checkType :: SrcSpan -> Map Text ParsedSideInfo -> Map Text (SrcSpan,[KeyInfo],SrcSpan,[KeyInfo],Maybe Text,Maybe Text,Maybe Text) -> TagValueMap -> AltGroupMap -> Map Text (SrcSpan,[Text]) -> Map Text (Bool,Bool) -> Text -> [(SrcSpan, JsonIdLawError)]
+checkType moduleSpan parsedMap localKeys tagValues altGroups definedHere instPresence tyKey
+  | not definedHereNow = []
+  | not (encPresent && decPresent) = []
+  | otherwise =
+      let psi = fromMaybe emptyParsedSideInfo (Map.lookup tyKey parsedMap)
+          (encSpan, locEncKeys, decSpan, locDecKeys, mEncGenOpts, mDecGenOpts, mDelegatedKey) = fromMaybe (noSrcSpan,[],noSrcSpan,[],Nothing,Nothing,Nothing) (Map.lookup tyKey localKeys)
+          (encInInsts, decInInsts) = fromMaybe (False,False) (Map.lookup tyKey instPresence)
+          (typeSpan, fields) = fromMaybe (moduleSpan,[]) (Map.lookup tyKey definedHere)
+          -- Resolve the effective key sets per side, if computable.
+          encKeysE = resolveKeys (encSpan /= noSrcSpan) mEncGenOpts locEncKeys (psiOptsEnc psi) (psiViaEnc psi) (psiPlainEnc psi) encInInsts fields
+          -- If encoder keys are unknown due to non-standard encoding (toJSON delegation),
+          -- try to resolve keys from the delegated type's localKeys entry.
+          encKeysResolved = encKeysE <|> resolveDelegatedKeys mDelegatedKey localKeys
+          decKeysE = resolveKeys (decSpan /= noSrcSpan) mDecGenOpts locDecKeys (psiOptsDec psi) (psiViaDec psi) (psiPlainDec psi) decInInsts fields
+          keyErrs = case (encKeysResolved, decKeysE) of
+            (Just ek, Just dk) -> keyChecks tyKey ek dk
+              (effectiveSpan [encSpan, psiSpan psi, typeSpan, moduleSpan])
+              (effectiveSpan [decSpan, psiSpan psi, typeSpan, moduleSpan])
+              (Map.findWithDefault Map.empty tyKey altGroups)
+            _ -> []
+          optErrs = optionsChecks tyKey psi (effectiveSpan [psiSpan psi, moduleSpan])
+          genOptErrs = genericOptionsChecks tyKey mEncGenOpts mDecGenOpts (effectiveSpan [psiSpan psi, encSpan, decSpan, moduleSpan])
+          (encTags, decTags, encConToTag, mCatchAllCon, encCons, decCons) = fromMaybe (Set.empty, Set.empty, Map.empty, Nothing, Set.empty, Set.empty) (Map.lookup tyKey tagValues)
+          tagErrs = tagChecks tyKey encTags decTags encConToTag mCatchAllCon (effectiveSpan [encSpan, decSpan, typeSpan, moduleSpan])
+          collapseErrs = collapseChecks tyKey encTags encCons decCons (effectiveSpan [encSpan, decSpan, typeSpan, moduleSpan])
+      in keyErrs ++ optErrs ++ genOptErrs ++ tagErrs ++ collapseErrs
+  where
+    definedHereNow = Map.member tyKey definedHere
+    effectiveSpan = foldr1 (\s acc -> if s /= noSrcSpan then s else acc)
+    encPresent = let psi = fromMaybe emptyParsedSideInfo (Map.lookup tyKey parsedMap)
+                     (encSpan, locEncKeys, _, _, _, _, _) = fromMaybe (noSrcSpan,[],noSrcSpan,[],Nothing,Nothing,Nothing) (Map.lookup tyKey localKeys)
+                     (encInInsts, _) = fromMaybe (False,False) (Map.lookup tyKey instPresence)
+                 in not (null locEncKeys) || encInInsts || isJust (psiOptsEnc psi) || psiPlainEnc psi || isJust (psiViaEnc psi)
+    decPresent = let psi = fromMaybe emptyParsedSideInfo (Map.lookup tyKey parsedMap)
+                     (_, _, _, locDecKeys, _, _, _) = fromMaybe (noSrcSpan,[],noSrcSpan,[],Nothing,Nothing,Nothing) (Map.lookup tyKey localKeys)
+                     (_, decInInsts) = fromMaybe (False,False) (Map.lookup tyKey instPresence)
+                 in not (null locDecKeys) || decInInsts || isJust (psiOptsDec psi) || psiPlainDec psi || isJust (psiViaDec psi)
+
+-- Right (Just keys) if the side's keys are statically computable, Nothing if not.
+-- When @hasLocalBind@ is True the side has a locally-defined method bind; an
+-- empty key list then means /genuinely empty/ (the method uses no @.:=/@.:@
+-- operators), not /unknown/.  When @mGenOpts@ is @Just opts@ the method delegates
+-- to @genericToJSON@/@@genericParseJSON@/@defaultEncode@/@@defaultDecode@.  If the
+-- options are plain @defaultOptions@ (no @fieldLabelModifier@), the JSON keys
+-- are the raw field labels (after 'decodeFieldKey' underscore stripping) and we
+-- can use them.  Otherwise keys are unknown.
+resolveKeys :: Bool -> Maybe Text -> [KeyInfo] -> Maybe Text -> Maybe Text -> Bool -> Bool -> [Text] -> Maybe [KeyInfo]
+resolveKeys hasLocalBind mGenOpts locKeys mOpts mVia plain inInsts fields
+  | isJust mGenOpts, isDefaultOptionsText (fromJust mGenOpts), not (null locKeys), all kiOptional locKeys
+    = Just [KeyInfo (decodeFieldKey f) Nothing False | f <- fields]
+  | not (null locKeys) = Just locKeys
+  | isJust mGenOpts, isDefaultOptionsText (fromJust mGenOpts) = Just [KeyInfo (decodeFieldKey f) Nothing False | f <- fields]
+  | isJust mGenOpts = Nothing
+  | isJust mOpts = Nothing
+  | hasLocalBind = Just []
+  | isJust mVia = Nothing
+  | plain, not (null fields) = Just [KeyInfo f Nothing False | f <- fields]
+  | plain = Nothing
+  | inInsts = Nothing
+  | otherwise = Nothing
+
+-- | Replicate the @Nau.Utils.DecodeField@ underscore-stripping logic used by
+-- the Presto framework's @defaultEncode@/@defaultDecode@.  Strips a leading
+-- underscore when the field is one of the special names (\"_id\", \"_type\",
+-- \"_class\", \"_data\", \"_default\") or when the character after the
+-- underscore is uppercase.  Otherwise leaves the field unchanged.
+decodeFieldKey :: Text -> Text
+decodeFieldKey s
+  | "__" `T.isPrefixOf` s = s  -- double underscore: not handled here
+  | s `elem` ["_id","_type","_class","_data","_default"] = T.drop 1 s
+  | Just rest <- T.stripPrefix "_" s, not (T.null rest), T.head rest `elem` ['A'..'Z'] = rest
+  | otherwise = s
+
+-- | Check if the pretty-printed options text represents plain @defaultOptions@
+-- (no record extension, no @fieldLabelModifier@).  Matches both unqualified
+-- (@defaultOptions@) and qualified (@A.defaultOptions@).
+isDefaultOptionsText :: Text -> Bool
+isDefaultOptionsText t =
+  let s = T.unpack (T.strip t)
+      base = reverse (takeWhile (/= '.') (reverse s))
+  in base == "defaultOptions"
+
+keyChecks :: Text -> [KeyInfo] -> [KeyInfo] -> SrcSpan -> SrcSpan -> Map Text (Set Text) -> [(SrcSpan, JsonIdLawError)]
+keyChecks ty enc dec encSpan decSpan altGroups =
+     [ (decSpan, KEY_ONLY_IN_DECODE ty (kiKey d))
+     | d <- dec
+     , kiKey d `notElem` map kiKey enc
+     , not (any (\alt -> alt `elem` map kiKey enc) (Set.toList (Map.findWithDefault Set.empty (kiKey d) altGroups)))
+     ]
+  ++ [ pickEncodeError ty e dec encSpan
+     | e <- enc
+     , kiKey e `notElem` map kiKey dec
+     ]
+
+pickEncodeError :: Text -> KeyInfo -> [KeyInfo] -> SrcSpan -> (SrcSpan, JsonIdLawError)
+pickEncodeError ty e dec encSpan =
+  case [ d | d <- dec, T.toLower (kiKey e) == T.toLower (kiKey d), kiKey e /= kiKey d ] of
+    (d : _) -> (encSpan, KEY_CASE_MISMATCH ty (fromMaybe (kiKey e) (kiField e)) (kiKey e) (kiKey d))
+    [] -> (encSpan, KEY_ONLY_IN_ENCODE ty (kiKey e))
+
+optionsChecks :: Text -> ParsedSideInfo -> SrcSpan -> [(SrcSpan, JsonIdLawError)]
+optionsChecks ty psi sp =
+     case (psiOptsEnc psi, psiOptsDec psi) of
+       (Just oe, Just od) | stripOmitNothingFields oe /= stripOmitNothingFields od
+         -> [(sp, OPTIONS_MISMATCH ty oe od)]
+       _ -> []
+  ++ case (psiViaEnc psi, psiViaDec psi) of
+       (Just ve, Just vd) | stripOmitNothingFields ve /= stripOmitNothingFields vd
+         -> [(sp, OPTIONS_VIA_MISMATCH ty ve vd)]
+       _ -> []
+
+-- | Remove @omitNothingFields = <bool>@ from options text so this
+-- safe-to-differ field does not cause a false options mismatch.
+-- Also normalizes whitespace, commas, braces, and @defaultOptions@ prefix
+-- to handle GHC pretty-printer line-wrapping differences.
+stripOmitNothingFields :: Text -> Text
+stripOmitNothingFields t =
+  T.unwords (T.words (T.replace "," " " (removeDefaultOpts (fixBrace stripped))))
+  where
+    flat = T.unwords (T.words t)
+    parts = T.splitOn ", " flat
+    kept = filter (not . T.isInfixOf "omitNothingFields") parts
+    stripped = T.intercalate ", " kept
+    fixBrace s
+      | "}" `T.isInfixOf` t && not ("}" `T.isSuffixOf` (T.strip s)) =
+          T.append (T.strip s) "}"
+      | otherwise = s
+    removeDefaultOpts s = T.replace "defaultOptions" "" s
+
+-- | Compare key-affecting 'Options' fields between @genericToJSON@ and
+-- @genericParseJSON@ calls. Only fields that change JSON key or tag names
+-- are compared; safe-to-differ fields like @omitNothingFields@ are ignored.
+genericOptionsChecks :: Text -> Maybe Text -> Maybe Text -> SrcSpan -> [(SrcSpan, JsonIdLawError)]
+genericOptionsChecks ty mEncOpts mDecOpts sp =
+  case (mEncOpts, mDecOpts) of
+    (Just encOpts, Just decOpts) ->
+      let encFiltered = filterKeyAffecting encOpts
+          decFiltered = filterKeyAffecting decOpts
+      in if encFiltered /= decFiltered
+          then [(sp, OPTIONS_MISMATCH ty encOpts decOpts)]
+          else []
+    _ -> []
+  where
+    -- Fields that affect JSON key/tag names and must match for round-trip safety.
+    keyAffectingFields = ["fieldLabelModifier","constructorTagModifier","allNullaryToStringTag","tagSingleConstructor","sumEncoding","unwrapUnaryRecords"]
+    -- Keep only the lines mentioning a key-affecting field, and normalize
+    -- GHC internal variable names (e.g. x_aPhB -> x_) so that the same
+    -- lambda with different internal names doesn't cause a false mismatch.
+    filterKeyAffecting opts =
+      normalizeVarNames (T.unlines (filter (\l -> any (`T.isInfixOf` l) keyAffectingFields) (T.lines (stripOmitNothingFields opts))))
+    -- Replace GHC internal variable name suffixes like _aPhB, _aPfZ with _
+    normalizeVarNames = T.pack . go . T.unpack
+      where
+        go [] = []
+        go ('_':rest@(c:_)) | c >= 'a' && c <= 'z' =
+          case dropWhile (\d -> d >= 'a' && d <= 'z' || d >= 'A' && d <= 'Z' || d >= '0' && d <= '9') rest of
+            rest' -> '_' : go rest'
+        go (c:rest) = c : go rest
+
+-- | Compare constructor tag values between encoder and decoder.
+-- Fires for any type that has tag values on the encoder side (per user's
+-- choice of option b for Question 2). Two kinds of mismatch:
+--   1. Case-insensitive match but different case (e.g. "leaf" vs "LEAF")
+--      — suppressed when the encoder tag has an exact match in the decoder
+--      (the case-variant is just an extra accepted spelling).
+--   2. Encoder tag with no match at all in decoder (e.g. "RightCtor" missing)
+--      — suppressed when the decoder catch-all @_@ returns the /same/
+--      constructor that the encoder used (round-trip is correct).
+tagChecks :: Text -> Set Text -> Set Text -> Map Text Text -> Maybe Text -> SrcSpan -> [(SrcSpan, JsonIdLawError)]
+tagChecks ty encTags decTags encConToTag mCatchAllCon sp
+  | Set.null encTags = []
+  | otherwise =
+      let encConForTag tag = listToMaybe [con | (con, t) <- Map.toList encConToTag, t == tag]
+          catchAllOk tag = case (encConForTag tag, mCatchAllCon) of
+            (Just encCon, Just catchCon) -> encCon == catchCon
+            _ -> False
+      in  [ (sp, TAG_VALUE_MISMATCH ty encTag decTag)
+         | encTag <- Set.toList encTags
+         , not (encTag `Set.member` decTags)
+         , decTag <- Set.toList decTags
+         , T.toLower encTag == T.toLower decTag
+         , encTag /= decTag
+         ]
+      ++ [ (sp, TAG_VALUE_MISMATCH ty encTag "<not handled>")
+         | encTag <- Set.toList encTags
+         , not (any (\d -> T.toLower encTag == T.toLower d) (Set.toList decTags))
+         , not (catchAllOk encTag)
+         ]
+
+-- | Detect constructor collapse: the encoder has multiple constructors
+-- (sum type) but the decoder only produces one constructor. This catches
+-- patterns like @toJSON (WrapperA inner) = toJSON inner; toJSON (WrapperB inner) = toJSON inner@
+-- where the decoder always returns the same constructor.
+-- Only fires when there are no encoder tag values (tag checks handle tagged sum types).
+collapseChecks :: Text -> Set Text -> Set Text -> Set Text -> SrcSpan -> [(SrcSpan, JsonIdLawError)]
+collapseChecks ty encTags encCons decCons sp
+  | not (Set.null encTags) = []  -- tag checks handle tagged sum types
+  | Set.size encCons > 1 =
+      let decEncCons = Set.intersection decCons encCons
+      in if Set.size decEncCons == 1
+           then [ (sp, TAG_VALUE_MISMATCH ty encCon "<not handled>")
+                | encCon <- Set.toList encCons
+                , not (encCon `Set.member` decEncCons)
+                ]
+           else []
+  | otherwise = []
+
+----------------------------------------------------------------------
+-- The universe of types to consider.
+----------------------------------------------------------------------
+
+allTypesOfInterest :: Map Text ParsedSideInfo -> Map Text (SrcSpan,[KeyInfo],SrcSpan,[KeyInfo],Maybe Text,Maybe Text,Maybe Text) -> Map Text (SrcSpan,[Text]) -> Map Text (Bool,Bool) -> [Text]
+allTypesOfInterest parsedMap localKeys definedHere instPresence =
+  nub $ Map.keys definedHere
+     ++ Map.keys parsedMap
+     ++ Map.keys localKeys
+     ++ Map.keys instPresence
+
+----------------------------------------------------------------------
+-- Helpers.
+----------------------------------------------------------------------
+
+parseCli :: [CommandLineOption] -> CliOptions
+parseCli [] = idLawDefaultCliOptions
+parseCli (local : _) = case A.decode (BL.fromStrict (encodeUtf8 (T.pack local)) :: BL.ByteString) of
+  Just (val :: CliOptions) -> val
+  Nothing -> idLawDefaultCliOptions
+
+idLawDefaultCliOptions :: CliOptions
+idLawDefaultCliOptions = CliOptions
+  { path = "./.juspay/api-contract/"
+  , port = 4444
+  , host = "::1"
+  , log = False
+  , tc_funcs = Just False
+  , api_contract = Just True
+  , id_law_check = Just True
+  , id_law_exceptions_path = Just "./.juspay/jsonIdLawExceptions.yaml"
+  }
+
+idLawEnabled :: CliOptions -> Bool
+idLawEnabled opts = fromMaybe True (id_law_check opts) && not envDisabled
+  where
+    envDisabled = readBool (unsafePerformIO (lookupEnv "JSON_ID_LAW_CHECK"))
+    readBool (Just "false") = True
+    readBool (Just "False") = True
+    readBool (Just "FALSE") = True
+    readBool _ = False
+
+-- | YAML config for type-level exceptions.
+data ExceptionConfig = ExceptionConfig
+  { exceptions     :: Maybe [Text]   -- ^ Module-qualified type names (e.g. "Mod.Type")
+  , ignore_modules :: Maybe [Text]   -- ^ Module names to skip entirely
+  } deriving (Generic, A.FromJSON)
+
+-- | Load exception config from a YAML file. Returns (exception type set,
+-- ignore module set). On file-not-found or parse error, returns empty sets
+-- (graceful — no build failure).
+loadExceptions :: Maybe FilePath -> IO (Set Text, Set Text)
+loadExceptions mPath = do
+  let path = fromMaybe "./.juspay/jsonIdLawExceptions.yaml" mPath
+  result <- YAML.decodeFileEither path
+  pure $ case result of
+    Left _  -> (Set.empty, Set.empty)
+    Right cfg -> (Set.fromList (fromMaybe [] (exceptions cfg)), Set.fromList (fromMaybe [] (ignore_modules cfg)))
+
+-- | Build a module-qualified type key ("ModuleName.TypeName") for a type
+-- defined in the current module. Since @checkType@ already guards on
+-- @definedHereNow@, only types defined in the current module reach the
+-- filter, so the module qualifier is always the current module.
+qualifiedKey :: Text -> TcGblEnv -> Text
+qualifiedKey tyKey tcg =
+  T.pack (moduleNameString (moduleName (tcg_mod tcg))) <> "." <> tyKey
+
+pprText :: (Outputable a) => a -> Text
+pprText = T.pack . showSDocUnsafe . ppr
+
+stripQuotes :: String -> String
+stripQuotes = dropWhile (== '\'') . reverse . dropWhile (== '\'') . reverse
+
+unXPs :: LIdP GhcPs -> RdrName
+#if __GLASGOW_HASKELL__ >= 900
+unXPs = GHC.unXRec @GhcPs
+#else
+unXPs (L _ n) = n
+#endif
+
+mkFileSrcSpan :: ModLocation -> SrcSpan
+mkFileSrcSpan mod_loc = case ml_hs_file mod_loc of
+  Just fp -> mkGeneralSrcSpan (mkFastString fp)
+  Nothing -> interactiveSrcSpan
+
+isSafeTyCon :: TyCon -> Bool
+isSafeTyCon tc = not (isClassTyCon tc) && not (isPromotedDataCon tc) && not (isTcTyCon tc)

--- a/api-contract/src/ApiContract/JsonIdLaw.hs
+++ b/api-contract/src/ApiContract/JsonIdLaw.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 
 module ApiContract.JsonIdLaw
@@ -18,7 +19,7 @@ module ApiContract.JsonIdLaw
 import GHC
 import GHC.Data.Bag (bagToList)
 import GHC.Core.Class (className, classMethods)
-import GHC.Core.ConLike (conLikeName)
+import GHC.Core.ConLike (ConLike, conLikeName)
 import GHC.Core.DataCon (dataConFieldLabels, dataConName)
 import GHC.Core.InstEnv (ClsInst(..))
 import GHC.Core.TyCo.Rep
@@ -31,6 +32,7 @@ import GHC.Tc.Utils.Monad (TcM)
 import qualified GHC.Tc.Utils.Monad as TCError
 import GHC.Hs.Expr (HsWrap(..), XXExprGhcTc(..), HsExpansion(..))
 import GHC.Types.Name hiding (varName)
+import GHC.Types.Var (Var)
 import GHC.Types.Name.Reader (RdrName(..), rdrNameOcc)
 import GHC.Types.SrcLoc
 import GHC.Unit.Module.ModSummary
@@ -40,6 +42,15 @@ import GHC.Utils.Outputable (Outputable(..), showSDocUnsafe, ppr, docToSDoc)
 import qualified GHC.Utils.Ppr as Pretty
 import GHC.Types.FieldLabel (flLabel)
 import GHC.Data.FastString (unpackFS, mkFastString)
+#if __GLASGOW_HASKELL__ >= 904
+-- GHC 9.4 replaced the raw @SDoc@ error API with structured @TcRnMessage@s.
+import GHC.Tc.Errors.Types (mkTcRnUnknownMessage)
+import qualified GHC.Types.Error as ParseError
+#endif
+#if __GLASGOW_HASKELL__ >= 908
+-- GHC 9.8 made @FieldLabelString@ a newtype around @FastString@.
+import Language.Haskell.Syntax.Basic (field_label)
+#endif
 #else
 import GHC hiding (typeKind)
 import Bag (bagToList)
@@ -70,7 +81,7 @@ import qualified Data.Aeson as A
 import Data.Bool (bool)
 import Data.Data (Data)
 import Data.Char (toLower)
-import Data.List (foldl', nub, sort, isInfixOf)
+import Data.List (foldl', nub, sort, isInfixOf, isPrefixOf)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust, fromJust, mapMaybe, catMaybes, listToMaybe)
@@ -95,6 +106,61 @@ unXRecTc = GHC.unXRec @GhcTc
 #else
 unXRecTc :: LHsExpr GhcTc -> HsExpr GhcTc
 unXRecTc (L _ e) = e
+#endif
+
+----------------------------------------------------------------------
+-- Version-stable pattern synonyms bridging the post-9.2 AST changes.
+-- GHC 9.4+ dropped the `HsConLikeOut` constructor (the typechecked conlike
+-- now rides on the `ConLikeTc` extension), moved `AbsBinds` behind
+-- `XHsBindsLR`, dropped `FunBind`'s tick field, and gave the paren / let /
+-- lambda-case constructors extra token fields.  Matching through these
+-- synonyms keeps every call site below identical across compilers.
+----------------------------------------------------------------------
+
+#if __GLASGOW_HASKELL__ >= 904
+pattern HsConLikeOut :: [Var] -> ConLike -> HsExpr GhcTc
+pattern HsConLikeOut tvs con <- XExpr (ConLikeTc con tvs _)
+
+pattern PatHsPar :: LHsExpr (GhcPass p) -> HsExpr (GhcPass p)
+pattern PatHsPar e <- HsPar _ _ e _
+
+pattern PatParPat :: LPat (GhcPass p) -> Pat (GhcPass p)
+pattern PatParPat p <- ParPat _ _ p _
+
+pattern PatHsLet :: HsLocalBinds (GhcPass p) -> LHsExpr (GhcPass p) -> HsExpr (GhcPass p)
+pattern PatHsLet binds body <- HsLet _ _ binds _ body
+
+pattern PatHsLamCase :: MatchGroup (GhcPass p) (LHsExpr (GhcPass p)) -> HsExpr (GhcPass p)
+pattern PatHsLamCase mg <- HsLamCase _ _ mg
+
+pattern PatFunBind :: LIdP GhcTc -> MatchGroup GhcTc (LHsExpr GhcTc) -> HsBindLR GhcTc GhcTc
+pattern PatFunBind fid mg <- FunBind _ fid mg
+
+pattern PatAbsBinds :: LHsBinds GhcTc -> HsBindLR GhcTc GhcTc
+pattern PatAbsBinds binds <- XHsBindsLR (AbsBinds{abs_binds = binds})
+#else
+pattern PatHsPar :: LHsExpr (GhcPass p) -> HsExpr (GhcPass p)
+pattern PatHsPar e <- HsPar _ e
+
+pattern PatParPat :: LPat (GhcPass p) -> Pat (GhcPass p)
+pattern PatParPat p <- ParPat _ p
+
+pattern PatHsLet :: LHsLocalBinds (GhcPass p) -> LHsExpr (GhcPass p) -> HsExpr (GhcPass p)
+pattern PatHsLet binds body <- HsLet _ binds body
+
+pattern PatHsLamCase :: MatchGroup (GhcPass p) (LHsExpr (GhcPass p)) -> HsExpr (GhcPass p)
+pattern PatHsLamCase mg <- HsLamCase _ mg
+
+#if __GLASGOW_HASKELL__ >= 900
+-- 9.0/9.2: `fun_co_fn` is gone, `fun_tick` is not.
+pattern PatFunBind :: LIdP GhcTc -> MatchGroup GhcTc (LHsExpr GhcTc) -> HsBindLR GhcTc GhcTc
+pattern PatFunBind fid mg <- FunBind _ fid mg _
+#else
+pattern PatFunBind fid mg <- FunBind _ fid mg _ _
+#endif
+
+pattern PatAbsBinds :: LHsBinds GhcTc -> HsBindLR GhcTc GhcTc
+pattern PatAbsBinds binds <- AbsBinds{abs_binds = binds}
 #endif
 
 ----------------------------------------------------------------------
@@ -177,7 +243,14 @@ handleSpliceDecl acc l (SpliceDecl _ (L _ splice) _) =
         "mkParseJSON"       -> insertField key (\psi -> psi{psiOptsDec = Just optsStr, psiSpan = l}) acc
         _ -> acc
 
-#if __GLASGOW_HASKELL__ >= 900
+#if __GLASGOW_HASKELL__ >= 904
+-- `HsSplice` was split up after 9.2: a declaration splice now carries an
+-- `HsUntypedSplice` (typed splices became an `HsExpr` constructor and cannot
+-- appear at declaration level, so nothing is lost here).
+spliceSpine :: HsUntypedSplice GhcPs -> Maybe (String, Text, String)
+spliceSpine (HsUntypedSpliceExpr _ expr) = spineOf (unLoc expr)
+spliceSpine _ = Nothing
+#elif __GLASGOW_HASKELL__ >= 900
 spliceSpine :: HsSplice GhcPs -> Maybe (String, Text, String)
 spliceSpine (HsUntypedSplice _ _ _ expr) = spineOf (unLoc expr)
 spliceSpine (HsTypedSplice _ _ _ expr) = spineOf (unLoc expr)
@@ -210,7 +283,7 @@ spineOf e = case appSpine e of
     tyNameOfExpr other = stripQuotes (T.unpack (pprText other))
 
 appSpine :: HsExpr GhcPs -> [HsExpr GhcPs]
-appSpine (HsPar _ e) = appSpine (GHC.unXRec @GhcPs e)
+appSpine (PatHsPar e) = appSpine (GHC.unXRec @GhcPs e)
 appSpine (HsApp _ f a) = appSpine (GHC.unXRec @GhcPs f) ++ [GHC.unXRec @GhcPs a]
 appSpine e = [e]
 
@@ -265,16 +338,35 @@ checkJsonIdLaw opts modSummary tcg = do
             allTypes
           errs = concatMap (checkType moduleSrcSpan parsedMap localKeys tagValues altGroups definedHere instPresence) typesToCheck
           errsNub = nub errs
+#if __GLASGOW_HASKELL__ >= 904
+      -- `addErrs` takes structured `TcRnMessage`s from GHC 9.4 onwards.
+      unless (null errsNub) $ TCError.addErrs (map (\(sp,e) -> (sp, mkTcRnUnknownMessage (ParseError.mkPlainError ParseError.noHints (docToSDoc (Pretty.text (generateJsonIdLawError e)))))) errsNub)
+#else
       unless (null errsNub) $ TCError.addErrs (map (\(sp,e) -> (sp, docToSDoc (Pretty.text (generateJsonIdLawError e)))) errsNub)
+#endif
       pure tcg
 
 -- | Per type (keyed by head tycon occNameString): the type's source span and
 -- record-field labels, so that a 'DerivedPlain' side's keys can be taken as
 -- the field labels.
-definedHereTyCons :: TcGblEnv -> ModSummary -> Map Text (SrcSpan, [Text])
+-- | What we know about a type declared in this module.
+data TyConInfo = TyConInfo
+  { tciSpan    :: SrcSpan
+  , tciFields  :: [Text]
+  -- ^ Record field labels, across all constructors.
+  , tciNumCons :: Int
+  -- ^ Number of data constructors.  aeson only emits a constructor tag for a
+  -- single-constructor type when @tagSingleConstructors@ is set, so this decides
+  -- whether the tag-related 'Options' fields can affect any JSON key.
+  }
+
+emptyTyConInfo :: SrcSpan -> TyConInfo
+emptyTyConInfo sp = TyConInfo sp [] 0
+
+definedHereTyCons :: TcGblEnv -> ModSummary -> Map Text TyConInfo
 definedHereTyCons tcg modSummary =
-  Map.fromListWith (\(s1,a) (s2,b) -> (combineSpan s1 s2, nub (a ++ b)))
-    [ (keyOfTyCon tc, (nameSrcSpan (tyConName tc), fieldLabelsOf tc))
+  Map.fromListWith mergeInfo
+    [ (keyOfTyCon tc, TyConInfo (nameSrcSpan (tyConName tc)) (fieldLabelsOf tc) (length (tyConDataCons tc)))
     | tc <- tcsOf tcg
     , isAlgTyCon tc
     , not (isClassTyCon tc)
@@ -282,6 +374,9 @@ definedHereTyCons tcg modSummary =
     ]
   where
     tcsOf = filter isSafeTyCon . maybe [] id . fmap (\e -> e ^? biplateRef) . Just . tcg_tcs
+    mergeInfo a b = TyConInfo (combineSpan (tciSpan a) (tciSpan b))
+                              (nub (tciFields a ++ tciFields b))
+                              (max (tciNumCons a) (tciNumCons b))
     combineSpan s1 s2 | s1 /= noSrcSpan = s1
                       | otherwise       = s2
 
@@ -290,7 +385,12 @@ tcDefinedHere modSummary tc = nameModule_maybe (tyConName tc) == Just (ms_mod mo
 
 fieldLabelsOf :: TyCon -> [Text]
 fieldLabelsOf tc = nub
+#if __GLASGOW_HASKELL__ >= 908
+  -- `flLabel` yields a `FieldLabelString` newtype from GHC 9.8 onwards.
+  [ T.pack (unpackFS (field_label (flLabel fl)))
+#else
   [ T.pack (unpackFS (flLabel fl))
+#endif
   | dc <- tyConDataCons tc
   , fl <- dataConFieldLabels dc
   ]
@@ -324,6 +424,26 @@ headTypeKeyOfInst inst = case is_tys inst of
 -- Local (custom) instance key extraction from @tcg_binds@.
 ----------------------------------------------------------------------
 
+-- | Markers used in place of a pretty-printed @Options@ expression when a side
+-- builds its JSON in a way we cannot read statically.  They are not valid
+-- Haskell, so they can never collide with a real @Options@ text.
+nonStandardEncoding, nonStandardDecoding :: Text
+nonStandardEncoding = "<non-standard encoding>"
+nonStandardDecoding = "<non-standard decoding>"
+
+isUnknownOptsText :: Text -> Bool
+isUnknownOptsText t = "<non-standard" `T.isPrefixOf` t
+
+-- | Is this method body just the class default method (@$dmtoJSON@ and
+-- friends)?  GHC emits a real @FunBind@ named after the method for
+-- @deriving anyclass@ instances and for any method an instance omits, so
+-- without this test such a binding looks like a hand-written method that
+-- produces no JSON keys at all.  Returns the default method's @OccName@.
+defaultMethodOf :: HsExpr GhcTc -> Maybe String
+defaultMethodOf body = case appSpineTc body of
+  (h : _) | Just (occ, _) <- opName h, "$dm" `isPrefixOf` occ -> Just occ
+  _ -> Nothing
+
 -- type occNameString key -> (encSpan, encode keys, decSpan, decode keys,
 --                              encGenericOpts, decGenericOpts, delegated enc type key)
 collectLocalKeys :: TcGblEnv -> IO (Map Text (SrcSpan, [KeyInfo], SrcSpan, [KeyInfo], Maybe Text, Maybe Text, Maybe Text))
@@ -336,18 +456,107 @@ collectLocalKeys tcg = do
       (combineSpan es1 es2, ek1++ek2, combineSpan ds1 ds2, dk1++dk2, go1 `plusOpt` go3, go2 `plusOpt` go4, del1 <|> del2)
     combineSpan s1 s2 | s1 /= noSrcSpan = s1
                       | otherwise       = s2
+    -- A type can contribute several rows (e.g. @toJSON@ and @toEncoding@).  An
+    -- "unknown keys" marker must win over a concrete @Options@ text regardless of
+    -- the order the binds happen to come out of the bag, or the verdict would
+    -- depend on @tcg_binds@ ordering.
     plusOpt Nothing x = x
-    plusOpt x _ = x
+    plusOpt x Nothing = x
+    plusOpt x@(Just a) y@(Just b)
+      | isUnknownOptsText a = x
+      | isUnknownOptsText b = y
+      | otherwise           = x
 
     processBind :: LHsBindLR GhcTc GhcTc -> IO [(Text, (SrcSpan, [KeyInfo], SrcSpan, [KeyInfo], Maybe Text, Maybe Text, Maybe Text))]
 #if __GLASGOW_HASKELL__ >= 900
-    processBind (L l (FunBind _ id' matches _)) = methodKeys (locA l) id' matches
-    processBind (L _ (AbsBinds{abs_binds = binds})) = concat <$> mapM processBind (bagToList binds)
+    processBind (L l (PatFunBind id' matches)) = methodKeys (locA l) id' matches
+    processBind (L _ (PatAbsBinds binds)) = concat <$> mapM processBind (bagToList binds)
 #else
-    processBind (L l (FunBind _ id' matches _ _)) = methodKeys l id' matches
-    processBind (L _ (AbsBinds{abs_binds = binds})) = concat <$> mapM processBind (bagToList binds)
+    processBind (L l (PatFunBind id' matches)) = methodKeys l id' matches
+    processBind (L _ (PatAbsBinds binds)) = concat <$> mapM processBind (bagToList binds)
 #endif
     processBind _ = pure []
+
+    -- Every top-level function in this module, so that a @toJSON@/@parseJSON@
+    -- that delegates to one can be followed into it.  The JSON methods
+    -- themselves are excluded: they are handled by 'methodKeys'.
+    helperBinds :: Map String (MatchGroup GhcTc (LHsExpr GhcTc))
+    helperBinds = Map.fromList (concatMap collectHelper (bagToList (tcg_binds tcg)))
+
+    collectHelper :: LHsBindLR GhcTc GhcTc -> [(String, MatchGroup GhcTc (LHsExpr GhcTc))]
+    collectHelper (L _ (PatFunBind fid mg))
+      | let occ = occNameString (nameOccName (getName (unXRecTc fid)))
+      , occ `notElem` jsonMethodNames
+      = [(occ, mg)]
+    collectHelper (L _ (PatAbsBinds binds)) = concatMap collectHelper (bagToList binds)
+    collectHelper _ = []
+
+    -- Names of same-module functions applied in these expressions -- the same
+    -- notion of "local call" that 'hasLocalFuncCall' tests for.  Record field
+    -- selectors land here too; they are harmless because they contribute no keys.
+    localCalleeNames :: [LHsExpr GhcTc] -> [String]
+    localCalleeNames es = nub
+      [ occ
+      | L _ e <- es
+      , (h : _) <- [appSpineTc e]
+      , Just (occ, Just m) <- [opName h]
+      , m == currentModName
+      , occ /= "parseJSON"
+      ]
+
+    -- The keys a same-module helper contributes, when its body can be read in
+    -- full.  'Nothing' means "not statically readable", which leaves the calling
+    -- side unknown exactly as it was before this tracing existed.  An empty key
+    -- set is also reported as unreadable: a helper we can parse but which yields
+    -- no keys (a value transformer, a dynamic @fromText k@ lookup) must not be
+    -- mistaken for a decoder that reads nothing.
+    tracedHelperKeys :: Side -> MatchGroup GhcTc (LHsExpr GhcTc) -> Maybe [KeyInfo]
+    tracedHelperKeys side mg
+      | any unreadable bodies = Nothing
+      | delegatesFurther = Nothing
+      | null keys = Nothing
+      | otherwise = Just keys
+      where
+        alts = unLoc (mg_alts mg :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)])
+        subExprs = alts ^? biplateRef :: [LHsExpr GhcTc]
+        bodies = [ b | L _ m <- alts, Just b <- [matchBody m] ]
+        keys = helperOwnKeys side mg
+        unreadable b = hasObjectConstruction b || hasCompositionGeneric b
+                    || (case side of
+                          DecodeSide -> hasDecDelegation b
+                          EncodeSide -> hasDelegation b)
+        -- Does this helper hand the JSON off to a *further* helper that carries
+        -- keys of its own?  We only follow one level, so anything deeper would
+        -- give us a partial key set, which is worse than no key set.  Callees
+        -- that carry no keys -- record field selectors, formatting utilities --
+        -- are not delegation and must not block the trace.
+        delegatesFurther =
+          any (\c -> maybe False (not . null . helperOwnKeys side) (Map.lookup c helperBinds))
+              (localCalleeNames subExprs)
+
+    -- The keys a function's own body mentions, ignoring anything it delegates to.
+    helperOwnKeys :: Side -> MatchGroup GhcTc (LHsExpr GhcTc) -> [KeyInfo]
+    helperOwnKeys side mg = nub $ case side of
+        DecodeSide -> concatMap (extractKeysFromExpr (Just currentModName) DecodeSide . unLoc) subExprs
+        EncodeSide -> concatMap (walkEncKeys (Just currentModName)) bodies
+                        ++ concat [ whereClauseKeys (Just currentModName) m | L _ m <- alts ]
+      where
+        alts = unLoc (mg_alts mg :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)])
+        subExprs = alts ^? biplateRef :: [LHsExpr GhcTc]
+        bodies = [ b | L _ m <- alts, Just b <- [matchBody m] ]
+
+    -- Follow a delegating method into the one helper that actually yields keys.
+    -- Ambiguity (two readable helpers) means we cannot tell which one produces
+    -- the JSON, so the side stays unknown.
+    tracedKeysFor :: Side -> [LHsExpr GhcTc] -> [KeyInfo]
+    tracedKeysFor side es =
+      case [ ks
+           | c <- localCalleeNames es
+           , Just mg <- [Map.lookup c helperBinds]
+           , Just ks <- [tracedHelperKeys side mg]
+           ] of
+        [ks] -> ks
+        _    -> []
 
     methodKeys :: SrcSpan -> LIdP GhcTc -> MatchGroup GhcTc (LHsExpr GhcTc) -> IO [(Text, (SrcSpan, [KeyInfo], SrcSpan, [KeyInfo], Maybe Text, Maybe Text, Maybe Text))]
     methodKeys l id' matches = do
@@ -365,19 +574,46 @@ collectLocalKeys tcg = do
                    | methodName == "parseJSON" = DecodeSide
                    | otherwise = EncodeSide
               mGenOpts = detectGenericDeriving matchAlts
+              allBodies = [ body | L _ m <- matchAlts, Just body <- [matchBody m] ]
+              defaultMethods = mapMaybe defaultMethodOf allBodies
+              -- Set only when *every* alternative is the class default method.
+              mDefaultMethod
+                | not (null allBodies)
+                , length defaultMethods == length allBodies = listToMaybe defaultMethods
+                | otherwise = Nothing
           case () of
-            _ | methodName `elem` ["toJSON","toEncoding"] -> do
-                  let encKeys = nub (concat
+            -- @deriving anyclass@, or a method the instance omitted: the keys are
+            -- whatever aeson's generic default produces, i.e. the field labels.
+            _ | Just "$dmtoJSON" <- mDefaultMethod ->
+                  pure [(tyKey, (l, [], noSrcSpan, [], Just "defaultOptions", Nothing, Nothing))]
+              | Just "$dmparseJSON" <- mDefaultMethod ->
+                  pure [(tyKey, (noSrcSpan, [], l, [], Nothing, Just "defaultOptions", Nothing))]
+              -- Any other defaulted method (@toEncoding@, @toJSONList@, ...) says
+              -- nothing about this type's keys.  A row here would claim the side
+              -- has a local binding producing zero keys -- which is how every
+              -- hand-written 'ToJSON' picks up a spurious empty encode row from
+              -- its defaulted @toEncoding@.
+              | isJust mDefaultMethod -> pure []
+              | methodName `elem` ["toJSON","toEncoding"] -> do
+                  let ownEncKeys = nub (concat
                                     [ walkEncKeys (Just currentModName) body
                                     | L _ m <- matchAlts, Just body <- [matchBody m] ]
                                       ++ concat [ whereClauseKeys (Just currentModName) m
                                                 | L _ m <- matchAlts ])
-                      bodies = [ body | L _ m <- matchAlts, Just body <- [matchBody m] ]
-                      hasDel = any hasDelegation bodies
-                      hasObj = any hasObjectConstruction bodies
-                      hasCompGen = any hasCompositionGeneric bodies
-                      nonStd = hasDel || hasObj || hasCompGen
-                      finalGenOpts = mGenOpts <|> (guard nonStd >> Just "<non-standard encoding>")
+                      -- An encoder that builds part or all of its object in a
+                      -- same-module helper (@toJSON x = mkPayload x@) has those
+                      -- keys nowhere in its own body; read them out of the
+                      -- helper when it is simple enough.
+                      encKeys = nub (ownEncKeys ++ tracedKeysFor EncodeSide exprs)
+                      hasDel = any hasDelegation allBodies
+                      hasObj = any hasObjectConstruction allBodies
+                      hasCompGen = any hasCompositionGeneric allBodies
+                      hasLocalCall = any (hasLocalFuncCall currentModName) exprs
+                      -- Without this, an encoder whose helper we could not read
+                      -- looks like an encoder that writes no keys at all, and
+                      -- every decoder key is reported as missing.
+                      nonStd = hasDel || hasObj || hasCompGen || (hasLocalCall && null encKeys)
+                      finalGenOpts = mGenOpts <|> (guard nonStd >> Just nonStandardEncoding)
                       mDelegatedKey = if hasDel && not hasObj && null encKeys
                                         then findDelegatedTypeKey matchAlts
                                         else Nothing
@@ -392,15 +628,25 @@ collectLocalKeys tcg = do
                         | L _ m <- matchAlts
                         , let lbs = grhssLocalBinds (matchGRHSs m)
                         ]
-                      decKeys = nub (filter (\k -> kiKey k `notElem` map kiKey badWhereKeys) decKeys')
-                      bodies = [ body | L _ m <- matchAlts, Just body <- [matchBody m] ]
-                      hasDecDel = any hasDecDelegation bodies
-                      hasCompGen = any hasCompositionGeneric bodies
+                      ownDecKeys = nub (filter (\k -> kiKey k `notElem` map kiKey badWhereKeys) decKeys')
+                      -- @parseJSON v = parseThing v@: some or all of the keys
+                      -- live in a helper, so merge whatever it yields.
+                      allDecKeys = nub (ownDecKeys ++ tracedKeysFor DecodeSide exprs)
+                      -- Envelope keys whose alternation has a keyless branch.
+                      altKeys = defaultedAltKeys (Just currentModName) exprs
+                      decKeys = [ k | k <- allDecKeys, not (kiKey k `Set.member` altKeys) ]
+                      hasDecDel = any hasDecDelegation allBodies
+                      hasCompGen = any hasCompositionGeneric allBodies
                       hasLocalCall = any (hasLocalFuncCall currentModName) (matchAlts ^? biplateRef :: [LHsExpr GhcTc])
                       nonStdDec = hasDecDel || hasCompGen || hasLocalCall
-                      finalDecGenOpts = mGenOpts <|> (guard (nonStdDec && null decKeys) >> Just "<non-standard decoding>")
+                      finalDecGenOpts = mGenOpts <|> (guard (nonStdDec && null decKeys) >> Just nonStandardDecoding)
                   pure [(tyKey, (noSrcSpan, [], l, decKeys, Nothing, finalDecGenOpts, Nothing))]
               | otherwise -> pure []
+
+-- | The aeson class methods this check reads.  Anything else bound at the top
+-- level of a module is an ordinary function, and therefore a potential helper.
+jsonMethodNames :: [String]
+jsonMethodNames = ["toJSON", "toEncoding", "parseJSON", "toJSONList", "parseJSONList"]
 
 methodAppliedType :: String -> Type -> Maybe Type
 #if __GLASGOW_HASKELL__ >= 900
@@ -456,13 +702,31 @@ collectTagValues tcg = do
     mergeRows (e1,d1,c1,ca1,ec1,dc1) (e2,d2,c2,ca2,ec2,dc2) =
       (Set.union e1 e2, Set.union d1 d2, Map.union c1 c2, ca1 <|> ca2, Set.union ec1 ec2, Set.union dc1 dc2)
 
+    -- Same-module functions that write the @"tag"@ key of a value handed to
+    -- them, keyed by name and carrying the parameter positions the tag arrives
+    -- in.  An encoder delegating to one of these still has a statically known
+    -- tag value even though its own body never mentions @"tag"@.
+    helperTagPos :: Map String [Int]
+    helperTagPos = Map.fromListWith (\a b -> nub (a ++ b))
+                     (concatMap collectTagHelper (bagToList (tcg_binds tcg)))
+
+    collectTagHelper :: LHsBindLR GhcTc GhcTc -> [(String, [Int])]
+    collectTagHelper (L _ (PatFunBind fid mg))
+      | let occ = occNameString (nameOccName (getName (unXRecTc fid)))
+      , occ `notElem` jsonMethodNames
+      , poss <- helperTagParamPositions mg
+      , not (null poss)
+      = [(occ, poss)]
+    collectTagHelper (L _ (PatAbsBinds binds)) = concatMap collectTagHelper (bagToList binds)
+    collectTagHelper _ = []
+
     processBind :: LHsBindLR GhcTc GhcTc -> IO [(Text, (Set Text, Set Text, Map Text Text, Maybe Text, Set Text, Set Text))]
 #if __GLASGOW_HASKELL__ >= 900
-    processBind (L l (FunBind _ id' matches _)) = methodTags (locA l) id' matches
-    processBind (L _ (AbsBinds{abs_binds = binds})) = concat <$> mapM processBind (bagToList binds)
+    processBind (L l (PatFunBind id' matches)) = methodTags (locA l) id' matches
+    processBind (L _ (PatAbsBinds binds)) = concat <$> mapM processBind (bagToList binds)
 #else
-    processBind (L l (FunBind _ id' matches _ _)) = methodTags l id' matches
-    processBind (L _ (AbsBinds{abs_binds = binds})) = concat <$> mapM processBind (bagToList binds)
+    processBind (L l (PatFunBind id' matches)) = methodTags l id' matches
+    processBind (L _ (PatAbsBinds binds)) = concat <$> mapM processBind (bagToList binds)
 #endif
     processBind _ = pure []
 
@@ -480,7 +744,7 @@ collectTagValues tcg = do
               exprs = matchAlts ^? biplateRef :: [LHsExpr GhcTc]
           case () of
             _ | methodName `elem` ["toJSON","toEncoding"] ->
-                  let (encTags, encConToTag, encCons) = collectEncTags matchAlts
+                  let (encTags, encConToTag, encCons) = collectEncTags currentModName helperTagPos matchAlts
                   in pure [(tyKey, (encTags, Set.empty, encConToTag, Nothing, encCons, Set.empty))]
               | methodName == "parseJSON" ->
                   let (decTagsCase, mCatchAllCase) = collectDecTags exprs
@@ -496,20 +760,16 @@ collectTagValues tcg = do
 -- keys that appear as alternatives in a @<|>@ expression (direct or via @liftA2@).
 collectAltGroups :: TcGblEnv -> IO AltGroupMap
 collectAltGroups tcg = do
-  rows <- mapM processBind (bagToList (tcg_binds tcg))
+  let currentModName = moduleNameString (moduleName (tcg_mod tcg))
+  rows <- mapM (processBind currentModName) (bagToList (tcg_binds tcg))
   pure (Map.fromListWith (Map.unionWith Set.union) (concat rows))
   where
-    processBind :: LHsBindLR GhcTc GhcTc -> IO [(Text, Map Text (Set Text))]
-#if __GLASGOW_HASKELL__ >= 900
-    processBind (L _ (FunBind _ id' matches _)) = pure (methodAlts id' matches)
-    processBind (L _ (AbsBinds{abs_binds = binds})) = concat <$> mapM processBind (bagToList binds)
-#else
-    processBind (L _ (FunBind _ id' matches _ _)) = pure (methodAlts id' matches)
-    processBind (L _ (AbsBinds{abs_binds = binds})) = concat <$> mapM processBind (bagToList binds)
-#endif
-    processBind _ = pure []
+    processBind :: String -> LHsBindLR GhcTc GhcTc -> IO [(Text, Map Text (Set Text))]
+    processBind modName (L _ (PatFunBind id' matches)) = pure (methodAlts modName id' matches)
+    processBind modName (L _ (PatAbsBinds binds)) = concat <$> mapM (processBind modName) (bagToList binds)
+    processBind _ _ = pure []
 
-    methodAlts id' matches =
+    methodAlts currentModName id' matches =
       let methodName = occNameString (nameOccName (getName (unXRecTc id')))
           ty = idType (unXRecTc id')
           mTyKey = case methodAppliedType methodName ty of
@@ -521,9 +781,62 @@ collectAltGroups tcg = do
              let matchAlts = unLoc (mg_alts matches :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)])
                  exprs = matchAlts ^? biplateRef :: [LHsExpr GhcTc]
                  groups = concatMap (findAltGroups . unLoc) exprs
+                            ++ caseFallbackGroups currentModName exprs
                  keyMap = buildAltMap groups
              in [(tyKey, keyMap)]
            _ -> []
+
+-- | Fallback groups written as a @case@ over an already-parsed optional key
+-- rather than with @\<|\>@:
+--
+-- @
+--   mbBooking \<- v .:? "booking"
+--   bData \<- case mbBooking of
+--             Just b  -> pure (Just b)
+--             Nothing -> v .:? "data"
+-- @
+--
+-- \"booking\" and \"data\" fill the same field, so the encoder only has to write
+-- one of them.  Recognised by binding the scrutinee: a @do@ statement
+-- @v \<- \<expr reading exactly one key\>@ followed by a @case@ on that same @v@.
+caseFallbackGroups :: String -> [LHsExpr GhcTc] -> [[Text]]
+caseFallbackGroups currentModName exprs =
+  [ nub (boundKey : altKeys)
+  | (scrutName, boundKey) <- boundKeys
+  , (caseName, altKeys) <- caseKeys
+  , scrutName == caseName
+  , not (null altKeys)
+  ]
+  where
+    stmts = [ s | L _ e <- exprs, HsDo _ _ ss <- [peelWrap e], L _ s <- unLoc ss ]
+    boundKeys =
+      [ (v, k)
+      | BindStmt _ pat rhs <- stmts
+      , Just v <- [patVarName (unXRecTc pat)]
+      , [k] <- [nub (map kiKey (deepDecKeys rhs))]
+      ]
+    caseKeys =
+      [ (v, concatMap (map kiKey . deepDecKeys) (altBodies mg))
+      | L _ e <- exprs
+      , HsCase _ scrut mg <- [peelWrap e]
+      , Just v <- [exprVarName (unXRecTc scrut)]
+      ]
+    altBodies mg = [ b | L _ m <- unLoc (mg_alts mg :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)])
+                       , Just b <- [matchBodyL m] ]
+    deepDecKeys b = [ k
+                    | L _ sub <- (b ^? biplateRef :: [LHsExpr GhcTc])
+                    , k <- extractKeysFromExpr (Just currentModName) DecodeSide sub
+                    ]
+    exprVarName e = case peelWrap e of
+      HsVar _ (L _ v) -> Just (occNameString (nameOccName (getName v)))
+      _ -> Nothing
+
+-- | The variable a pattern binds, for simple @v <- ...@ binders.
+patVarName :: Pat GhcTc -> Maybe String
+patVarName p = case p of
+  VarPat _ (L _ v) -> Just (occNameString (nameOccName (getName v)))
+  PatParPat inner -> patVarName (unXRecTc inner)
+  _ -> Nothing
 
 -- | Find @<|>@ fallback groups in an expression. Returns a list of
 --   key-groups, where each group is a list of decode keys that are
@@ -574,7 +887,14 @@ findAltGroups e0 = go 0 (peelWrap e0)
       Just ("foldr1", _) -> True
       _ -> False
 
-    hasAltOpInSpine = any (\x -> isAltOp x || isLiftA2 x)
+    -- The combining function of a @foldr1@ arrives as an argument, so it is an
+    -- application (@liftA2 (<|>)@) rather than a bare variable.  Look at the
+    -- head of each element's own spine, or @foldr1 (liftA2 (<|>)) [...]@ is
+    -- never recognised as an alternation.
+    hasAltOpInSpine = any (\x -> isAltOp x || isLiftA2 x || altOpUnderHead x)
+    altOpUnderHead x = case appSpineTc (peelWrap x) of
+      (h : args) -> isLiftA2 h && any isAltOp args
+      [] -> False
 
     isExplicitList x = case peelWrap x of
       ExplicitList _ _ -> True
@@ -591,7 +911,7 @@ findAltGroups e0 = go 0 (peelWrap e0)
           in if not (null ks) then ks
              else case peelWrap expr of
                HsApp _ f a -> extractKeys (unXRecTc f) ++ extractKeys (unXRecTc a)
-               HsPar _ p -> extractKeys (unXRecTc p)
+               PatHsPar p -> extractKeys (unXRecTc p)
                _ -> []
 
 -- | Build a map from each key to the set of its alternative keys.
@@ -614,6 +934,67 @@ extractEncTagObjValues e = case appSpineTc e of
                               (v : _) -> [v]
                               [] -> []
       _ -> []
+  _ -> []
+
+-- | Like 'extractEncTagObjValues', but returns the 'Name' of the variable in
+-- the tag position rather than a literal: @"tag" .= t@ yields @t@.  Used to
+-- work out which of a helper's parameters ends up as the constructor tag.
+encTagValueVars :: HsExpr GhcTc -> [Name]
+encTagValueVars e = case appSpineTc e of
+  (h : keyArg : valArgs)
+    | Just (occ, Just mmod) <- opName h
+    , isAesonMod (Just mmod)
+    , occ == ".="
+    , Just "tag" <- keyString keyArg
+    -> [ getName v | a <- valArgs, HsVar _ (L _ v) <- [peelWrap a] ]
+  _ -> []
+
+-- | Which of a same-module function's parameters are written out as a
+-- constructor tag by its body.  For
+--
+-- @
+--   mkTagged tag payload = object [ "tag" .= tag, "payload" .= payload ]
+-- @
+--
+-- this is @[0]@, which lets 'collectEncTags' read the tag value @"A"@ out of
+-- @toJSON (HiddenA x) = mkTagged "A" (toJSON x)@ -- an encoder that mentions
+-- no @"tag"@ key of its own.
+helperTagParamPositions :: MatchGroup GhcTc (LHsExpr GhcTc) -> [Int]
+helperTagParamPositions mg = nub
+  [ i
+  | L _ m <- alts
+  , (i, Just v) <- zip [0 ..] (matchPatVarNames m)
+  , v `elem` tagVars
+  ]
+  where
+    alts = unLoc (mg_alts mg :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)])
+    tagVars = concatMap (encTagValueVars . unLoc) (alts ^? biplateRef :: [LHsExpr GhcTc])
+
+-- | The 'Name' bound by each argument pattern of a match, in order
+-- ('Nothing' for anything that is not a plain variable).
+matchPatVarNames :: Match GhcTc (LHsExpr GhcTc) -> [Maybe Name]
+#if __GLASGOW_HASKELL__ >= 900
+matchPatVarNames (Match _ _ pats _) = map (patBoundName . unXRecTc) pats
+#else
+matchPatVarNames (Match _ pats _) = map (patBoundName . unLoc) pats
+#endif
+
+patBoundName :: Pat GhcTc -> Maybe Name
+patBoundName p = case p of
+  VarPat _ (L _ v) -> Just (getName v)
+  PatParPat inner -> patBoundName (unXRecTc inner)
+  _ -> Nothing
+
+-- | Extract tag values from a call to a same-module helper that writes the
+-- @"tag"@ key itself: the literal sitting in a tag-carrying parameter position
+-- is the constructor tag.
+extractEncTagHelperValues :: String -> Map String [Int] -> HsExpr GhcTc -> [Text]
+extractEncTagHelperValues currentModName helperTagPos e = case appSpineTc e of
+  (h : args)
+    | Just (occ, Just mmod) <- opName h
+    , mmod == currentModName
+    , Just poss <- Map.lookup occ helperTagPos
+    -> [ v | i <- poss, i < length args, Just v <- [keyString (args !! i)] ]
   _ -> []
 
 -- | Extract tag values from @String "VALUE"@ at the top level of a
@@ -656,10 +1037,10 @@ patTag _ = []
 -- non-constructor patterns (wildcards, variables, etc.).
 patConName :: Pat GhcTc -> Maybe Text
 #if __GLASGOW_HASKELL__ >= 900
-patConName (ParPat _ p) = patConName (unXRecTc p)
+patConName (PatParPat p) = patConName (unXRecTc p)
 patConName (ConPat _ lcon _) = Just (T.pack (occNameString (nameOccName (conLikeName (unLoc lcon)))))
 #else
-patConName (ParPat _ p) = patConName (unLoc p)
+patConName (PatParPat p) = patConName (unLoc p)
 patConName (ConPatOut _ lcon _ _ _ _ _) = Just (T.pack (occNameString (nameOccName (conLikeName (unLoc lcon)))))
 #endif
 patConName _ = Nothing
@@ -668,9 +1049,9 @@ patConName _ = Nothing
 -- Peels through 'ParPat' for robustness.
 isWildPat :: Pat GhcTc -> Bool
 #if __GLASGOW_HASKELL__ >= 900
-isWildPat (ParPat _ p) = isWildPat (unXRecTc p)
+isWildPat (PatParPat p) = isWildPat (unXRecTc p)
 #else
-isWildPat (ParPat _ p) = isWildPat (unLoc p)
+isWildPat (PatParPat p) = isWildPat (unLoc p)
 #endif
 isWildPat (WildPat _) = True
 isWildPat _ = False
@@ -724,7 +1105,7 @@ walkEncKeys mCurrentMod e0 = go False e0
              let alts = unLoc (mg_alts mg :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)])
              in concat [ go True body | L _ m <- alts, Just body <- [matchBody m] ]
            HsApp _ f a -> if inLambda then [] else go False (unXRecTc f) ++ go False (unXRecTc a)
-           HsPar _ p -> go inLambda (unXRecTc p)
+           PatHsPar p -> go inLambda (unXRecTc p)
 #if __GLASGOW_HASKELL__ >= 900
            ExplicitList _ xs -> if inLambda
                                   then concatMap (extractKeysFromExpr mCurrentMod EncodeSide . unXRecTc) xs
@@ -761,9 +1142,9 @@ walkDecKeys mCurrentMod e0 = go e0
              let alts = unLoc (mg_alts mg :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)])
              in concat [ go body | L _ m <- alts, Just body <- [matchBody m] ]
            HsApp _ f a -> go (unXRecTc f) ++ go (unXRecTc a)
-           HsPar _ p -> go (unXRecTc p)
+           PatHsPar p -> go (unXRecTc p)
            OpApp _ a _ b -> go (unXRecTc a) ++ go (unXRecTc b)
-           HsLet _ _ body -> go (unXRecTc body)
+           PatHsLet _ body -> go (unXRecTc body)
 #if __GLASGOW_HASKELL__ >= 900
            HsIf _ a b c -> go (unXRecTc a) ++ go (unXRecTc b) ++ go (unXRecTc c)
            HsDo _ _ stmts -> concatMap (stmtKeys . unXRecTc) (unXRecTc stmts)
@@ -866,7 +1247,7 @@ hasDecDelegation e = case appSpineTc e of
   (h : _) | Just (occ, mmod) <- opName h, occ == "parseJSON", isAesonMod' mmod -> True
   _ -> case peelWrap e of
     HsApp _ f a -> hasDecDelegation (unXRecTc f) || hasDecDelegation (unXRecTc a)
-    HsPar _ p -> hasDecDelegation (unXRecTc p)
+    PatHsPar p -> hasDecDelegation (unXRecTc p)
     _ -> False
 
 -- | Check whether an encoder body uses non-standard JSON construction
@@ -897,7 +1278,7 @@ hasDelegation = hasNonStd checkDelegation
     isDelegation arg = case peelWrap arg of
       HsVar _ _ -> True
       HsConLikeOut _ _ -> True
-      HsPar _ p -> isDelegation (unXRecTc p)
+      PatHsPar p -> isDelegation (unXRecTc p)
       _ -> False
 
 hasObjectConstruction :: HsExpr GhcTc -> Bool
@@ -946,16 +1327,16 @@ hasNonStd check e = check e || go (peelWrap e)
   where
     go expr = check expr || case peelWrap expr of
 #if __GLASGOW_HASKELL__ >= 900
-      HsLet _ lbs body -> any go (map unLoc (lbs ^? biplateRef :: [LHsExpr GhcTc])) || go (unXRecTc body)
+      PatHsLet lbs body -> any go (map unLoc (lbs ^? biplateRef :: [LHsExpr GhcTc])) || go (unXRecTc body)
       HsCase _ _ mg -> any (maybe False go . matchBody)
                           (map unLoc (unLoc (mg_alts mg :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)])))
 #else
-      HsLet _ lbs body -> any go (map unLoc (lbs ^? biplateRef :: [LHsExpr GhcTc])) || go (unLoc body)
+      PatHsLet lbs body -> any go (map unLoc (lbs ^? biplateRef :: [LHsExpr GhcTc])) || go (unLoc body)
       HsCase _ _ mg -> any (maybe False go . matchBody)
                           (map unLoc (unLoc (mg_alts mg)))
 #endif
       HsApp _ f a -> go (unXRecTc f) || go (unXRecTc a)
-      HsPar _ p -> go (unXRecTc p)
+      PatHsPar p -> go (unXRecTc p)
       _ -> False
 
 -- | Find the type key of the delegated type in a @toJSON <var>@ encoder body.
@@ -983,26 +1364,28 @@ findDelegatedTypeKey alts = listToMaybe
     isDict _ = False  -- We can't easily distinguish dict args, so we try all non-head args
 
 #if __GLASGOW_HASKELL__ >= 900
-    go (HsLet _ lbs body) = case [ findInExpr sub | L _ sub <- lbs ^? biplateRef :: [LHsExpr GhcTc] ] ++ [findInExpr (unXRecTc body)] of
+    go (PatHsLet lbs body) = case [ findInExpr sub | L _ sub <- lbs ^? biplateRef :: [LHsExpr GhcTc] ] ++ [findInExpr (unXRecTc body)] of
                               (Just k : _) -> Just k
                               _ -> Nothing
     go (HsCase _ _ mg) = listToMaybe [ k | L _ m <- unLoc (mg_alts mg :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)]), Just body <- [matchBody m], Just k <- [findInExpr body] ]
 #else
-    go (HsLet _ lbs body) = case [ findInExpr sub | L _ sub <- lbs ^? biplateRef :: [LHsExpr GhcTc] ] ++ [findInExpr (unLoc body)] of
+    go (PatHsLet lbs body) = case [ findInExpr sub | L _ sub <- lbs ^? biplateRef :: [LHsExpr GhcTc] ] ++ [findInExpr (unLoc body)] of
                               (Just k : _) -> Just k
                               _ -> Nothing
     go (HsCase _ _ mg) = listToMaybe [ k | L _ m <- unLoc (mg_alts mg), Just body <- [matchBody m], Just k <- [findInExpr body] ]
 #endif
     go (HsApp _ f a) = findInExpr (unXRecTc f) <|> findInExpr (unXRecTc a)
-    go (HsPar _ p) = findInExpr (unXRecTc p)
+    go (PatHsPar p) = findInExpr (unXRecTc p)
     go _ = Nothing
 
 -- | Collect encoder tag data from toJSON match alternatives.
 -- Returns (tag values, constructor→tag map, all encoder constructors).
 -- Pattern 1 (@"tag" .= value@): searched via 'biplateRef' anywhere in body.
 -- Pattern 2 (@String "VALUE"@): only from match body directly (not sub-expressions).
-collectEncTags :: [LMatch GhcTc (LHsExpr GhcTc)] -> (Set Text, Map Text Text, Set Text)
-collectEncTags alts =
+-- Pattern 3 (@mkTagged "A" ...@): a call to a same-module helper that writes
+-- the @"tag"@ key itself, with the tag value passed in as an argument.
+collectEncTags :: String -> Map String [Int] -> [LMatch GhcTc (LHsExpr GhcTc)] -> (Set Text, Map Text Text, Set Text)
+collectEncTags currentModName helperTagPos alts =
   let conTagPairs =
         [ (conName, tagVal)
         | alt <- alts
@@ -1021,6 +1404,7 @@ collectEncTags alts =
         , not (null ps)
         , Just conName <- [patConName (head ps)]
         , tagVal <- concatMap (extractEncTagObjValues . unLoc) ([alt] ^? biplateRef :: [LHsExpr GhcTc])
+                  ++ concatMap (extractEncTagHelperValues currentModName helperTagPos . unLoc) ([alt] ^? biplateRef :: [LHsExpr GhcTc])
                   ++ case matchBody m of
                        Just body -> extractEncTagStrValues body
                        Nothing -> []
@@ -1060,10 +1444,10 @@ collectDecTags exprs =
     decCaseAlts e0 = case peelWrap e0 of
 #if __GLASGOW_HASKELL__ >= 900
       HsCase _ _ mg -> map decAltData (map unLoc (unLoc (mg_alts mg :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)])))
-      HsLamCase _ mg -> map decAltData (map unLoc (unLoc (mg_alts mg :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)])))
+      PatHsLamCase mg -> map decAltData (map unLoc (unLoc (mg_alts mg :: XRec GhcTc [LMatch GhcTc (LHsExpr GhcTc)])))
 #else
       HsCase _ _ mg -> map decAltData (map unLoc (unLoc (mg_alts mg)))
-      HsLamCase _ mg -> map decAltData (map unLoc (unLoc (mg_alts mg)))
+      PatHsLamCase mg -> map decAltData (map unLoc (unLoc (mg_alts mg)))
 #endif
       _ -> []
 
@@ -1164,7 +1548,7 @@ grhsGuardStrings (GRHS _ guards _) =
       HsLit _ (HsString _ fs) -> [T.pack (unpackFS fs)]
       HsOverLit _ OverLit{ol_val = HsIsString _ fs} -> [T.pack (unpackFS fs)]
       HsApp _ f a -> exprStrings (unXRecTc f) ++ exprStrings (unXRecTc a)
-      HsPar _ p -> exprStrings (unXRecTc p)
+      PatHsPar p -> exprStrings (unXRecTc p)
       _ -> []
 
 -- | Get the GRHSs from a Match.
@@ -1180,10 +1564,10 @@ matchGRHSs (Match _ _ grhss) = grhss
 -- or when the argument is not a string literal.
 conPatStringTag :: Pat GhcTc -> [Text]
 #if __GLASGOW_HASKELL__ >= 900
-conPatStringTag (ParPat _ p) = conPatStringTag (unXRecTc p)
+conPatStringTag (PatParPat p) = conPatStringTag (unXRecTc p)
 conPatStringTag (ConPat _ lcon details)
 #else
-conPatStringTag (ParPat _ p) = conPatStringTag (unLoc p)
+conPatStringTag (PatParPat p) = conPatStringTag (unLoc p)
 conPatStringTag (ConPatOut _ lcon _ _ _ _ details)
 #endif
   | Just ("String", mmod) <- conLikeInfo
@@ -1244,22 +1628,95 @@ extractKeysFromExpr mCurrentMod side e0 = case appSpineTc e0 of
   -- that take a string key and an Object argument (e.g. readNumberAsMoney "amount" o).
   (h : args) | Just (occ, mmod) <- opName h
              , not (occ `elem` ["<>", "$", ".", "<<<", ">>>", "<|>", ">>=", ">>", "=<<", "++", ">", "<", ">=", "<=", "==", "/=", "&&", "||", "*"])
-             , isLocalHelper mmod
-               || (not (isAesonMod mmod) && not (isTextUtilMod mmod) && length args >= 2 && isVarArg (args !! 1))
+             , isWhereBoundHelper mmod
+               || (isSameModuleHelper mmod && takesObjectArg args)
+               || (not (isAesonMod mmod) && not (isTextUtilMod mmod) && length args >= 2 && objectArg (args !! 1))
              -> let strArgs = case [k | Just k <- map keyString args] of (k:_) -> [k]; [] -> []
                 in [KeyInfo k Nothing False | k <- strArgs]
   -- Tuple syntax in encoder: ("key", value) inside object [...]
   [e] | side == EncodeSide, Just k <- tupleFirstKey e -> [KeyInfo k Nothing False]
   _ -> []
   where
-    isLocalHelper Nothing = True
-    isLocalHelper (Just m) = maybe False (== m) mCurrentMod
+    -- A @where@- or lambda-bound helper has no module.  These are written right
+    -- next to the object they build (@toE "key" val@), so a string literal in
+    -- one really is a key.
+    isWhereBoundHelper Nothing = True
+    isWhereBoundHelper (Just _) = False
+    isSameModuleHelper Nothing = False
+    isSameModuleHelper (Just m) = maybe False (== m) mCurrentMod
+    -- A top-level helper is only reading or writing a JSON key if it is also
+    -- handed the object (or record) to work on.  @mkTagged "A" (toJSON x)@ is
+    -- passing a constructor tag *value*, not a key, and reading it as a key
+    -- invents encoder keys that no decoder will ever ask for.
+    takesObjectArg as = length as >= 2 && (objectArg (head as) || objectArg (as !! 1))
+    -- On the decode side the companion argument really is the JSON object, and
+    -- we can check that from its type.  On the encode side a helper is handed
+    -- the record or the value itself, so any variable will do.
+    objectArg = case side of
+      DecodeSide -> isJsonObjectArg
+      EncodeSide -> isVarArg
 
 -- | Check if an expression is a variable reference (HsVar).
 isVarArg :: HsExpr GhcTc -> Bool
 isVarArg arg = case peelWrap arg of
   HsVar _ _ -> True
   _ -> False
+
+-- | Is this argument the JSON object being read?  A decoder helper that pulls a
+-- key out is always handed the 'Object'\/'Value'.  Without this test, any
+-- two-argument call whose first argument is a string literal looks like a key
+-- read -- @fromMaybe "request_failed" code@ being the classic false positive,
+-- where the literal is a default *value*.
+isJsonObjectArg :: HsExpr GhcTc -> Bool
+isJsonObjectArg arg = case peelWrap arg of
+  HsVar _ (L _ v) -> keyOfType (idType v) `elem` ["Object", "Value", "KeyMap", "Array"]
+  _ -> False
+
+-- | Keys read in an @\<|\>@ alternation where /another branch reads no key at
+-- all/ -- @o .: "DataSet" \<|\> pure o@, or
+-- @parseFields v \<|\> withObject "Wrapped" (\\o -> o .: "contents" >>= parseFields) v@.
+-- The parse succeeds through the keyless branch, so the encoder is under no
+-- obligation to write them; they are envelopes, not data.
+--
+-- Note this deliberately does /not/ cover an alternation between two keys
+-- (@o .:? "a" \<|\> o .:? "b"@).  There one of the two really must be written,
+-- and 'buildAltMap' is what decides whether the encoder wrote either.
+defaultedAltKeys :: Maybe String -> [LHsExpr GhcTc] -> Set Text
+defaultedAltKeys mCurrentMod es = Set.fromList
+  [ k
+  | L _ e <- es
+  , Just branches <- [altBranches (peelWrap e)]
+  , let branchKeys = map deepKeys branches
+  , any null branchKeys          -- some branch parses without reading anything
+  , any (not . null) branchKeys  -- ...and some other branch reads a key
+  , k <- concat branchKeys
+  ]
+  where
+    -- The branches of an alternation, if this expression is one.  Dictionary
+    -- arguments ride in the wrapper rather than the spine, so what is left is
+    -- exactly the operands.
+    altBranches e = case appSpineTc e of
+      sp@(h : _) | isAlt h -> case filter (not . isAlt) sp of
+                                bs | length bs >= 2 -> Just bs
+                                _ -> Nothing
+      (h : altOp : a1 : a2 : _) | isLiftA2Head h, isAlt altOp -> Just [a1, a2]
+      _ -> Nothing
+    isAlt x = spineHeadName x == Just "<|>"
+    isLiftA2Head x = spineHeadName x == Just "liftA2"
+    -- 'biplateRef' yields a node's children, so the branch expression itself
+    -- has to be included or a branch that /is/ the key read is seen as empty.
+    deepKeys b = [ kiKey k
+                 | sub <- b : [ s | L _ s <- (b ^? biplateRef :: [LHsExpr GhcTc]) ]
+                 , k <- extractKeysFromExpr mCurrentMod DecodeSide sub
+                 ]
+
+-- | The name at the head of an expression's application spine, so that an
+-- operator passed as an argument (@liftA2 (\<|\>)@, @foldr1 (liftA2 (\<|\>))@)
+-- is still recognised.
+spineHeadName :: HsExpr GhcTc -> Maybe String
+spineHeadName e = case appSpineTc (peelWrap e) of
+  (h : _) -> fst <$> opName h
+  [] -> Nothing
 
 -- | Check if a module is a text utility module (Data.Text, Text.Read,
 -- Data.List, etc.) whose functions' string arguments are prefixes,
@@ -1297,7 +1754,7 @@ appSpineTc e0 = go (peelWrap e0)
 peelWrap :: HsExpr GhcTc -> HsExpr GhcTc
 peelWrap (XExpr (WrapExpr (HsWrap _ e))) = peelWrap e
 peelWrap (XExpr (ExpansionExpr (HsExpanded _ e))) = peelWrap e
-peelWrap (HsPar _ e) = peelWrap (unXRecTc e)
+peelWrap (PatHsPar e) = peelWrap (unXRecTc e)
 peelWrap (ExprWithTySig _ e _) = peelWrap (unXRecTc e)
 peelWrap e = e
 #else
@@ -1448,7 +1905,7 @@ resolveDelegatedKeys (Just delegatedKey) localKeys =
 -- Per-type checking.
 ----------------------------------------------------------------------
 
-checkType :: SrcSpan -> Map Text ParsedSideInfo -> Map Text (SrcSpan,[KeyInfo],SrcSpan,[KeyInfo],Maybe Text,Maybe Text,Maybe Text) -> TagValueMap -> AltGroupMap -> Map Text (SrcSpan,[Text]) -> Map Text (Bool,Bool) -> Text -> [(SrcSpan, JsonIdLawError)]
+checkType :: SrcSpan -> Map Text ParsedSideInfo -> Map Text (SrcSpan,[KeyInfo],SrcSpan,[KeyInfo],Maybe Text,Maybe Text,Maybe Text) -> TagValueMap -> AltGroupMap -> Map Text TyConInfo -> Map Text (Bool,Bool) -> Text -> [(SrcSpan, JsonIdLawError)]
 checkType moduleSpan parsedMap localKeys tagValues altGroups definedHere instPresence tyKey
   | not definedHereNow = []
   | not (encPresent && decPresent) = []
@@ -1456,13 +1913,16 @@ checkType moduleSpan parsedMap localKeys tagValues altGroups definedHere instPre
       let psi = fromMaybe emptyParsedSideInfo (Map.lookup tyKey parsedMap)
           (encSpan, locEncKeys, decSpan, locDecKeys, mEncGenOpts, mDecGenOpts, mDelegatedKey) = fromMaybe (noSrcSpan,[],noSrcSpan,[],Nothing,Nothing,Nothing) (Map.lookup tyKey localKeys)
           (encInInsts, decInInsts) = fromMaybe (False,False) (Map.lookup tyKey instPresence)
-          (typeSpan, fields) = fromMaybe (moduleSpan,[]) (Map.lookup tyKey definedHere)
+          tci = fromMaybe (emptyTyConInfo moduleSpan) (Map.lookup tyKey definedHere)
+          typeSpan = tciSpan tci
+          fields = tciFields tci
+          nCons = tciNumCons tci
           -- Resolve the effective key sets per side, if computable.
-          encKeysE = resolveKeys (encSpan /= noSrcSpan) mEncGenOpts locEncKeys (psiOptsEnc psi) (psiViaEnc psi) (psiPlainEnc psi) encInInsts fields
+          encKeysE = resolveKeys nCons (encSpan /= noSrcSpan) mEncGenOpts locEncKeys (psiOptsEnc psi) (psiViaEnc psi) (psiPlainEnc psi) encInInsts fields
           -- If encoder keys are unknown due to non-standard encoding (toJSON delegation),
           -- try to resolve keys from the delegated type's localKeys entry.
           encKeysResolved = encKeysE <|> resolveDelegatedKeys mDelegatedKey localKeys
-          decKeysE = resolveKeys (decSpan /= noSrcSpan) mDecGenOpts locDecKeys (psiOptsDec psi) (psiViaDec psi) (psiPlainDec psi) decInInsts fields
+          decKeysE = resolveKeys nCons (decSpan /= noSrcSpan) mDecGenOpts locDecKeys (psiOptsDec psi) (psiViaDec psi) (psiPlainDec psi) decInInsts fields
           keyErrs = case (encKeysResolved, decKeysE) of
             (Just ek, Just dk) -> keyChecks tyKey ek dk
               (effectiveSpan [encSpan, psiSpan psi, typeSpan, moduleSpan])
@@ -1470,7 +1930,7 @@ checkType moduleSpan parsedMap localKeys tagValues altGroups definedHere instPre
               (Map.findWithDefault Map.empty tyKey altGroups)
             _ -> []
           optErrs = optionsChecks tyKey psi (effectiveSpan [psiSpan psi, moduleSpan])
-          genOptErrs = genericOptionsChecks tyKey mEncGenOpts mDecGenOpts (effectiveSpan [psiSpan psi, encSpan, decSpan, moduleSpan])
+          genOptErrs = genericOptionsChecks nCons tyKey mEncGenOpts mDecGenOpts (effectiveSpan [psiSpan psi, encSpan, decSpan, moduleSpan])
           (encTags, decTags, encConToTag, mCatchAllCon, encCons, decCons) = fromMaybe (Set.empty, Set.empty, Map.empty, Nothing, Set.empty, Set.empty) (Map.lookup tyKey tagValues)
           tagErrs = tagChecks tyKey encTags decTags encConToTag mCatchAllCon (effectiveSpan [encSpan, decSpan, typeSpan, moduleSpan])
           collapseErrs = collapseChecks tyKey encTags encCons decCons (effectiveSpan [encSpan, decSpan, typeSpan, moduleSpan])
@@ -1487,28 +1947,37 @@ checkType moduleSpan parsedMap localKeys tagValues altGroups definedHere instPre
                      (_, decInInsts) = fromMaybe (False,False) (Map.lookup tyKey instPresence)
                  in not (null locDecKeys) || decInInsts || isJust (psiOptsDec psi) || psiPlainDec psi || isJust (psiViaDec psi)
 
--- Right (Just keys) if the side's keys are statically computable, Nothing if not.
--- When @hasLocalBind@ is True the side has a locally-defined method bind; an
--- empty key list then means /genuinely empty/ (the method uses no @.:=/@.:@
--- operators), not /unknown/.  When @mGenOpts@ is @Just opts@ the method delegates
--- to @genericToJSON@/@@genericParseJSON@/@defaultEncode@/@@defaultDecode@.  If the
--- options are plain @defaultOptions@ (no @fieldLabelModifier@), the JSON keys
--- are the raw field labels (after 'decodeFieldKey' underscore stripping) and we
--- can use them.  Otherwise keys are unknown.
-resolveKeys :: Bool -> Maybe Text -> [KeyInfo] -> Maybe Text -> Maybe Text -> Bool -> Bool -> [Text] -> Maybe [KeyInfo]
-resolveKeys hasLocalBind mGenOpts locKeys mOpts mVia plain inInsts fields
-  | isJust mGenOpts, isDefaultOptionsText (fromJust mGenOpts), not (null locKeys), all kiOptional locKeys
-    = Just [KeyInfo (decodeFieldKey f) Nothing False | f <- fields]
+-- Returns @Just keys@ if the side's keys are statically computable, @Nothing@ if
+-- not.  When @mGenOpts@ is @Just opts@ the method delegates to
+-- @genericToJSON@/@genericParseJSON@/@defaultEncode@/@defaultDecode@; if those
+-- options cannot change a key (see 'isKeyPreservingOptionsText') the JSON keys
+-- are the field labels (after 'decodeFieldKey' underscore stripping).  When
+-- @hasLocalBind@ is True the side has a locally-defined method bind and an empty
+-- key list means /genuinely empty/ (the method uses no @.=@/@.:@ operators)
+-- rather than /unknown/ -- but that reading only holds once the /derived/ cases
+-- have been ruled out, hence the guard order below.
+resolveKeys :: Int -> Bool -> Maybe Text -> [KeyInfo] -> Maybe Text -> Maybe Text -> Bool -> Bool -> [Text] -> Maybe [KeyInfo]
+resolveKeys nCons hasLocalBind mGenOpts locKeys mOpts mVia plain inInsts fields
+  | isJust mGenOpts, keyPreserving (fromJust mGenOpts), not (null fields), not (null locKeys), all kiOptional locKeys
+    = Just (genericKeys fields)
   | not (null locKeys) = Just locKeys
-  | isJust mGenOpts, isDefaultOptionsText (fromJust mGenOpts) = Just [KeyInfo (decodeFieldKey f) Nothing False | f <- fields]
+  -- Generic derivation only tells us the keys of a record.  A type with no
+  -- record fields is encoded as a tag/contents envelope, which we do not model.
+  | isJust mGenOpts, keyPreserving (fromJust mGenOpts), not (null fields) = Just (genericKeys fields)
   | isJust mGenOpts = Nothing
   | isJust mOpts = Nothing
-  | hasLocalBind = Just []
+  -- 'deriving via' and plain 'deriving' also produce a local method bind (GHC
+  -- fills the instance in for you), so these must be consulted before falling
+  -- back on "has a bind, therefore writes no keys".
   | isJust mVia = Nothing
-  | plain, not (null fields) = Just [KeyInfo f Nothing False | f <- fields]
+  | plain, not (null fields) = Just (genericKeys fields)
   | plain = Nothing
+  | hasLocalBind = Just []
   | inInsts = Nothing
   | otherwise = Nothing
+  where
+    keyPreserving = isKeyPreservingOptionsText nCons
+    genericKeys fs = [KeyInfo (decodeFieldKey f) Nothing False | f <- fs]
 
 -- | Replicate the @Nau.Utils.DecodeField@ underscore-stripping logic used by
 -- the Presto framework's @defaultEncode@/@defaultDecode@.  Strips a leading
@@ -1530,6 +1999,52 @@ isDefaultOptionsText t =
   let s = T.unpack (T.strip t)
       base = reverse (takeWhile (/= '.') (reverse s))
   in base == "defaultOptions"
+
+-- | The 'Options' fields that can change a JSON key /for this type/.
+--
+-- aeson only writes a constructor tag for a single-constructor type when
+-- @tagSingleConstructors@ is set (see aeson's @D1 d (C1 c a)@ instance), so for
+-- a one-constructor type without it, @sumEncoding@, @constructorTagModifier@ and
+-- @allNullaryToStringTag@ are inert and must not be compared -- otherwise a
+-- record whose encoder says @defaultOptions {sumEncoding = UntaggedValue}@ is
+-- reported against a decoder that says @defaultOptions@, with no key ever
+-- differing.
+--
+-- The field names below are matched as substrings, so the singular spellings
+-- also match aeson's actual @tagSingleConstructors@ field.
+keyAffectingFieldsFor :: Int -> Text -> Text -> [Text]
+keyAffectingFieldsFor nCons encOpts decOpts
+  | nCons == 1, not (mentionsTagSingle encOpts || mentionsTagSingle decOpts) = alwaysKeyAffecting
+  | otherwise = alwaysKeyAffecting ++ tagRelated
+  where
+    mentionsTagSingle = T.isInfixOf "tagSingleConstructor"
+
+alwaysKeyAffecting :: [Text]
+alwaysKeyAffecting = ["fieldLabelModifier", "unwrapUnaryRecords", "tagSingleConstructor"]
+
+tagRelated :: [Text]
+tagRelated = ["constructorTagModifier", "allNullaryToStringTag", "sumEncoding"]
+
+-- | Does this pretty-printed 'Options' expression leave the JSON keys equal to
+-- the (underscore-stripped) record field labels?  True for plain
+-- @defaultOptions@ and for record updates that only set fields which cannot
+-- change a key for a type with @nCons@ constructors.
+isKeyPreservingOptionsText :: Int -> Text -> Bool
+isKeyPreservingOptionsText nCons t
+  | isDefaultOptionsText t = True
+  | isUnknownOptsText t = False
+  | otherwise =
+      let inert = ["omitNothingFields"]
+                    ++ (if nCons == 1 && not (T.isInfixOf "tagSingleConstructor" t) then tagRelated else [])
+          -- Every field assignment left after dropping the inert ones.
+          remaining = [ p
+                      | p <- T.splitOn "," (T.unwords (T.words t))
+                      , T.isInfixOf "=" p
+                      , not (any (`T.isInfixOf` p) inert)
+                      ]
+          -- What is left once the record-update braces and the base name go.
+          base = T.strip (T.takeWhile (/= '{') t)
+      in null remaining && isDefaultOptionsText base
 
 keyChecks :: Text -> [KeyInfo] -> [KeyInfo] -> SrcSpan -> SrcSpan -> Map Text (Set Text) -> [(SrcSpan, JsonIdLawError)]
 keyChecks ty enc dec encSpan decSpan altGroups =
@@ -1581,8 +2096,8 @@ stripOmitNothingFields t =
 -- | Compare key-affecting 'Options' fields between @genericToJSON@ and
 -- @genericParseJSON@ calls. Only fields that change JSON key or tag names
 -- are compared; safe-to-differ fields like @omitNothingFields@ are ignored.
-genericOptionsChecks :: Text -> Maybe Text -> Maybe Text -> SrcSpan -> [(SrcSpan, JsonIdLawError)]
-genericOptionsChecks ty mEncOpts mDecOpts sp =
+genericOptionsChecks :: Int -> Text -> Maybe Text -> Maybe Text -> SrcSpan -> [(SrcSpan, JsonIdLawError)]
+genericOptionsChecks nCons ty mEncOpts mDecOpts sp =
   case (mEncOpts, mDecOpts) of
     (Just encOpts, Just decOpts) ->
       let encFiltered = filterKeyAffecting encOpts
@@ -1593,7 +2108,7 @@ genericOptionsChecks ty mEncOpts mDecOpts sp =
     _ -> []
   where
     -- Fields that affect JSON key/tag names and must match for round-trip safety.
-    keyAffectingFields = ["fieldLabelModifier","constructorTagModifier","allNullaryToStringTag","tagSingleConstructor","sumEncoding","unwrapUnaryRecords"]
+    keyAffectingFields = keyAffectingFieldsFor nCons (fromMaybe "" mEncOpts) (fromMaybe "" mDecOpts)
     -- Keep only the lines mentioning a key-affecting field, and normalize
     -- GHC internal variable names (e.g. x_aPhB -> x_) so that the same
     -- lambda with different internal names doesn't cause a false mismatch.
@@ -1660,7 +2175,7 @@ collapseChecks ty encTags encCons decCons sp
 -- The universe of types to consider.
 ----------------------------------------------------------------------
 
-allTypesOfInterest :: Map Text ParsedSideInfo -> Map Text (SrcSpan,[KeyInfo],SrcSpan,[KeyInfo],Maybe Text,Maybe Text,Maybe Text) -> Map Text (SrcSpan,[Text]) -> Map Text (Bool,Bool) -> [Text]
+allTypesOfInterest :: Map Text ParsedSideInfo -> Map Text (SrcSpan,[KeyInfo],SrcSpan,[KeyInfo],Maybe Text,Maybe Text,Maybe Text) -> Map Text TyConInfo -> Map Text (Bool,Bool) -> [Text]
 allTypesOfInterest parsedMap localKeys definedHere instPresence =
   nub $ Map.keys definedHere
      ++ Map.keys parsedMap

--- a/api-contract/src/ApiContract/JsonIdLaw/Types.hs
+++ b/api-contract/src/ApiContract/JsonIdLaw/Types.hs
@@ -1,0 +1,184 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+
+module ApiContract.JsonIdLaw.Types where
+
+import Data.Text (Text)
+import qualified Data.Text as T
+import GHC.Generics (Generic)
+import Data.Aeson (ToJSON, FromJSON)
+
+-- | A JSON object key as it appears in source (e.g. the LHS of @.=@ or the
+-- argument of @.:@/@.:?@).
+type JsonKey = Text
+
+-- | The Haskell record field name a JSON key is associated with, when we can
+-- infer it statically.
+type FieldName = Text
+
+-- | Which side of the round-trip a key was observed on.
+data Side = EncodeSide | DecodeSide
+  deriving (Eq, Show, Ord, Generic, ToJSON, FromJSON)
+
+-- | Information about a single observed JSON key.
+data KeyInfo = KeyInfo
+  { kiKey      :: !JsonKey
+  -- ^ The JSON key literal as written in source.
+  , kiField    :: !(Maybe FieldName)
+  -- ^ The record field it maps to, if discoverable.
+  , kiOptional :: !Bool
+  -- ^ For decode keys: True if read via @.:?@/@.:!@ (i.e. the field is
+  -- 'Maybe' and may legitimately be absent on encode). Always False for
+  -- encode keys.
+  }
+  deriving (Eq, Show, Ord, Generic, ToJSON, FromJSON)
+
+-- | How a 'ToJSON'\/'FromJSON' instance was produced for a type.
+data InstanceOrigin
+  = CustomInstance
+  -- ^ A hand-written @instance ToJSON T where toJSON = ...@.
+  | DerivedPlain
+  -- ^ @deriving (ToJSON, FromJSON)@, @GeneralizedNewtypeDeriving@, or
+  -- @deriveJSON defaultOptions@. Law-abiding by construction; not checked.
+  | DerivedWithOptions
+  -- ^ @deriveToJSON opts@\/@deriveFromJSON opts@ with explicit (possibly
+  -- non-identity) options, or @mkToJSON@\/@mkParseJSON@.
+  | DerivedVia
+  -- ^ @deriving (ToJSON) via V@ for some helper type @V@.
+  | NotPresent
+  -- ^ The instance does not exist (locally or in the instance env).
+  deriving (Eq, Show, Ord, Generic, ToJSON, FromJSON)
+
+-- | Per-type summary of what we observed for the round-trip.
+data TypeJsonInfo = TypeJsonInfo
+  { tjiType        :: !Text
+  -- ^ The type name (as pretty-printed).
+  , tjiEncodeKeys  :: ![KeyInfo]
+  -- ^ JSON keys written by @toJSON@\/@toEncoding@.
+  , tjiDecodeKeys  :: ![KeyInfo]
+  -- ^ JSON keys read by @parseJSON@.
+  , tjiEncOrigin   :: !InstanceOrigin
+  , tjiDecOrigin   :: !InstanceOrigin
+  , tjiEncOpts      :: !(Maybe Text)
+  -- ^ Pretty-printed @Options@ expression for the encode side, when
+  -- 'tjiEncOrigin' is 'DerivedWithOptions'.
+  , tjiDecOpts      :: !(Maybe Text)
+  -- ^ Pretty-printed @Options@ expression for the decode side.
+  , tjiEncVia       :: !(Maybe Text)
+  -- ^ The @via@ type for 'DerivedVia' encode.
+  , tjiDecVia       :: !(Maybe Text)
+  -- ^ The @via@ type for 'DerivedVia' decode.
+  , tjiDefinedHere  :: !Bool
+  -- ^ Whether the type itself is defined in this module.
+  }
+  deriving (Eq, Show, Generic, ToJSON, FromJSON)
+
+-- | Errors emitted by the JSON ID-law check. These are all cases where the
+-- @fromJSON . toJSON@ round-trip can statically be shown to lose data (or be
+-- impossible).
+data JsonIdLawError
+  -- | A /required/ decode key (read via @.:@\/@.:!@) is never produced by the
+  -- encoder. @fromJSON (toJSON x)@ will therefore fail to find the key.
+  = KEY_ONLY_IN_DECODE
+      { idlawType :: !Text
+      , idlawKey  :: !JsonKey
+      }
+  -- | The same record field is encoded under one key but decoded from another
+  -- (the classic snake_case-vs-camelCase data-loss bug).
+  | KEY_CASE_MISMATCH
+      { idlawType   :: !Text
+      , idlawField  :: !FieldName
+      , idlawEncKey :: !JsonKey
+      , idlawDecKey :: !JsonKey
+      }
+  -- | The same JSON key maps to different record fields on encode vs decode,
+  -- so the value round-trips into the wrong field.
+  | FIELD_KEY_MISMATCH
+      { idlawType    :: !Text
+      , idlawKey      :: !JsonKey
+      , idlawEncField :: !FieldName
+      , idlawDecField :: !FieldName
+      }
+  -- | A JSON key is written by the encoder but never read by the decoder and
+  -- does not correspond to any field of the type. Dead\/typo key that breaks
+  -- the round-trip.
+  | KEY_ONLY_IN_ENCODE
+      { idlawType :: !Text
+      , idlawKey  :: !JsonKey
+      }
+  -- | @deriveToJSON@\/@deriveFromJSON@ (or @mkToJSON@\/@mkParseJSON@) use different 'Options'
+  -- (e.g. a different @fieldLabelModifier@), so encode keys != decode keys.
+  | OPTIONS_MISMATCH
+      { idlawType    :: !Text
+      , idlawEncOpts :: !Text
+      , idlawDecOpts :: !Text
+      }
+  -- | @deriving ... via V@ uses different via types\/options on the two sides.
+  | OPTIONS_VIA_MISMATCH
+      { idlawType   :: !Text
+      , idlawEncVia :: !Text
+      , idlawDecVia :: !Text
+      }
+  -- | A sum-type constructor tag value is encoded differently from what the
+  -- decoder expects (e.g. encoder writes @"A"@ but decoder matches @"AA"@).
+  | TAG_VALUE_MISMATCH
+      { idlawType    :: !Text
+      , idlawEncTag  :: !Text
+      , idlawDecTag  :: !Text
+      }
+  deriving (Eq, Show, Ord, Generic, ToJSON, FromJSON)
+
+-- | Pretty-print an error for the GHC diagnostic. The leading
+-- @"[JsonIdLaw] "@ tag makes the check easy to identify in build logs.
+generateJsonIdLawError :: JsonIdLawError -> String
+generateJsonIdLawError (KEY_ONLY_IN_DECODE ty key) =
+  "[JsonIdLaw] Data loss: the required JSON key '" <> T.unpack key
+  <> "' is read by 'parseJSON' for type '" <> T.unpack ty
+  <> "' but is never produced by 'toJSON'/'toEncoding'.\n"
+  <> "\t'fromJSON (toJSON x)' will fail to find this key.\n"
+  <> "\tEither add the key to the encoder or remove it from the decoder."
+
+generateJsonIdLawError (KEY_CASE_MISMATCH ty field encKey decKey) =
+  "[JsonIdLaw] Data loss: field '" <> T.unpack field
+  <> "' of type '" <> T.unpack ty
+  <> "' is encoded under the key '" <> T.unpack encKey
+  <> "' but decoded from the key '" <> T.unpack decKey <> "'.\n"
+  <> "\t'fromJSON (toJSON x)' will lose this field because the keys do not match.\n"
+  <> "\tMake the encoder and decoder use the same JSON key for this field."
+
+generateJsonIdLawError (FIELD_KEY_MISMATCH ty key encField decField) =
+  "[JsonIdLaw] Data loss: JSON key '" <> T.unpack key
+  <> "' for type '" <> T.unpack ty
+  <> "' is bound to field '" <> T.unpack encField
+  <> "' on encode but field '" <> T.unpack decField <> "' on decode.\n"
+  <> "\tThe round-tripped value lands in the wrong field.\n"
+  <> "\tMake both sides bind the same field for this key."
+
+generateJsonIdLawError (KEY_ONLY_IN_ENCODE ty key) =
+  "[JsonIdLaw] Data loss: JSON key '" <> T.unpack key
+  <> "' is written by 'toJSON'/'toEncoding' for type '" <> T.unpack ty
+  <> "' but is never read by 'parseJSON' and does not correspond to any field.\n"
+  <> "\tThe decoder cannot recover this key; the round-trip is lossy.\n"
+  <> "\tEither read the key in 'parseJSON' or remove it from the encoder."
+
+generateJsonIdLawError (OPTIONS_MISMATCH ty encOpts decOpts) =
+  "[JsonIdLaw] Data loss: the 'Options' used to derive 'ToJSON' and 'FromJSON' for type '"
+  <> T.unpack ty <> "' differ, so the encode/decode JSON keys will not match.\n"
+  <> "\tEncoder options: " <> T.unpack encOpts <> "\n"
+  <> "\tDecoder options: " <> T.unpack decOpts <> "\n"
+  <> "\tUse the same 'Options' (e.g. the same 'fieldLabelModifier') on both sides."
+
+generateJsonIdLawError (OPTIONS_VIA_MISMATCH ty encVia decVia) =
+  "[JsonIdLaw] Data loss: 'deriving via' uses different via types for 'ToJSON' and 'FromJSON' of type '"
+  <> T.unpack ty <> "'.\n"
+  <> "\tEncoder via: " <> T.unpack encVia <> "\n"
+  <> "\tDecoder via: " <> T.unpack decVia <> "\n"
+  <> "\tUse the same via type on both sides."
+
+generateJsonIdLawError (TAG_VALUE_MISMATCH ty encTag decTag) =
+  "[JsonIdLaw] Data loss: constructor tag '" <> T.unpack encTag
+  <> "' is encoded for type '" <> T.unpack ty
+  <> "' but the decoder expects '" <> T.unpack decTag <> "'.\n"
+  <> "\t'fromJSON (toJSON x)' will fail to match this constructor.\n"
+  <> "\tMake the encoder and decoder use the same tag value."

--- a/api-contract/src/ApiContract/Plugin.hs
+++ b/api-contract/src/ApiContract/Plugin.hs
@@ -121,6 +121,7 @@ import qualified Data.Map.Ordered as OMap
 import Data.Ord (comparing)
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Aeson as A
+import ApiContract.JsonIdLaw (collectJsonIdLaw, checkJsonIdLaw)
 
 -- ENABLE_ISOLATION
 #if defined(ENABLE_LR_PLUGINS)
@@ -229,7 +230,7 @@ showSDocUnsafe' = showSDocUnsafe . ppr
 #endif
 
 defaultCliOptions :: CliOptions
-defaultCliOptions = CliOptions {path="./.juspay/api-contract/",port=4444,host="::1",log=False,tc_funcs=Just False,api_contract=Just True}
+defaultCliOptions = CliOptions {path="./.juspay/api-contract/",port=4444,host="::1",log=False,tc_funcs=Just False,api_contract=Just True,id_law_check=Just True,id_law_exceptions_path=Just "./.juspay/jsonIdLawExceptions.yaml"}
 
 collectTypeInfoParser :: [CommandLineOption] -> ModSummary -> HsParsedModule -> Hsc HsParsedModule
 collectTypeInfoParser opts modSummary hpm = do
@@ -239,6 +240,7 @@ collectTypeInfoParser opts modSummary hpm = do
                                 case A.decode $ BL.fromStrict $ encodeUtf8 $ T.pack local of
                                     Just (val :: CliOptions) -> val
                                     Nothing -> defaultCliOptions
+    _ <- collectJsonIdLaw opts modSummary hpm
     let prefixPath = "./.juspay/api-contract/"
         moduleName' = moduleNameString $ moduleName $ ms_mod modSummary
         modulePath = prefixPath <> msHsFilePath modSummary
@@ -348,6 +350,7 @@ collectInstanceInfo opts modSummary tcEnv = do
         modulePath = prefixPath <> msHsFilePath modSummary
         moduleSrcSpan = mkFileSrcSpan $ ms_location modSummary
         path = (intercalate "/" . init . splitOn "/") modulePath
+    _ <- checkJsonIdLaw opts modSummary tcEnv
     when (fromMaybe True $ api_contract cliOptions) $ do
         typeInstances <- liftIO $ toList $ mapM processInstance (fromList $ bagToList $ tcg_binds tcEnv)
         (instanceSrcSpansHM :: HashMapL SrcSpan) <- pure $ HM.fromList $ map (\(srcSpan,typeName,instanceName,_) -> (fromString' (typeName <> "--" <> instanceName), srcSpan)) $ Prelude.concat typeInstances

--- a/api-contract/src/ApiContract/Types.hs
+++ b/api-contract/src/ApiContract/Types.hs
@@ -21,7 +21,9 @@ data CliOptions = CliOptions {
     host :: String,
     log :: Bool,
     tc_funcs :: Maybe Bool,
-    api_contract :: Maybe Bool
+    api_contract :: Maybe Bool,
+    id_law_check :: Maybe Bool,
+    id_law_exceptions_path :: Maybe String
 } deriving (Show, Eq, Ord,Generic,ToJSON,FromJSON)
 
 data TypeOfInstance =

--- a/api-contract/test/IdLawTest/IDLawAllTestCases.hs
+++ b/api-contract/test/IdLawTest/IDLawAllTestCases.hs
@@ -1,0 +1,2910 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | Positive control: a law-abiding type. Must compile cleanly under the plugin.
+module IdLawTest.IDLawAllTestCases where
+
+import Data.Aeson
+import qualified Data.Aeson as A
+import Data.Aeson.TH (deriveToJSON, deriveFromJSON)
+import Data.Aeson.Types (Parser)
+import Control.Applicative ((<|>), liftA2, empty)
+import Control.Category ((<<<), (>>>))
+import Control.Monad (when)
+import Data.Text hiding (map, toLower, zip)
+import qualified Data.Text as T
+import GHC.Generics (Generic)
+import Data.Aeson.Key (fromText)
+import qualified Data.Aeson.Key as AK
+import qualified Data.Aeson.KeyMap as KM
+import Data.Char (toLower)
+import qualified Data.Vector as V
+import Data.Maybe (fromMaybe)
+
+----------- Happy Case -------------
+data T = T { a :: Int, b :: Maybe Int }
+
+instance ToJSON T where
+  toJSON (T a' b') = object [ "a" .= a', "b" .= b' ]
+
+instance FromJSON T where
+  parseJSON = withObject "T" $ \o -> do
+    a' <- o .: "a"
+    b' <- o .:? "b"
+    pure (T a' b')
+
+---------------- Camel/Snake case issue -----------------
+data A = A { myField :: Int }
+
+instance ToJSON A where
+  toJSON (A f) = object [ "my_field" .= f ]
+
+instance FromJSON A where
+  parseJSON = withObject "A" $ \o -> do
+    myField <- o .: "myField"
+    pure (A myField)
+
+------------------- Missing field in toJSON ----------------
+data B = B { a1 :: Int, b1 :: Int }
+
+instance ToJSON B where
+  toJSON (B a' _) = object [ "a" .= a' ]
+
+instance FromJSON B where
+  parseJSON = withObject "B" $ \o -> do
+    a' <- o .: "a"
+    b' <- o .: "b"
+    pure (B a' b')
+
+-------------- Missing field in fromJSON --------------
+data C = C { field1 :: Text, field2 :: Maybe Int }
+
+instance ToJSON C where
+  toJSON (C a b) = object [ "field1" .= a, "field2" .= b ]
+
+instance FromJSON C where
+  parseJSON = withObject "C" $ \o -> do
+    a <- o .: "field1"
+    pure (C a Nothing)
+
+---------------- Optional vs Required ----------------
+
+data D = D { dField :: Maybe Int }
+
+instance ToJSON D where
+  toJSON (D x) = object ["dField" .= x]
+
+instance FromJSON D where
+  parseJSON = withObject "D" $ \o -> do
+    dField <- o .: "dField"   -- required but nullable
+    pure (D dField)
+
+---------------- Extra field written by encoder ----------------
+
+data E = E { eField :: Int }
+
+instance ToJSON E where
+  toJSON (E x) =
+    object
+      [ "eField" .= x
+      , "debug" .= ("test" :: Text)
+      ]
+
+instance FromJSON E where
+  parseJSON = withObject "E" $ \o -> do
+    eField <- o .: "eField"
+    pure (E eField)
+
+---------------- Decoder invents constant ----------------
+
+data F = F
+  { f1 :: Int
+  , f2 :: Int
+  }
+
+instance ToJSON F where
+  toJSON (F a b) =
+    object
+      [ "f1" .= a
+      , "f2" .= b
+      ]
+
+instance FromJSON F where
+  parseJSON = withObject "F" $ \o -> do
+    f1 <- o .: "f1"
+    pure (F f1 999)
+
+---------------- Different key names ----------------
+
+data G = G { userId :: Int }
+
+instance ToJSON G where
+  toJSON (G x) =
+    object ["user_id" .= x]
+
+instance FromJSON G where
+  parseJSON = withObject "G" $ \o -> do
+    userId <- o .: "userid"
+    pure (G userId)
+
+---------------- Nested record: child field lost ----------------
+
+data ChildH = ChildH
+  { childA :: Int
+  , childB :: Int
+  }
+
+instance ToJSON ChildH where
+  toJSON (ChildH a b) =
+    object
+      [ "childA" .= a
+      , "childB" .= b
+      ]
+
+instance FromJSON ChildH where
+  parseJSON = withObject "ChildH" $ \o -> do
+    childA <- o .: "childA"
+    pure (ChildH childA 0)
+
+data H = H
+  { parentField :: Int
+  , childField  :: ChildH
+  }
+
+instance ToJSON H where
+  toJSON (H p c) =
+    object
+      [ "parentField" .= p
+      , "childField" .= c
+      ]
+
+instance FromJSON H where
+  parseJSON = withObject "H" $ \o -> do
+    parentField <- o .: "parentField"
+    childField <- o .: "childField"
+    pure (H parentField childField)
+
+---------------- Newtype wrapper ----------------
+
+newtype I = I { unI :: Int }
+
+instance ToJSON I where
+  toJSON (I x) =
+    object ["value" .= x]
+
+instance FromJSON I where
+  parseJSON = withObject "I" $ \o -> do
+    unI <- o .: "val"
+    pure (I unI)
+
+---------------- Same field encoded twice logically ----------------
+
+data J = J
+  { firstName :: Text
+  , lastName  :: Text
+  }
+
+instance ToJSON J where
+  toJSON (J f l) =
+    object
+      [ "name" .= f
+      , "surname" .= l
+      ]
+
+instance FromJSON J where
+  parseJSON = withObject "J" $ \o -> do
+    firstName <- o .: "name"
+    lastName <- o .: "name"
+    pure (J firstName lastName)
+
+---------------- Decoder reads wrong field ----------------
+
+data K = K
+  { k1 :: Int
+  , k2 :: Int
+  }
+
+instance ToJSON K where
+  toJSON (K a b) =
+    object
+      [ "k1" .= a
+      , "k2" .= b
+      ]
+
+instance FromJSON K where
+  parseJSON = withObject "K" $ \o -> do
+    k1 <- o .: "k1"
+    k2 <- o .: "k1"
+    pure (K k1 k2)
+
+---------------- Extra decoder key ----------------
+
+data L = L
+  { l1 :: Int
+  }
+
+instance ToJSON L where
+  toJSON (L x) =
+    object ["l1" .= x]
+
+instance FromJSON L where
+  parseJSON = withObject "L" $ \o -> do
+    l1 <- o .: "l1"
+    (_extra :: Text) <- o .: "extra"
+    pure (L l1)
+
+---------------- List field omitted ----------------
+
+data M = M
+  { mName :: Text
+  , mItems :: [Int]
+  }
+
+instance ToJSON M where
+  toJSON (M n _) =
+    object
+      [ "mName" .= n
+      ]
+
+instance FromJSON M where
+  parseJSON = withObject "M" $ \o -> do
+    mName <- o .: "mName"
+    mItems <- o .: "mItems"
+    pure (M mName mItems)
+
+---------------- Encoder writes wrong key ----------------
+
+data N = N
+  { nValue :: Int
+  }
+
+instance ToJSON N where
+  toJSON (N x) =
+    object ["nvalue" .= x]
+
+instance FromJSON N where
+  parseJSON = withObject "N" $ \o -> do
+    nValue <- o .: "nValue"
+    pure (N nValue)
+
+---------------- Happy nested case ----------------
+
+data O = O
+  { o1 :: Int
+  , o2 :: Maybe Text
+  }
+
+instance ToJSON O where
+  toJSON (O a b) =
+    object
+      [ "o1" .= a
+      , "o2" .= b
+      ]
+
+instance FromJSON O where
+  parseJSON = withObject "O" $ \o -> do
+    o1 <- o .: "o1"
+    o2 <- o .:? "o2"
+    pure (O o1 o2)
+
+---------------- Constructor tag mismatch ----------------
+
+data S1
+  = S1A Int
+  | S1B Text
+
+instance ToJSON S1 where
+  toJSON (S1A x) =
+    object
+      [ "tag" .= ("A" :: Text)
+      , "value" .= x
+      ]
+
+  toJSON (S1B x) =
+    object
+      [ "tag" .= ("B" :: Text)
+      , "value" .= x
+      ]
+
+instance FromJSON S1 where
+  parseJSON = withObject "S1" $ \o -> do
+    tag <- o .: "tag"
+
+    case (tag :: Text) of
+      "AA" -> S1A <$> o .: "value"
+      "B"  -> S1B <$> o .: "value"
+      _    -> fail "invalid tag"
+
+--------------------------------------------------------------------------------
+
+---------------- Decoder supports only one constructor ----------------
+
+data S2
+  = LeftCtor Int
+  | RightCtor Text
+
+instance ToJSON S2 where
+  toJSON (LeftCtor x) =
+    object
+      [ "tag" .= ("LeftCtor" :: Text)
+      , "value" .= x
+      ]
+
+  toJSON (RightCtor x) =
+    object
+      [ "tag" .= ("RightCtor" :: Text)
+      , "value" .= x
+      ]
+
+instance FromJSON S2 where
+  parseJSON = withObject "S2" $ \o -> do
+    tag <- o .: "tag"
+
+    case (tag :: Text) of
+      "LeftCtor" -> LeftCtor <$> o .: "value"
+      _          -> fail "unsupported"
+
+--------------------------------------------------------------------------------
+
+---------------- Constructor collapse ----------------
+
+data S3
+  = Email Text
+  | Phone Text
+
+instance ToJSON S3 where
+  toJSON (Email x) =
+    object
+      [ "tag" .= ("email" :: Text)
+      , "value" .= x
+      ]
+
+  toJSON (Phone x) =
+    object
+      [ "tag" .= ("phone" :: Text)
+      , "value" .= x
+      ]
+
+instance FromJSON S3 where
+  parseJSON = withObject "S3" $ \o -> do
+    value <- o .: "value"
+    pure (Email value)
+
+--------------------------------------------------------------------------------
+-- NEWTYPES
+--------------------------------------------------------------------------------
+
+---------------- Key mismatch ----------------
+
+newtype N1 = N1
+  { unN1 :: Int
+  }
+
+instance ToJSON N1 where
+  toJSON (N1 x) =
+    object
+      [ "value" .= x
+      ]
+
+instance FromJSON N1 where
+  parseJSON = withObject "N1" $ \o ->
+    N1 <$> o .: "val"
+
+--------------------------------------------------------------------------------
+
+---------------- Constant decoder ----------------
+
+newtype N2 = N2
+  { unN2 :: Int
+  }
+
+instance ToJSON N2 where
+  toJSON (N2 x) =
+    object
+      [ "value" .= x
+      ]
+
+instance FromJSON N2 where
+  parseJSON _ =
+    pure (N2 42)
+
+--------------------------------------------------------------------------------
+-- NESTED TYPES
+--------------------------------------------------------------------------------
+
+---------------- Nested key mismatch ----------------
+
+data Child1 = Child1
+  { childId :: Int
+  }
+
+instance ToJSON Child1 where
+  toJSON (Child1 x) =
+    object
+      [ "child_id" .= x
+      ]
+
+instance FromJSON Child1 where
+  parseJSON = withObject "Child1" $ \o ->
+    Child1 <$> o .: "childId"
+
+--------------------------------------------------------------------------------
+
+data Parent1 = Parent1
+  { parentId :: Int
+  , childObj :: Child1
+  }
+
+instance ToJSON Parent1 where
+  toJSON (Parent1 p c) =
+    object
+      [ "parentId" .= p
+      , "childObj" .= c
+      ]
+
+instance FromJSON Parent1 where
+  parseJSON = withObject "Parent1" $ \o -> do
+    parentId <- o .: "parentId"
+    childObj <- o .: "childObj"
+    pure Parent1 {..}
+
+--------------------------------------------------------------------------------
+
+---------------- Child field silently dropped ----------------
+
+data Child2X = Child2X
+  { childAX :: Int
+  , childBX :: Int
+  }
+
+instance ToJSON Child2X where
+  toJSON (Child2X a b) =
+    object
+      [ "childA" .= a
+      , "childB" .= b
+      ]
+
+instance FromJSON Child2X where
+  parseJSON = withObject "Child2X" $ \o -> do
+    childAX <- o .: "childA"
+    pure (Child2X childAX 0)
+
+--------------------------------------------------------------------------------
+-- LISTS
+--------------------------------------------------------------------------------
+
+---------------- List field ignored ----------------
+
+data Arr1 = Arr1
+  { values :: [Int]
+  }
+
+instance ToJSON Arr1 where
+  toJSON (Arr1 xs) =
+    object
+      [ "values" .= xs
+      ]
+
+instance FromJSON Arr1 where
+  parseJSON = withObject "Arr1" $ \_ ->
+    pure (Arr1 [])
+
+--------------------------------------------------------------------------------
+
+---------------- Required list missing ----------------
+
+data Arr2 = Arr2
+  { ids :: [Int]
+  }
+
+instance ToJSON Arr2 where
+  toJSON _ =
+    object []
+
+instance FromJSON Arr2 where
+  parseJSON = withObject "Arr2" $ \o ->
+    Arr2 <$> o .: "ids"
+
+--------------------------------------------------------------------------------
+-- OPTIONALITY
+--------------------------------------------------------------------------------
+
+---------------- .: on Maybe ----------------
+-- Should generally roundtrip for produced JSON.
+-- Good sanity check that plugin does not over-report.
+
+data Opt1 = Opt1
+  { optField :: Maybe Int
+  }
+
+instance ToJSON Opt1 where
+  toJSON (Opt1 x) =
+    object
+      [ "optField" .= x
+      ]
+
+instance FromJSON Opt1 where
+  parseJSON = withObject "Opt1" $ \o -> do
+    optField <- o .: "optField"
+    pure Opt1 {..}
+
+--------------------------------------------------------------------------------
+-- FIELD COLLAPSE
+--------------------------------------------------------------------------------
+
+---------------- Two encoded fields become one ----------------
+
+data Merge1X = Merge1X
+  { mergeFirstName :: Text
+  , mergeLastName  :: Text
+  }
+
+instance ToJSON Merge1X where
+  toJSON (Merge1X f l) =
+    object
+      [ "firstName" .= f
+      , "lastName" .= l
+      ]
+
+instance FromJSON Merge1X where
+  parseJSON = withObject "Merge1X" $ \o -> do
+    name <- o .: "firstName"
+    pure (Merge1X name name)
+
+--------------------------------------------------------------------------------
+-- PHANTOM TYPES
+--------------------------------------------------------------------------------
+
+---------------- Happy phantom type ----------------
+
+newtype Phantom a = Phantom Int
+
+instance ToJSON (Phantom a) where
+  toJSON (Phantom x) =
+    object
+      [ "value" .= x
+      ]
+
+instance FromJSON (Phantom a) where
+  parseJSON = withObject "Phantom" $ \o ->
+    Phantom <$> o .: "value"
+
+--------------------------------------------------------------------------------
+-- HAPPY CASE
+--------------------------------------------------------------------------------
+
+---------------- Fully symmetric ----------------
+
+data Good =
+  Good
+    { g1 :: Int
+    , g2 :: Maybe Text
+    , g3 :: [Int]
+    }
+
+instance ToJSON Good where
+  toJSON (Good a b c) =
+    object
+      [ "g1" .= a
+      , "g2" .= b
+      , "g3" .= c
+      ]
+
+instance FromJSON Good where
+  parseJSON = withObject "Good" $ \o -> do
+    g1 <- o .: "g1"
+    g2 <- o .:? "g2"
+    g3 <- o .: "g3"
+    pure Good {..}
+
+--------------------------------------------------------------------------------
+-- EXTRA DECODER KEY
+--------------------------------------------------------------------------------
+
+---------------- Decoder requires key never emitted ----------------
+
+data L2 = L2
+  { l2 :: Int
+  }
+
+instance ToJSON L2 where
+  toJSON (L2 x) =
+    object
+      [ "l1" .= x
+      ]
+
+instance FromJSON L2 where
+  parseJSON = withObject "L2" $ \o -> do
+    l2 <- o .: "l1"
+    (_ :: Value) <- o .: "extra"
+    pure (L2 l2)
+
+--------------------------------------------------------------------------------
+-- EXTRA ENCODER KEY
+--------------------------------------------------------------------------------
+
+---------------- Encoder emits key never read ----------------
+
+data E2 = E2
+  { eField2 :: Int
+  }
+
+instance ToJSON E2 where
+  toJSON (E2 x) =
+    object
+      [ "eField" .= x
+      , "debug" .= ("test" :: Text)
+      ]
+
+instance FromJSON E2 where
+  parseJSON = withObject "E2" $ \o -> do
+    eField2 <- o .: "eField"
+    pure (E2 eField2)
+
+--------------------------------------------------------------------------------
+-- CONSTANT FIELD INVENTION
+--------------------------------------------------------------------------------
+
+---------------- Decoder invents field ----------------
+
+data F2 = F2
+  { f1x :: Int
+  , f2x :: Int
+  }
+
+instance ToJSON F2 where
+  toJSON (F2 a b) =
+    object
+      [ "f1" .= a
+      , "f2" .= b
+      ]
+
+instance FromJSON F2 where
+  parseJSON = withObject "F2" $ \o -> do
+    f1x <- o .: "f1"
+    pure (F2 f1x 999)
+
+--------------------------------------------------------------------------------
+-- SUM TYPE VALIDATION
+--------------------------------------------------------------------------------
+
+-------------------------- Constructor Tag Mismatch + Nested Type --------------------
+
+data UserInfo = UserInfo
+  { uiUserId   :: Int
+  , uiUserName :: Text
+  }
+
+instance ToJSON UserInfo where
+  toJSON (UserInfo uid name) =
+    object
+      [ "userId" .= uid
+      , "userName" .= name
+      ]
+
+instance FromJSON UserInfo where
+  parseJSON = withObject "UserInfo" $ \o -> do
+    uiUserId   <- o .: "userId"
+    uiUserName <- o .: "userName"
+    pure UserInfo {..}
+
+--------------------------------------------------------
+
+data SumNested
+  = User UserInfo
+  | Admin UserInfo
+
+instance ToJSON SumNested where
+  toJSON (User u) =
+    object
+      [ "tag" .= ("User" :: Text)
+      , "payload" .= u
+      ]
+
+  toJSON (Admin u) =
+    object
+      [ "tag" .= ("Admin" :: Text)
+      , "payload" .= u
+      ]
+
+instance FromJSON SumNested where
+  parseJSON = withObject "SumNested" $ \o -> do
+    tag <- o .: "tag"
+
+    case (tag :: Text) of
+      "USER"  -> User <$> o .: "payload"
+      "Admin" -> Admin <$> o .: "payload"
+      _       -> fail "invalid tag"
+
+---------------------------- Constructor Collapse ---------------------------
+
+data Address = Address
+  { city :: Text
+  , pinCode :: Int
+  }
+
+instance ToJSON Address where
+  toJSON (Address city pinCode) =
+    object
+      [ "city" .= city
+      , "pinCode" .= pinCode
+      ]
+
+instance FromJSON Address where
+  parseJSON = withObject "Address" $ \o -> do
+    city <- o .: "city"
+    pinCode <- o .: "pinCode"
+    pure Address {..}
+
+--------------------------------------------------------
+
+data CustomerType
+  = Home Address
+  | Office Address
+
+instance ToJSON CustomerType where
+  toJSON (Home a) =
+    object
+      [ "tag" .= ("Home" :: Text)
+      , "payload" .= a
+      ]
+
+  toJSON (Office a) =
+    object
+      [ "tag" .= ("Office" :: Text)
+      , "payload" .= a
+      ]
+
+instance FromJSON CustomerType where
+  parseJSON = withObject "CustomerType" $ \o -> do
+    payload <- o .: "payload"
+    pure (Home payload)
+
+----------------------------- Missing Constructor --------------------------
+
+data PaymentInfo = PaymentInfo
+  { amount :: Int
+  }
+
+instance ToJSON PaymentInfo where
+  toJSON (PaymentInfo amount) =
+    object [ "amount" .= amount ]
+
+instance FromJSON PaymentInfo where
+  parseJSON = withObject "PaymentInfo" $ \o -> do
+    amount <- o .: "amount"
+    pure PaymentInfo {..}
+
+--------------------------------------------------------
+
+data PaymentMethod
+  = Card PaymentInfo
+  | UPI PaymentInfo
+
+instance ToJSON PaymentMethod where
+  toJSON (Card p) =
+    object
+      [ "tag" .= ("Card" :: Text)
+      , "payload" .= p
+      ]
+
+  toJSON (UPI p) =
+    object
+      [ "tag" .= ("UPI" :: Text)
+      , "payload" .= p
+      ]
+
+instance FromJSON PaymentMethod where
+  parseJSON = withObject "PaymentMethod" $ \o -> do
+    tag <- o .: "tag"
+
+    case (tag :: Text) of
+      "Card" -> Card <$> o .: "payload"
+      _      -> fail "unsupported"
+
+--------------------------- Nested Field Mismatch Inside Sum Type ---------------------
+
+data Profile = Profile
+  { emailAddress :: Text
+  }
+
+instance ToJSON Profile where
+  toJSON (Profile e) =
+    object
+      [ "email_address" .= e
+      ]
+
+instance FromJSON Profile where
+  parseJSON = withObject "Profile" $ \o -> do
+    emailAddress <- o .: "emailAddress"
+    pure Profile {..}
+
+--------------------------------------------------------
+
+data Actor
+  = Customer Profile
+  | Merchant Profile
+
+instance ToJSON Actor where
+  toJSON (Customer p) =
+    object
+      [ "tag" .= ("Customer" :: Text)
+      , "payload" .= p
+      ]
+
+  toJSON (Merchant p) =
+    object
+      [ "tag" .= ("Merchant" :: Text)
+      , "payload" .= p
+      ]
+
+instance FromJSON Actor where
+  parseJSON = withObject "Actor" $ \o -> do
+    tag <- o .: "tag"
+    case (tag :: Text) of
+      "Customer" -> Customer <$> o .: "payload"
+      "Merchant" -> Merchant <$> o .: "payload"
+      _ -> fail "invalid"
+
+---------------------------------------------------
+-- GENERIC/CONTAINER TYPES TESTING
+---------------------------------------------------
+
+------------------------ Happy Generic Wrapper -----------------------
+
+data MyType a = MyType
+  { myValue :: a
+  }
+
+instance ToJSON a => ToJSON (MyType a) where
+  toJSON (MyType a) =
+    object
+      [ "myValue" .= a
+      ]
+
+instance FromJSON a => FromJSON (MyType a) where
+  parseJSON = withObject "MyType" $ \o -> do
+    myValue <- o .: "myValue"
+    pure MyType {..}
+
+------------------------ Generic Wrapper - Key Mismatch ----------------------
+
+data MyTypeBad a = MyTypeBad
+  { myBadValue :: a
+  }
+
+instance ToJSON a => ToJSON (MyTypeBad a) where
+  toJSON (MyTypeBad a) =
+    object
+      [ "value" .= a
+      ]
+
+instance FromJSON a => FromJSON (MyTypeBad a) where
+  parseJSON = withObject "MyTypeBad" $ \o -> do
+    myBadValue <- o .: "myValue"
+    pure MyTypeBad {..}
+
+-------------------------- Generic Sum Type ------------------------
+
+data Wrapped a
+  = MySuccess a
+  | Failure Text
+
+instance ToJSON a => ToJSON (Wrapped a) where
+  toJSON (MySuccess a) =
+    object
+      [ "tag" .= ("success" :: Text)
+      , "payload" .= a
+      ]
+
+  toJSON (Failure e) =
+    object
+      [ "tag" .= ("failure" :: Text)
+      , "payload" .= e
+      ]
+
+instance FromJSON a => FromJSON (Wrapped a) where
+  parseJSON = withObject "Wrapped" $ \o -> do
+    tag <- o .: "tag"
+
+    case (tag :: Text) of
+      "success" -> MySuccess <$> o .: "payload"
+      "failure" -> Failure <$> o .: "payload"
+      _         -> fail "invalid tag"
+
+-------------------------- Generic Sum Type - Constructor Mismatch ---------------------
+
+data WrappedBad a
+  = WrappedSuccess a
+  | WrappedFailure Text
+
+instance ToJSON a => ToJSON (WrappedBad a) where
+  toJSON (WrappedSuccess a) =
+    object
+      [ "tag" .= ("success" :: Text)
+      , "payload" .= a
+      ]
+
+  toJSON (WrappedFailure e) =
+    object
+      [ "tag" .= ("failure" :: Text)
+      , "payload" .= e
+      ]
+
+instance FromJSON a => FromJSON (WrappedBad a) where
+  parseJSON = withObject "WrappedBad" $ \o -> do
+    tag <- o .: "tag"
+
+    case (tag :: Text) of
+      "SUCCESS" -> WrappedSuccess <$> o .: "payload"
+      "failure" -> WrappedFailure <$> o .: "payload"
+      _         -> fail "invalid tag"
+
+------------------------- Nested Generic Type ---------------------
+
+data Box a = Box
+  { boxed :: a
+  }
+
+instance ToJSON a => ToJSON (Box a) where
+  toJSON (Box a) =
+    object
+      [ "boxed" .= a
+      ]
+
+instance FromJSON a => FromJSON (Box a) where
+  parseJSON = withObject "Box" $ \o -> do
+    boxed <- o .: "boxed"
+    pure Box {..}
+
+------------------------------------------------
+
+data ProfileBad = ProfileBad
+  { pbEmail :: Text
+  }
+
+instance ToJSON ProfileBad where
+  toJSON (ProfileBad e) =
+    object
+      [ "email_address" .= e
+      ]
+
+instance FromJSON ProfileBad where
+  parseJSON = withObject "ProfileBad" $ \o -> do
+    pbEmail <- o .: "email"
+    pure ProfileBad {..}
+
+------------------------------------------------
+
+type NestedGeneric = Box ProfileBad
+
+---------------------------- Higher-Kinded Container ------------------------
+
+data Pair a = Pair
+  { leftValue  :: a
+  , rightValue :: a
+  }
+
+instance ToJSON a => ToJSON (Pair a) where
+  toJSON (Pair l r) =
+    object
+      [ "left" .= l
+      , "right" .= r
+      ]
+
+instance FromJSON a => FromJSON (Pair a) where
+  parseJSON = withObject "Pair" $ \o -> do
+    leftValue  <- o .: "left"
+    rightValue <- o .: "right"
+    pure Pair {..}
+
+type PairInt = Pair Int
+type PairProfile = Pair ProfileBad
+
+--------------------------------------------------------
+-- GADT TESTING
+--------------------------------------------------------
+
+------------------------------ Constructor tag mismatch -----------------------------
+
+data GADT1 where
+  GInt  :: Int  -> GADT1
+  GText :: Text -> GADT1
+
+instance ToJSON GADT1 where
+  toJSON (GInt n) =
+    object ["tag" .= ("int" :: Text), "value" .= n]
+
+  toJSON (GText t) =
+    object ["tag" .= ("text" :: Text), "value" .= t]
+
+instance FromJSON GADT1 where
+  parseJSON = withObject "GADT1" $ \o -> do
+    tag <- o .: "tag"
+    case (tag :: Text) of
+      "INT"  -> GInt <$> o .: "value"
+      "text" -> GText <$> o .: "value"
+      _      -> fail "invalid"
+
+------------------------------ Constructor Collapse ---------------------------
+
+data GADT2 where
+  UserId  :: Int  -> GADT2
+  UserName :: Text -> GADT2
+
+instance ToJSON GADT2 where
+  toJSON (UserId n) =
+    object ["tag" .= ("id" :: Text), "value" .= n]
+
+  toJSON (UserName t) =
+    object ["tag" .= ("name" :: Text), "value" .= t]
+
+instance FromJSON GADT2 where
+  parseJSON = withObject "GADT2" $ \o -> do
+    v <- o .: "value"
+    pure (UserName v)
+
+--------------------------- Existential Information Loss -------------------
+
+data SomeValue where
+  SomeValue :: Show a => a -> SomeValue
+
+instance ToJSON SomeValue where
+  toJSON (SomeValue a) =
+    String (pack (show a))
+
+instance FromJSON SomeValue where
+  parseJSON =
+    withText "SomeValue" $ \t ->
+      pure (SomeValue t)
+
+--------------------------- Type-Indexed GADT -------------------------
+
+data Expr a where
+  LitInt  :: Int  -> Expr Int
+  LitText :: Text -> Expr Text
+
+instance ToJSON (Expr a) where
+  toJSON (LitInt n) =
+    object ["tag" .= ("int" :: Text), "value" .= n]
+
+  toJSON (LitText t) =
+    object ["tag" .= ("text" :: Text), "value" .= t]
+
+---------------------------------------------------------------------
+-- DEFAULT FUNCTIONALITY TESTING
+---------------------------------------------------------------------
+
+data Enc1 = Enc1
+  { encField :: Int
+  }
+
+instance ToJSON Enc1 where
+  toJSON (Enc1 x) =
+    object ["field1" .= x]
+
+  toEncoding (Enc1 x) =
+    pairs ("field2" .= x)
+
+instance FromJSON Enc1 where
+  parseJSON = withObject "Enc1" $ \o ->
+    Enc1 <$> o .: "field1"
+
+mkPayload :: Text -> Int -> Value
+mkPayload k v =
+  object [fromText k .= v]
+
+data Helper1 = Helper1
+  { h1 :: Int
+  }
+
+instance ToJSON Helper1 where
+  toJSON (Helper1 x) =
+    mkPayload "writtenField" x
+
+instance FromJSON Helper1 where
+  parseJSON = withObject "Helper1" $ \o ->
+    Helper1 <$> o .: "readField"
+
+parseField :: FromJSON a => Object -> Text -> Parser a
+parseField o k =
+  o .: fromText k
+
+data Helper2 = Helper2
+  { h2 :: Int
+  }
+
+instance ToJSON Helper2 where
+  toJSON (Helper2 x) =
+    object ["field" .= x]
+
+instance FromJSON Helper2 where
+  parseJSON = withObject "Helper2" $ \o ->
+    Helper2 <$> parseField o "differentField"
+
+data Generic1 = Generic1
+  { firstField :: Int
+  }
+  deriving Generic
+
+instance ToJSON Generic1 where
+  toJSON =
+    genericToJSON defaultOptions
+      { fieldLabelModifier = camelTo2 '_' }
+
+instance FromJSON Generic1 where
+  parseJSON =
+    genericParseJSON defaultOptions
+
+data Generic2 = Generic2
+  { customerId :: Int
+  }
+  deriving Generic
+
+instance ToJSON Generic2 where
+  toJSON =
+    genericToJSON defaultOptions
+      { fieldLabelModifier = camelTo2 '_' }
+
+instance FromJSON Generic2 where
+  parseJSON =
+    genericParseJSON defaultOptions
+      { fieldLabelModifier = map toLower }
+
+data Opt2 = Opt2
+  { maybeField :: Maybe Int
+  }
+  deriving Generic
+
+instance ToJSON Opt2 where
+  toJSON =
+    genericToJSON defaultOptions
+      { omitNothingFields = True }
+
+instance FromJSON Opt2 where
+  parseJSON =
+    genericParseJSON defaultOptions
+
+data WT = WT
+  { wtField :: Int
+  }
+
+instance ToJSON WT where
+  toJSON (WT x) =
+    object ["wtField" .= x]
+
+instance FromJSON WT where
+  parseJSON =
+    withText "WT" $ \_ ->
+      pure (WT 0)
+
+data NumWrapper =
+  NumWrapper Int
+
+instance ToJSON NumWrapper where
+  toJSON (NumWrapper x) =
+    object ["value" .= x]
+
+instance FromJSON NumWrapper where
+  parseJSON =
+    withScientific "NumWrapper" $
+      pure . NumWrapper . round
+
+data Weird1 =
+  Weird1 Int Text
+
+instance ToJSON Weird1 where
+  toJSON (Weird1 a b) =
+    toJSON [toJSON a, toJSON b]
+
+instance FromJSON Weird1 where
+  parseJSON =
+    withObject "Weird1" $ \o -> do
+      a <- o .: "a"
+      b <- o .: "b"
+      pure (Weird1 a b)
+
+data Weird2 =
+  Weird2 Int Text
+
+instance ToJSON Weird2 where
+  toJSON (Weird2 a b) =
+    object
+      [ "a" .= a
+      , "b" .= b
+      ]
+
+instance FromJSON Weird2 where
+  parseJSON =
+    withArray "Weird2" $ \v ->
+      Weird2
+        <$> parseJSON (v V.! 0)
+        <*> parseJSON (v V.! 1)
+
+mkUser :: Int -> Value
+mkUser x =
+  object ["user_id" .= x]
+
+data HelperNested =
+  HelperNested Int
+
+instance ToJSON HelperNested where
+  toJSON (HelperNested x) =
+    mkUser x
+
+instance FromJSON HelperNested where
+  parseJSON = withObject "HelperNested" $ \o ->
+    HelperNested <$> o .: "userId"
+
+data Serialized =
+  Serialized
+  { sField :: Int
+  }
+
+instance ToJSON Serialized where
+  toJSON (Serialized x) =
+    String (pack (show x))
+
+instance FromJSON Serialized where
+  parseJSON =
+    withText "Serialized" $
+      pure . Serialized . read . unpack
+
+mkTagged :: Text -> Value -> Value
+mkTagged tag payload =
+  object
+    [ "tag" .= tag
+    , "payload" .= payload
+    ]
+
+data HiddenTag
+  = HiddenA Int
+  | HiddenB Int
+
+instance ToJSON HiddenTag where
+  toJSON (HiddenA x) =
+    mkTagged "A" (toJSON x)
+
+  toJSON (HiddenB x) =
+    mkTagged "B" (toJSON x)
+
+instance FromJSON HiddenTag where
+  parseJSON = withObject "HiddenTag" $ \o -> do
+    tag <- o .: "tag"
+    case (tag :: Text) of
+      "AA" -> HiddenA <$> o .: "payload"
+      "B"  -> HiddenB <$> o .: "payload"
+      _    -> fail "invalid"
+
+data Tree
+  = Leaf Int
+  | Node Tree Tree
+
+instance ToJSON Tree where
+  toJSON (Leaf x) =
+    object
+      [ "tag" .= ("leaf" :: Text)
+      , "value" .= x
+      ]
+
+  toJSON (Node l r) =
+    object
+      [ "tag" .= ("node" :: Text)
+      , "left" .= l
+      , "right" .= r
+      ]
+
+instance FromJSON Tree where
+  parseJSON = withObject "Tree" $ \o -> do
+    tag <- o .: "tag"
+
+    case (tag :: Text) of
+      "LEAF" ->
+        Leaf <$> o .: "value"
+
+      "node" ->
+        Node <$> o .: "left"
+             <*> o .: "right"
+
+      _ ->
+        fail "invalid"
+
+------------------------------------------------------------
+-- REAL LIFE SCENARIOS
+------------------------------------------------------------
+
+data NormalizeEmail = NormalizeEmail
+  { email :: Text
+  }
+
+instance ToJSON NormalizeEmail where
+  toJSON (NormalizeEmail e) =
+    object ["email" .= e]
+
+instance FromJSON NormalizeEmail where
+  parseJSON = withObject "NormalizeEmail" $ \o -> do
+    email <- T.toLower <$> o .: "email"
+    pure NormalizeEmail {..}
+
+data DefaultCountry = DefaultCountry
+  { country :: Text
+  }
+
+instance ToJSON DefaultCountry where
+  toJSON (DefaultCountry c) =
+    object ["country" .= c]
+
+instance FromJSON DefaultCountry where
+  parseJSON = withObject "DefaultCountry" $ \o -> do
+    country <- fromMaybe "IND" <$> o .:? "country"
+    pure DefaultCountry {..}
+
+data ProdPaymentStatus
+  = ProdSuccess
+  | ProdFailure
+  | ProdPending
+
+instance ToJSON ProdPaymentStatus where
+  toJSON ProdSuccess = String "SUCCESS"
+  toJSON ProdFailure = String "FAILURE"
+  toJSON ProdPending = String "PENDING"
+
+instance FromJSON ProdPaymentStatus where
+  parseJSON = withText "ProdPaymentStatus" $ \t ->
+    pure $
+      case t of
+        "SUCCESS" -> ProdSuccess
+        "FAILURE" -> ProdFailure
+        _         -> ProdPending
+
+data ProdAmount =
+  ProdAmount
+    { prodAmount :: Double
+    }
+
+instance ToJSON ProdAmount where
+  toJSON (ProdAmount x) =
+    object ["amount" .= x]
+
+instance FromJSON ProdAmount where
+  parseJSON = withObject "Amount" $ \o -> do
+    d <- (o .: "amount" :: Parser Double)
+    pure $ ProdAmount (fromIntegral (round d :: Int))
+
+data ProdCustomer = ProdCustomer
+  { prodMobile :: Text
+  }
+
+instance ToJSON ProdCustomer where
+  toJSON (ProdCustomer m) =
+    object ["mobile" .= m]
+
+instance FromJSON ProdCustomer where
+  parseJSON = withObject "Customer" $ \o -> do
+    prodMobile <- (("MASKED-" :: Text) <>) <$> (o .: "mobile" :: Parser Text)
+    pure ProdCustomer {..}
+
+data Payload = Payload
+  { body :: Text
+  }
+
+instance ToJSON Payload where
+  toJSON (Payload b) =
+    object ["body" .= b]
+
+decodeBase64Dummy :: Text -> Text
+decodeBase64Dummy = ("decoded:" <>)
+
+instance FromJSON Payload where
+  parseJSON = withObject "Payload" $ \o -> do
+    body <- decodeBase64Dummy <$> o .: "body"
+    pure Payload {..}
+
+data State
+  = Enabled
+  | Disabled
+
+instance ToJSON State where
+  toJSON Enabled = String "ENABLED"
+  toJSON Disabled = String "DISABLED"
+
+instance FromJSON State where
+  parseJSON = withText "State" $ \t ->
+    pure $
+      case t of
+        "ENABLED" -> Enabled
+        "enabled" -> Enabled
+        _         -> Disabled
+
+data ProdUser = ProdUser
+  { prodFirstName :: Text
+  , prodLastName :: Text
+  }
+
+instance ToJSON ProdUser where
+  toJSON ProdUser{..} =
+    object
+      [ "full_name" .= (prodFirstName <> " " <> prodLastName)
+      ]
+
+splitName :: Text -> (Text, Text)
+splitName t =
+  case T.words t of
+    []       -> ("", "")
+    [x]      -> (x, "")
+    (x : xs) -> (x, T.unwords xs)
+
+instance FromJSON ProdUser where
+  parseJSON = withObject "User" $ \o -> do
+    fullName <- o .: "full_name"
+    let (f,l) = splitName fullName
+    pure (ProdUser f l)
+
+data ProdMethod
+  = ProdCard
+  | ProdUPI
+  | ProdNetBanking
+
+instance ToJSON ProdMethod where
+  toJSON ProdCard = String "CARD"
+  toJSON ProdUPI = String "UPI"
+  toJSON ProdNetBanking = String "NB"
+
+instance FromJSON ProdMethod where
+  parseJSON = withText "Method" $ \t ->
+    pure $
+      case t of
+        "CARD" -> ProdCard
+        "UPI" -> ProdUPI
+        _ -> ProdCard
+
+data GenericUserProd =
+  GenericUserProd
+    { genericCustomerId :: Int
+    , genericMerchantId :: Int
+    } deriving Generic
+
+instance ToJSON GenericUserProd where
+  toJSON =
+    genericToJSON defaultOptions
+      { fieldLabelModifier = camelTo2 '_'
+      }
+
+instance FromJSON GenericUserProd where
+  parseJSON =
+    genericParseJSON defaultOptions
+
+newtype Secret a = Secret a
+
+data CustomerPIIProd =
+  CustomerPIIProd
+    { piiMobile :: Secret Text
+    }
+
+instance ToJSON CustomerPIIProd where
+  toJSON (CustomerPIIProd (Secret m)) =
+    object ["mobile" .= m]
+
+instance FromJSON CustomerPIIProd where
+  parseJSON = withObject "CustomerPII" $ \o -> do
+    piiMobile <- Secret . (("encrypted:::" :: Text) <>) <$> o .: "mobile"
+    pure CustomerPIIProd {..}
+
+---------------- String field value (not a tag) ----------------
+
+newtype Money = Money Double
+
+instance ToJSON Money where
+  toJSON (Money d) = if True then object ["version" .= String "v1", "value" .= d] else Number (fromRational (toRational d * 10000))
+
+instance FromJSON Money where
+  parseJSON v = parseNewFormat v <|> parseOldFormat v
+    where
+      parseNewFormat = withObject "Money" $ \obj -> do
+        version <- obj .: "version"
+        case (version :: Value) of
+          String "v1" -> Money <$> obj .: "value"
+          _           -> fail "Unsupported version"
+      parseOldFormat = withScientific "Money" $ \num -> pure (Money (realToFrac num / 10000))
+
+---------------- Direct pattern match decoder ----------------
+
+data FlowConfigSource = GPMF
+
+instance ToJSON FlowConfigSource where
+  toJSON GPMF = String "GPMF"
+
+instance FromJSON FlowConfigSource where
+  parseJSON (String "GPMF") = pure GPMF
+  parseJSON _ = fail "Invalid FlowConfigSource value"
+
+---------------- Guard-based string matching decoder ----------------
+
+data UpTo = UpToInt Int | UpToInfinity
+
+instance ToJSON UpTo where
+  toJSON (UpToInt n) = Number (fromIntegral n)
+  toJSON UpToInfinity = String "INFINITY"
+
+instance FromJSON UpTo where
+  parseJSON (Number n) = pure (UpToInt (floor n))
+  parseJSON (String s) | T.toUpper s == "INFINITY" = pure UpToInfinity
+  parseJSON _ = fail "upTo must be a number or 'INFINITY'"
+
+---------------- Fallback key via <|> ----------------
+
+data WalletAccount = WalletAccount
+  { waId :: Text
+  , waVersion :: Int
+  , authenticationDetails :: Maybe Text
+  }
+
+instance ToJSON WalletAccount where
+  toJSON WalletAccount {..} = object
+    [ "id" .= waId
+    , "version" .= waVersion
+    , "authDetails" .= authenticationDetails
+    ]
+
+instance FromJSON WalletAccount where
+  parseJSON = withObject "walletAccount" $ \o -> do
+    waId <- o .: "id"
+    waVersion <- o .: "version"
+    authenticationDetails <- (o .:? "authDetails") <|> (o .:? "authenticationDetails")
+    pure WalletAccount {..}
+
+---------------- Lambda in encoder (nested object keys) ----------------
+
+data OlMonitoringData = OlMonitoringData
+  { olStatic :: [Text]
+  , olScoreMap :: KM.KeyMap Double
+  , olPrefix :: Text
+  }
+
+instance ToJSON OlMonitoringData where
+  toJSON (OlMonitoringData statics scoreMap prefix) =
+    object
+      [ "staticDimensions" .= statics
+      , "variableDimensionScoreMap" .= map (\(key, value) -> object ["variableDimension" .= toJSON key, "score" .= value]) (KM.toList scoreMap)
+      , "prefix" .= prefix
+      ]
+
+instance FromJSON OlMonitoringData where
+  parseJSON = withObject "OlMonitoringData" $ \o -> do
+    olStatic <- o .: "staticDimensions"
+    scoreMapList <- o .: "variableDimensionScoreMap" :: Parser [Value]
+    olPrefix <- o .: "prefix"
+    pure (OlMonitoringData olStatic KM.empty olPrefix)
+
+---------------- Non-standard encoder (toJSON delegation) ----------------
+
+data CellSelectorSuccessResponse = CellSelectorSuccessResponse
+  { cellStatus :: Text
+  , cellSelector :: Maybe Text
+  }
+
+instance ToJSON CellSelectorSuccessResponse where
+  toJSON (CellSelectorSuccessResponse s c) = object ["status" .= s, "cell_selector" .= c]
+
+instance FromJSON CellSelectorSuccessResponse where
+  parseJSON = withObject "CellSelectorSuccessResponse" $ \o -> do
+    cellStatus <- o .: "status"
+    cellSelector <- o .:? "cell_selector"
+    pure CellSelectorSuccessResponse {..}
+
+data GetCellSelectorResponse
+  = GetCellSelectorSuccessResponse CellSelectorSuccessResponse
+  | GetCellSelectorFailureResponse CellSelectorSuccessResponse
+
+instance ToJSON GetCellSelectorResponse where
+  toJSON (GetCellSelectorSuccessResponse sr) = toJSON sr
+  toJSON (GetCellSelectorFailureResponse fr) = toJSON fr
+
+instance FromJSON GetCellSelectorResponse where
+  parseJSON = withObject "GetCellSelectorResponse" $ \o -> do
+    status <- o .: "status"
+    pure (GetCellSelectorSuccessResponse (CellSelectorSuccessResponse status Nothing))
+
+---------------- Non-standard encoder (Object insert) ----------------
+
+data ConfigValidationRule = ConfigValidationRule
+  { ruleField :: Text
+  , ruleOp :: Text
+  }
+
+instance FromJSON ConfigValidationRule where
+  parseJSON = withObject "ConfigValidationRule" $ \v -> do
+    ruleField <- v .: "field"
+    ruleOp <- v .: "operation"
+    pure ConfigValidationRule {..}
+
+instance ToJSON ConfigValidationRule where
+  toJSON (ConfigValidationRule fld op) =
+    Object (KM.insert (AK.fromText "field") (toJSON fld) (KM.singleton (AK.fromText "operation") (toJSON op)))
+
+--------------------------------------------------------------------------------
+-- ADDITIONAL FALSE POSITIVE GUARD CASES (from euler-db / euler-webservice)
+--------------------------------------------------------------------------------
+
+---------------- JuspayEvent: key name mismatch (class vs className) ----------------
+
+data JuspayEvent = JuspayEvent
+  { jeClassName :: Text
+  , jeEventData :: Value
+  }
+
+instance FromJSON JuspayEvent where
+  parseJSON = withObject "JuspayEvent" $ \o -> do
+    jeClassName <- o .: "className"
+    jeEventData <- o .: "data"
+    pure JuspayEvent {..}
+
+instance ToJSON JuspayEvent where
+  toJSON JuspayEvent {..} = object
+    [ "class" .= jeClassName
+    , "data" .= jeEventData
+    ]
+
+---------------- WalletAccount: encoder key missing from decoder (lastRefreshed) ----------------
+
+data WalletAccountFull = WalletAccountFull
+  { wafId :: Text
+  , wafVersion :: Int
+  , wafAuthDetails :: Maybe Text
+  , wafLastRefreshed :: Maybe Text
+  }
+
+instance ToJSON WalletAccountFull where
+  toJSON WalletAccountFull {..} = object
+    [ "id" .= wafId
+    , "version" .= wafVersion
+    , "authDetails" .= wafAuthDetails
+    , "lastRefreshed" .= wafLastRefreshed
+    ]
+
+instance FromJSON WalletAccountFull where
+  parseJSON = withObject "walletAccount" $ \o -> do
+    wafId <- o .: "id"
+    wafVersion <- o .: "version"
+    wafAuthDetails <- (o .:? "authDetails") <|> (o .:? "authenticationDetails")
+    wafLastRefreshed <- o .:? "dateCreated"
+    pure WalletAccountFull {..}
+
+---------------- Multiple <|> fallback chains ----------------
+
+data MultiFallback = MultiFallback
+  { mfKey :: Text
+  , mfValue :: Maybe Int
+  }
+
+instance ToJSON MultiFallback where
+  toJSON MultiFallback {..} = object
+    [ "key" .= mfKey
+    , "value" .= mfValue
+    ]
+
+instance FromJSON MultiFallback where
+  parseJSON = withObject "MultiFallback" $ \o -> do
+    mfKey <- o .: "key"
+    mfValue <- (o .:? "value") <|> (o .:? "val") <|> (o .:? "v")
+    pure MultiFallback {..}
+
+---------------- liftA2 <|> with nested object access ----------------
+
+data LiftA2Fallback = LiftA2Fallback
+  { la2Field :: Maybe Text
+  }
+
+instance ToJSON LiftA2Fallback where
+  toJSON LiftA2Fallback {..} = object
+    [ "field" .= la2Field
+    ]
+
+instance FromJSON LiftA2Fallback where
+  parseJSON = withObject "LiftA2Fallback" $ \o -> do
+    la2Field <- liftA2 (<|>) (o .:? "field") (o .:? "oldField")
+    pure LiftA2Fallback {..}
+
+---------------- String field value in if-then-else (Money variant) ----------------
+
+newtype MoneyV2 = MoneyV2 Double
+
+instance ToJSON MoneyV2 where
+  toJSON (MoneyV2 d) =
+    if d > 0
+      then object ["version" .= String "v2", "amount" .= d]
+      else object ["version" .= String "v1", "amount" .= d]
+
+instance FromJSON MoneyV2 where
+  parseJSON = withObject "MoneyV2" $ \obj -> do
+    version <- obj .: "version"
+    case (version :: Value) of
+      String "v1" -> MoneyV2 <$> obj .: "amount"
+      String "v2" -> MoneyV2 <$> obj .: "amount"
+      _           -> fail "Unsupported version"
+
+---------------- Guard with multiple string comparisons ----------------
+
+data StatusV2 = StatusActive | StatusInactive | StatusPending
+
+instance ToJSON StatusV2 where
+  toJSON StatusActive   = String "ACTIVE"
+  toJSON StatusInactive = String "INACTIVE"
+  toJSON StatusPending  = String "PENDING"
+
+instance FromJSON StatusV2 where
+  parseJSON (String s)
+    | T.toUpper s == "ACTIVE"   = pure StatusActive
+    | T.toUpper s == "INACTIVE" = pure StatusInactive
+    | T.toUpper s == "PENDING"  = pure StatusPending
+  parseJSON _ = fail "Invalid status"
+
+---------------- Direct pattern match with Number constructor ----------------
+
+data NumericEnum = NumOne | NumTwo
+
+instance ToJSON NumericEnum where
+  toJSON NumOne = Number 1
+  toJSON NumTwo = Number 2
+
+instance FromJSON NumericEnum where
+  parseJSON (Number 1) = pure NumOne
+  parseJSON (Number 2) = pure NumTwo
+  parseJSON _ = fail "Invalid NumericEnum"
+
+---------------- toJSON delegation to nested type (sum type) ----------------
+
+data InnerType = InnerType
+  { innerField :: Text
+  , innerValue :: Int
+  }
+
+instance ToJSON InnerType where
+  toJSON InnerType {..} = object
+    [ "field" .= innerField
+    , "value" .= innerValue
+    ]
+
+instance FromJSON InnerType where
+  parseJSON = withObject "InnerType" $ \o -> do
+    innerField <- o .: "field"
+    innerValue <- o .: "value"
+    pure InnerType {..}
+
+data WrapperType
+  = WrapperA InnerType
+  | WrapperB InnerType
+
+instance ToJSON WrapperType where
+  toJSON (WrapperA inner) = toJSON inner
+  toJSON (WrapperB inner) = toJSON inner
+
+instance FromJSON WrapperType where
+  parseJSON = withObject "WrapperType" $ \o -> do
+    f <- o .: "field"
+    pure (WrapperA (InnerType f 0))
+
+---------------- Object construction via HashMap insertion ----------------
+
+data HashMapEncode = HashMapEncode
+  { hmeKey :: Text
+  , hmeVal :: Int
+  }
+
+instance FromJSON HashMapEncode where
+  parseJSON = withObject "HashMapEncode" $ \o -> do
+    hmeKey <- o .: "key"
+    hmeVal <- o .: "val"
+    pure HashMapEncode {..}
+
+instance ToJSON HashMapEncode where
+  toJSON (HashMapEncode k v) =
+    Object (KM.insert (AK.fromText "key") (toJSON k) (KM.singleton (AK.fromText "val") (toJSON v)))
+
+---------------- Conditional encoder with nested object in lambda ----------------
+
+data ReportData = ReportData
+  { rdItems :: [Text]
+  , rdMetadata :: KM.KeyMap Text
+  }
+
+instance ToJSON ReportData where
+  toJSON (ReportData items meta) = object
+    [ "items" .= items
+    , "metadata" .= map (\(k, v) -> object ["name" .= toJSON k, "value" .= v]) (KM.toList meta)
+    ]
+
+instance FromJSON ReportData where
+  parseJSON = withObject "ReportData" $ \o -> do
+    rdItems <- o .: "items"
+    metaList <- o .: "metadata" :: Parser [Value]
+    pure (ReportData rdItems KM.empty)
+
+---------------- Encoder uses object in list comprehension ----------------
+
+data BulkResponse = BulkResponse
+  { brResults :: [Text]
+  }
+
+instance ToJSON BulkResponse where
+  toJSON (BulkResponse results) = object
+    [ "results" .= results
+    , "meta" .= [ object ["index" .= i, "value" .= r] | (i, r) <- zip [0 :: Int ..] results ]
+    ]
+
+instance FromJSON BulkResponse where
+  parseJSON = withObject "BulkResponse" $ \o -> do
+    rdResults <- o .: "results"
+    pure (BulkResponse rdResults)
+
+---------------- Non-standard encoder buried in let/case ----------------
+-- Mirrors real ConfigValidationRule from euler-webservice where the
+-- Object construction is inside a let ... in case ... of wrapper.
+
+data ConfigValidationRuleLet = ConfigValidationRuleLet
+  { cvrlField :: Text
+  , cvrlOp :: Text
+  }
+
+instance FromJSON ConfigValidationRuleLet where
+  parseJSON = withObject "ConfigValidationRuleLet" $ \v -> do
+    cvrlField <- v .: "field"
+    cvrlOp <- v .: "operation"
+    pure ConfigValidationRuleLet {..}
+
+instance ToJSON ConfigValidationRuleLet where
+  toJSON (ConfigValidationRuleLet fld op) =
+    let opJson = toJSON op
+    in case opJson of
+      Object o -> Object (KM.insert (AK.fromText "field") (toJSON fld) o)
+      _        -> error "Internal error: toJSON did not return an object"
+
+---------------- toJSON delegation buried in let ----------------
+
+data WrappedDelegated = WrappedDelegated
+  { wdInner :: InnerType
+  }
+
+instance ToJSON WrappedDelegated where
+  toJSON (WrappedDelegated inner) =
+    let json = toJSON inner
+    in json
+
+instance FromJSON WrappedDelegated where
+  parseJSON = withObject "WrappedDelegated" $ \o -> do
+    f <- o .: "field"
+    pure (WrappedDelegated (InnerType f 0))
+
+---------------- Conditional key via maybe + lambda ----------------
+
+data PricingTier = PricingTier
+  { ptUpTo :: Text
+  , ptUnitAmount :: Double
+  , ptFlatFee :: Maybe Double
+  }
+
+instance ToJSON PricingTier where
+  toJSON tier = object $
+    [ "up_to" .= ptUpTo tier
+    , "unit_amount" .= ptUnitAmount tier
+    ] ++ maybe [] (\fee -> ["flat_fee" .= fee]) (ptFlatFee tier)
+
+instance FromJSON PricingTier where
+  parseJSON = withObject "PricingTier" $ \o -> do
+    ptUpTo <- o .: "up_to"
+    ptUnitAmount <- o .: "unit_amount"
+    ptFlatFee <- o .:? "flat_fee"
+    pure PricingTier {..}
+
+---------------- Where-clause helper functions ----------------
+
+data TokenCacheData = TokenCacheData
+  { tcdResourceType :: Text
+  , tcdTokenMaxUsage :: Int
+  , tcdSource :: Maybe Text
+  , tcdUsageCount :: Maybe Int
+  }
+
+instance ToJSON TokenCacheData where
+  toJSON TokenCacheData{..} = object $
+    [ "resourceType" .= tcdResourceType
+    , "tokenMaxUsage" .= tcdTokenMaxUsage
+    ] ++ source' tcdSource
+      ++ usageCount' tcdUsageCount
+    where
+      source' (Just v) = ["source" .= v]
+      source' Nothing  = []
+      usageCount' (Just v) = ["usageCount" .= v]
+      usageCount' Nothing  = []
+
+instance FromJSON TokenCacheData where
+  parseJSON = withObject "TokenCacheData" $ \o -> do
+    tcdResourceType <- o .: "resourceType"
+    tcdTokenMaxUsage <- o .: "tokenMaxUsage"
+    tcdSource <- o .:? "source"
+    tcdUsageCount <- o .:? "usageCount"
+    pure TokenCacheData {..}
+
+---------------- Decoder delegation via parseJSON ----------------
+
+data InnerSerialized = InnerSerialized { innerJwt :: Text }
+
+instance ToJSON InnerSerialized where
+  toJSON InnerSerialized {..} = object ["JWT" .= innerJwt]
+
+instance FromJSON InnerSerialized where
+  parseJSON = withObject "InnerSerialized" $ \o -> do
+    innerJwt <- o .: "jwt" <|> o .: "JWT"
+    pure InnerSerialized {..}
+
+data InnerDeserialized = InnerDeserialized
+  { innerHeader :: Text
+  , innerPayload :: Text
+  }
+
+instance ToJSON InnerDeserialized where
+  toJSON InnerDeserialized {..} = object ["header" .= innerHeader, "payload" .= innerPayload]
+
+instance FromJSON InnerDeserialized where
+  parseJSON = withObject "InnerDeserialized" $ \o -> do
+    innerHeader <- o .: "header"
+    innerPayload <- o .: "payload"
+    pure InnerDeserialized {..}
+
+data DelegatedBody
+  = DelegatedSerialized InnerSerialized
+  | DelegatedDeserialized InnerDeserialized
+
+instance ToJSON DelegatedBody where
+  toJSON (DelegatedSerialized body) = toJSON body
+  toJSON (DelegatedDeserialized body) = toJSON body
+
+instance FromJSON DelegatedBody where
+  parseJSON obj = (DelegatedDeserialized <$> parseJSON obj) <|> (DelegatedSerialized <$> parseJSON obj)
+
+---------------- Lambda-case decoder pattern (\case) ----------------
+
+data GatewayTypeTest = NetworkTest | GatewayTest
+
+instance ToJSON GatewayTypeTest where
+  toJSON NetworkTest = String "NETWORK"
+  toJSON GatewayTest = String "GATEWAY"
+
+instance FromJSON GatewayTypeTest where
+  parseJSON = withText "GatewayTypeTest" $ \case
+    "NETWORK" -> pure NetworkTest
+    "GATEWAY" -> pure GatewayTest
+    other     -> fail $ "Invalid GatewayTypeTest: " <> unpack other
+
+---------------- Identical genericToJSON options with lambda [TRUE POSITIVE if keys differ] ----------------
+
+data ApiAccountTest = ApiAccountTest
+  { atMerchantId :: Text
+  , atMerchantZip :: Maybe Text
+  } deriving (Generic)
+
+instance ToJSON ApiAccountTest where
+  toJSON = A.genericToJSON A.defaultOptions { A.fieldLabelModifier = \x -> if x == "atMerchantZip" then "zip" else x}
+
+instance FromJSON ApiAccountTest where
+  parseJSON = A.genericParseJSON A.defaultOptions { A.fieldLabelModifier = \x -> if x == "atMerchantZip" then "zip" else x}
+
+---------------- TH deriveToJSON encoder + hand-written decoder [NO ERROR: TH encoder keys unknown] ----------------
+
+data ThEncManualDec = ThEncManualDec
+  { tedField1 :: Text
+  , tedField2 :: Maybe Int
+  } deriving (Generic)
+
+$(deriveToJSON A.defaultOptions { A.fieldLabelModifier = \x -> if x == "tedField1" then "field_one" else x } ''ThEncManualDec)
+
+instance FromJSON ThEncManualDec where
+  parseJSON = withObject "ThEncManualDec" $ \v -> ThEncManualDec
+    <$> v .: "field_one"
+    <*> v .:? "field2_mismatched"
+
+---------------- TH deriveFromJSON decoder + hand-written encoder [NO ERROR: TH decoder keys unknown] ----------------
+
+data ManualEncThDec = ManualEncThDec
+  { medField1 :: Text
+  , medField2 :: Maybe Int
+  } deriving (Generic)
+
+instance ToJSON ManualEncThDec where
+  toJSON = A.genericToJSON A.defaultOptions { A.fieldLabelModifier = \x -> if x == "medField1" then "field_one" else x }
+
+$(deriveFromJSON A.defaultOptions { A.fieldLabelModifier = \x -> if x == "medField1" then "field_one" else x } ''ManualEncThDec)
+
+---------------- AKM.lookup (AK.fromText "key") decoder pattern [NO ERROR: keys match] ----------------
+
+data AkmLookupMatch = AkmLookupMatch
+  { almPoints :: Text
+  , almPockets :: Maybe [Text]
+  }
+
+instance ToJSON AkmLookupMatch where
+  toJSON alm = object $
+    ("points" .= almPoints alm) :
+    case almPockets alm of
+      Nothing -> []
+      Just p  -> ["pockets" .= p]
+
+instance FromJSON AkmLookupMatch where
+  parseJSON = withObject "AkmLookupMatch" $ \o -> do
+    pts <- case KM.lookup (AK.fromText "points") o of
+      Just v  -> parseJSON v
+      Nothing -> fail "AkmLookupMatch: missing points field"
+    pkts <- case KM.lookup (AK.fromText "pockets") o of
+      Nothing -> pure Nothing
+      Just v  -> parseJSON v
+    pure AkmLookupMatch { almPoints = pts, almPockets = pkts }
+
+---------------- AKM.lookup decoder with key mismatch [TRUE POSITIVE: keys mismatch] ----------------
+
+data AkmLookupMismatch = AkmLookupMismatch
+  { alm2Points :: Text
+  , alm2Pockets :: Maybe [Text]
+  }
+
+instance ToJSON AkmLookupMismatch where
+  toJSON alm2 = object $
+    ("points" .= alm2Points alm2) :
+    case alm2Pockets alm2 of
+      Nothing -> []
+      Just p  -> ["pockets" .= p]
+
+instance FromJSON AkmLookupMismatch where
+  parseJSON = withObject "AkmLookupMismatch" $ \o -> do
+    pts <- case KM.lookup (AK.fromText "points") o of
+      Just v  -> parseJSON v
+      Nothing -> fail "AkmLookupMismatch: missing points field"
+    pkts <- case KM.lookup (AK.fromText "pockets_extra") o of
+      Nothing -> pure Nothing
+      Just v  -> parseJSON v
+    pure AkmLookupMismatch { alm2Points = pts, alm2Pockets = pkts }
+
+---------------- defaultEncode/defaultDecode generic with defaultOptions [NO ERROR: field labels match] ----------------
+
+data DefaultOptsMatch = DefaultOptsMatch
+  { domField1 :: Text
+  , domField2 :: Maybe Int
+  } deriving (Generic)
+
+instance ToJSON DefaultOptsMatch where
+  toJSON = A.genericToJSON A.defaultOptions
+
+instance FromJSON DefaultOptsMatch where
+  parseJSON = A.genericParseJSON A.defaultOptions
+
+---------------- defaultEncode generic + hand-written decoder with mismatched keys [TRUE POSITIVE] ----------------
+
+data DefaultOptsMismatch = DefaultOptsMismatch
+  { dommField1 :: Text
+  , dommField2 :: Maybe Int
+  , dommField3 :: Maybe Text
+  } deriving (Generic)
+
+instance ToJSON DefaultOptsMismatch where
+  toJSON = A.genericToJSON A.defaultOptions
+
+instance FromJSON DefaultOptsMismatch where
+  parseJSON = withObject "DefaultOptsMismatch" $ \v -> DefaultOptsMismatch
+    <$> v .: "field_one"
+    <*> v .:? "field2_camel"
+    <*> v .:? "field3_camel"
+
+---------------- defaultEncode (no args) + hand-written decoder with mismatched keys [TRUE POSITIVE] ----------------
+
+data DefaultEncodeMismatch = DefaultEncodeMismatch
+  { demType :: Text
+  , demValue :: Maybe Int
+  , demBrandName :: Maybe Text
+  } deriving (Generic)
+
+instance ToJSON DefaultEncodeMismatch where
+  toJSON = A.genericToJSON A.defaultOptions
+
+instance FromJSON DefaultEncodeMismatch where
+  parseJSON = withObject "DefaultEncodeMismatch" $ \v -> do
+    ty <- v .: "type"
+    val <- v .:? "value"
+    bn <- v .:? "brandName"
+    pure DefaultEncodeMismatch { demType = ty, demValue = val, demBrandName = bn }
+
+---------------- Tuple-syntax encoder + KeyMap.lookup decoder [TRUE POSITIVE: errorType written but not read] ----------------
+
+data TupleEncMatch = ExpectedArray2 | ExpectedObject2 | CouldNotParse2 Text
+
+instance ToJSON TupleEncMatch where
+  toJSON ExpectedArray2  = object [("errorType", String "TupleEncMatch"), ("reason", String "ExpectedArray2")]
+  toJSON ExpectedObject2 = object [("errorType", String "TupleEncMatch"), ("reason", String "ExpectedObject2")]
+  toJSON (CouldNotParse2 r) = object [("errorType", String "TupleEncMatch"), ("reason", String $ "CouldNotParse2: " <> r)]
+
+instance FromJSON TupleEncMatch where
+  parseJSON val = pure $ case val of
+    Object km -> case KM.lookup (AK.fromText "reason") km of
+      Just (String "ExpectedArray2") -> ExpectedArray2
+      Just (String "ExpectedObject2") -> ExpectedObject2
+      Just (String res) -> CouldNotParse2 $ T.replace "CouldNotParse2: " "" res
+      _ -> CouldNotParse2 "CouldNotParse2"
+    _ -> CouldNotParse2 "CouldNotParse2"
+
+---------------- Tuple-syntax encoder with mismatched decoder keys [TRUE POSITIVE] ----------------
+
+data TupleEncMismatch = ExpectedArray3 | ExpectedObject3 | CouldNotParse3 Text
+
+instance ToJSON TupleEncMismatch where
+  toJSON ExpectedArray3  = object [("errorType", String "TupleEncMismatch"), ("reason", String "ExpectedArray3")]
+  toJSON ExpectedObject3 = object [("errorType", String "TupleEncMismatch"), ("reason", String "ExpectedObject3")]
+  toJSON (CouldNotParse3 r) = object [("errorType", String "TupleEncMismatch"), ("reason", String $ "CouldNotParse3: " <> r)]
+
+instance FromJSON TupleEncMismatch where
+  parseJSON val = pure $ case val of
+    Object km -> case KM.lookup (AK.fromText "wrong_key") km of
+      Just (String "ExpectedArray3") -> ExpectedArray3
+      Just (String "ExpectedObject3") -> ExpectedObject3
+      Just (String res) -> CouldNotParse3 $ T.replace "CouldNotParse3: " "" res
+      _ -> CouldNotParse3 "CouldNotParse3"
+    _ -> CouldNotParse3 "CouldNotParse3"
+
+---------------- Tuple-syntax encoder + .:/.:? decoder [NO ERROR: keys match] ----------------
+
+data TupleEncDotMatch = TupleEncDotMatch
+  { tedmReason :: Text
+  , tedmErrorType :: Text
+  }
+
+instance ToJSON TupleEncDotMatch where
+  toJSON x = object [("reason", String (tedmReason x)), ("errorType", String (tedmErrorType x))]
+
+instance FromJSON TupleEncDotMatch where
+  parseJSON = withObject "TupleEncDotMatch" $ \v -> TupleEncDotMatch
+    <$> v .: "reason"
+    <*> v .: "errorType"
+
+---------------- genericEncode with omitNothingFields + defaultDecode [NO ERROR: encoder keys unknown] ----------------
+
+data GenericEncodeOmitNothing = GenericEncodeOmitNothing
+  { geonField1 :: Text
+  , geonField2 :: Maybe Int
+  , geonField3 :: Maybe Text
+  } deriving (Generic)
+
+instance ToJSON GenericEncodeOmitNothing where
+  toJSON = A.genericToJSON A.defaultOptions { A.omitNothingFields = True }
+
+instance FromJSON GenericEncodeOmitNothing where
+  parseJSON = A.genericParseJSON A.defaultOptions
+
+---------------- defaultDecode <<< composition + defaultEncode [NO ERROR: both field labels] ----------------
+
+convertIntToStringsTest :: A.Value -> A.Value
+convertIntToStringsTest = id
+
+data CompositionDecode = CompositionDecode
+  { cdField1 :: Text
+  , cdField2 :: Maybe Int
+  } deriving (Generic)
+
+instance ToJSON CompositionDecode where
+  toJSON = A.genericToJSON A.defaultOptions
+
+instance FromJSON CompositionDecode where
+  parseJSON = A.genericParseJSON A.defaultOptions <<< convertIntToStringsTest
+
+---------------- genericEncode defaultOptions + hand-written decoder mismatch [TRUE POSITIVE] ----------------
+
+data GenericEncodeMismatch = GenericEncodeMismatch
+  { gemField1 :: Text
+  , gemField2 :: Maybe Int
+  } deriving (Generic)
+
+instance ToJSON GenericEncodeMismatch where
+  toJSON = A.genericToJSON A.defaultOptions
+
+instance FromJSON GenericEncodeMismatch where
+  parseJSON = withObject "GenericEncodeMismatch" $ \v -> GenericEncodeMismatch
+    <$> v .: "field_one"
+    <*> v .:? "field2_camel"
+
+---------------- camelCaseToSnakeCase <<< defaultEncode [NO ERROR: encoder keys unknown] ----------------
+
+camelToSnake :: A.Value -> A.Value
+camelToSnake = id
+
+snakeToCamel :: A.Value -> A.Value
+snakeToCamel = id
+
+data ComposeEncTransform = ComposeEncTransform
+  { cetField1 :: Text
+  , cetField2 :: Maybe Int
+  } deriving (Generic)
+
+instance ToJSON ComposeEncTransform where
+  toJSON = camelToSnake <<< A.genericToJSON A.defaultOptions
+
+instance FromJSON ComposeEncTransform where
+  parseJSON = A.genericParseJSON A.defaultOptions
+
+---------------- snakeCaseToCamelCase >>> defaultDecode [NO ERROR: both field labels] ----------------
+
+data ComposeDecPreprocess = ComposeDecPreprocess
+  { cdpField1 :: Text
+  , cdpField2 :: Maybe Int
+  } deriving (Generic)
+
+instance ToJSON ComposeDecPreprocess where
+  toJSON = A.genericToJSON A.defaultOptions
+
+instance FromJSON ComposeDecPreprocess where
+  parseJSON = snakeToCamel >>> A.genericParseJSON A.defaultOptions
+
+---------------- camelCaseToSnakeCase <<< defaultEncode + snakeCaseToCamelCase >>> defaultDecode [NO ERROR: both unknown/match] ----------------
+
+data ComposeBothSides = ComposeBothSides
+  { cbsField1 :: Text
+  , cbsField2 :: Maybe Int
+  } deriving (Generic)
+
+instance ToJSON ComposeBothSides where
+  toJSON = camelToSnake <<< A.genericToJSON A.defaultOptions
+
+instance FromJSON ComposeBothSides where
+  parseJSON = snakeToCamel >>> A.genericParseJSON A.defaultOptions
+
+---------------- defaultDecode <<< convertIntToStrings [NO ERROR: still works] ----------------
+
+convertIntsTest :: A.Value -> A.Value
+convertIntsTest = id
+
+data ComposeDecodeFirst = ComposeDecodeFirst
+  { cdfField1 :: Text
+  , cdfField2 :: Maybe Int
+  } deriving (Generic)
+
+instance ToJSON ComposeDecodeFirst where
+  toJSON = A.genericToJSON A.defaultOptions
+
+instance FromJSON ComposeDecodeFirst where
+  parseJSON = A.genericParseJSON A.defaultOptions <<< convertIntsTest
+
+---------------- defaultEncode with underscore-prefixed field [NO ERROR: _BNPL -> BNPL] ----------------
+
+data UnderscoreUpper = UnderscoreUpper
+  { _BNPL :: Text
+  , _Type :: Maybe Text
+  } deriving (Generic)
+
+instance ToJSON UnderscoreUpper where
+  toJSON = A.genericToJSON A.defaultOptions
+
+instance FromJSON UnderscoreUpper where
+  parseJSON = withObject "UnderscoreUpper" $ \v -> UnderscoreUpper
+    <$> v .: "BNPL"
+    <*> v .:? "Type"
+
+---------------- defaultEncode with special underscore fields [NO ERROR: _id -> id, _type -> type] ----------------
+
+data UnderscoreSpecial = UnderscoreSpecial
+  { _id :: Text
+  , _type :: Maybe Text
+  , _class :: Maybe Text
+  , _data :: Maybe Text
+  , _default :: Maybe Text
+  } deriving (Generic)
+
+instance ToJSON UnderscoreSpecial where
+  toJSON = A.genericToJSON A.defaultOptions
+
+instance FromJSON UnderscoreSpecial where
+  parseJSON = withObject "UnderscoreSpecial" $ \v -> UnderscoreSpecial
+    <$> v .: "id"
+    <*> v .:? "type"
+    <*> v .:? "class"
+    <*> v .:? "data"
+    <*> v .:? "default"
+
+---------------- defaultEncode with lowercase underscore field [NO ERROR: _myField stays _myField] ----------------
+
+data UnderscoreLower = UnderscoreLower
+  { _myField :: Text
+  , normalField :: Maybe Int
+  } deriving (Generic)
+
+instance ToJSON UnderscoreLower where
+  toJSON = A.genericToJSON A.defaultOptions
+
+instance FromJSON UnderscoreLower where
+  parseJSON = withObject "UnderscoreLower" $ \v -> UnderscoreLower
+    <$> v .: "_myField"
+    <*> v .:? "normalField"
+
+---------------- defaultEncode with underscore field + mismatched decoder [TRUE POSITIVE] ----------------
+
+data UnderscoreMismatch = UnderscoreMismatch
+  { _BNPL2 :: Text
+  } deriving (Generic)
+
+instance ToJSON UnderscoreMismatch where
+  toJSON = A.genericToJSON A.defaultOptions
+
+instance FromJSON UnderscoreMismatch where
+  parseJSON = withObject "UnderscoreMismatch" $ \v -> UnderscoreMismatch
+    <$> v .: "_BNPL2"
+
+---------------- defaultEncodeOmitNothingOpts encoder + defaultDecode decoder [NO ERROR: field labels match] ----------------
+
+data OmitNothingMatch = OmitNothingMatch
+  { onmField1 :: Text
+  , onmField2 :: Maybe Int
+  , onmField3 :: Maybe Text
+  } deriving (Generic)
+
+instance ToJSON OmitNothingMatch where
+  toJSON = A.genericToJSON A.defaultOptions
+
+instance FromJSON OmitNothingMatch where
+  parseJSON = A.genericParseJSON A.defaultOptions
+
+---------------- defaultEncodeOmitNothingOpts encoder + hand-written decoder mismatch [TRUE POSITIVE] ----------------
+
+data OmitNothingMismatch = OmitNothingMismatch
+  { onmmField1 :: Text
+  , onmmField2 :: Maybe Int
+  } deriving (Generic)
+
+instance ToJSON OmitNothingMismatch where
+  toJSON = A.genericToJSON A.defaultOptions
+
+instance FromJSON OmitNothingMismatch where
+  parseJSON = withObject "OmitNothingMismatch" $ \v -> OmitNothingMismatch
+    <$> v .: "field_one"
+    <*> v .:? "field2_camel"
+
+---------------- transformFn <<< defaultDecode decoder [NO ERROR: decoder keys unknown] ----------------
+
+transformValue :: Functor f => f TransformDecMatch -> f TransformDecMatch
+transformValue = fmap (\x -> x{ tdmField1 = tdmField1 x <> "_transformed" })
+
+data TransformDecMatch = TransformDecMatch
+  { tdmField1 :: Text
+  , tdmField2 :: Maybe Int
+  } deriving (Generic, Show)
+
+instance ToJSON TransformDecMatch where
+  toJSON = A.genericToJSON A.defaultOptions
+
+instance FromJSON TransformDecMatch where
+  parseJSON = transformValue <<< A.genericParseJSON A.defaultOptions
+
+---------------- transformFn <<< defaultDecode decoder with mismatch [NO ERROR: both unknown, limitation] ----------------
+
+data TransformDecMismatch = TransformDecMismatch
+  { tdm2Field1 :: Text
+  , tdm2Field2 :: Maybe Int
+  } deriving (Generic, Show)
+
+instance ToJSON TransformDecMismatch where
+  toJSON = A.genericToJSON A.defaultOptions
+
+instance FromJSON TransformDecMismatch where
+  parseJSON = transformValue2 <<< A.genericParseJSON A.defaultOptions
+
+transformValue2 :: Functor f => f TransformDecMismatch -> f TransformDecMismatch
+transformValue2 = fmap (\x -> x{ tdm2Field1 = tdm2Field1 x <> "_transformed" })
+
+---------------- Cross-module decoder helper functions [NO ERROR: keys match] ----------------
+-- Simulates readNumberAsMoney "amount" o, readUtcTime "dateCreated" o, etc.
+-- from Euler.API.Gateway.Utils.Domain.Common
+
+crossModuleReadNumber :: Text -> A.Object -> Parser Double
+crossModuleReadNumber label value = value .: AK.fromText label
+
+crossModuleReadString :: Text -> A.Object -> Parser Text
+crossModuleReadString label value = value .: AK.fromText label
+
+data CrossModuleHelperMatch = CrossModuleHelperMatch
+  { cmhAmount      :: Text
+  , cmhDateCreated :: Text
+  , cmhGatewayId   :: Maybe Text
+  , cmhLastUpdated :: Maybe Text
+  }
+
+instance ToJSON CrossModuleHelperMatch where
+  toJSON x = object
+    [ "amount"        .= cmhAmount x
+    , "dateCreated"   .= cmhDateCreated x
+    , "gatewayId"     .= cmhGatewayId x
+    , "lastUpdated"   .= cmhLastUpdated x
+    ]
+
+instance FromJSON CrossModuleHelperMatch where
+  parseJSON = withObject "CrossModuleHelperMatch" $ \o -> do
+    amount      <- crossModuleReadNumber "amount" o
+    dateCreated <- crossModuleReadString "dateCreated" o
+    gatewayId   <- (o .:? "gatewayId" :: Parser (Maybe Text))
+    lastUpdated <- crossModuleReadString "lastUpdated" o
+    pure CrossModuleHelperMatch {..}
+
+---------------- Cross-module decoder helper with key mismatch [TRUE POSITIVE] ----------------
+
+data CrossModuleHelperMismatch = CrossModuleHelperMismatch
+  { cmhmAmount :: Text
+  , cmhmDate   :: Text
+  }
+
+instance ToJSON CrossModuleHelperMismatch where
+  toJSON x = object
+    [ "amount" .= cmhmAmount x
+    , "date"   .= cmhmDate x
+    ]
+
+instance FromJSON CrossModuleHelperMismatch where
+  parseJSON = withObject "CrossModuleHelperMismatch" $ \o -> do
+    amount <- crossModuleReadNumber "amount_wrong" o
+    date   <- crossModuleReadString "date" o
+    pure CrossModuleHelperMismatch {..}
+
+---------------- withObject should NOT extract "TypeName" as a key [NO ERROR] ----------------
+
+data WithObjectNotExtracted = WithObjectNotExtracted
+  { wneField1 :: Text
+  , wneField2 :: Maybe Int
+  }
+
+instance ToJSON WithObjectNotExtracted where
+  toJSON x = object
+    [ "field1" .= wneField1 x
+    , "field2" .= wneField2 x
+    ]
+
+instance FromJSON WithObjectNotExtracted where
+  parseJSON = withObject "WithObjectNotExtracted" $ \o -> WithObjectNotExtracted
+    <$> o .: "field1"
+    <*> o .:? "field2"
+
+---------------- Derived ToJSON (anyclass) sum type + hand-written FromJSON [NO ERROR: encoder keys unknown] ----------------
+
+data SumTypeDerivedEnc = SumConA Text | SumConB Int | SumConC
+  deriving stock (Generic, Eq)
+
+deriving anyclass instance ToJSON SumTypeDerivedEnc
+
+instance FromJSON SumTypeDerivedEnc where
+  parseJSON = withObject "SumTypeDerivedEnc" $ \v -> do
+    tag <- v .: "tag"
+    case (tag :: Text) of
+      "SumConA" -> SumConA <$> v .: "contents"
+      "SumConB" -> SumConB <$> v .: "contents"
+      "SumConC" -> pure SumConC
+      _ -> Control.Applicative.empty
+
+---------------- Derived ToJSON (anyclass) record type + hand-written FromJSON [TRUE POSITIVE if keys mismatch] ----------------
+
+data RecordDerivedEnc = RecordDerivedEnc
+  { rdeField1 :: Text
+  , rdeField2 :: Maybe Int
+  } deriving stock (Generic, Eq)
+
+deriving anyclass instance ToJSON RecordDerivedEnc
+
+instance FromJSON RecordDerivedEnc where
+  parseJSON = withObject "RecordDerivedEnc" $ \v -> RecordDerivedEnc
+    <$> v .: "field_one"
+    <*> v .:? "field2_camel"
+
+---------------- <|> alternative with genericParseJSON [NO ERROR: both field labels] ----------------
+
+data AltGenericMatch = AltGenericMatch
+  { agmField1 :: Text
+  , agmField2 :: Maybe Int
+  } deriving (Generic)
+
+instance ToJSON AltGenericMatch where
+  toJSON = A.genericToJSON A.defaultOptions
+
+instance FromJSON AltGenericMatch where
+  parseJSON val = A.genericParseJSON A.defaultOptions val <|> A.genericParseJSON A.defaultOptions val
+
+---------------- <|> alternative with derived ToJSON + genericParseJSON [NO ERROR] ----------------
+
+data AltGenericDerived = AltGenericDerived
+  { agdField1 :: Text
+  , agdField2 :: Maybe Int
+  } deriving stock (Generic, Eq)
+
+deriving anyclass instance ToJSON AltGenericDerived
+
+instance FromJSON AltGenericDerived where
+  parseJSON val = A.genericParseJSON A.defaultOptions val <|> A.genericParseJSON A.defaultOptions val
+
+---------------- Decoder delegates to local function [NO ERROR: constructors unknown] ----------------
+
+data LocalFuncDecDelegate = LFDD_ConA Text | LFDD_ConB Int | LFDD_ConC
+  deriving stock (Eq)
+
+instance ToJSON LocalFuncDecDelegate where
+  toJSON (LFDD_ConA x) = toJSON x
+  toJSON (LFDD_ConB x) = toJSON x
+  toJSON LFDD_ConC = object []
+
+instance FromJSON LocalFuncDecDelegate where
+  parseJSON v = parseLFDD v
+
+parseLFDD :: Value -> Parser LocalFuncDecDelegate
+parseLFDD v =
+  (LFDD_ConA <$> parseJSON v)
+  <|> (LFDD_ConB <$> parseJSON v)
+  <|> pure LFDD_ConC
+
+---------------- Genuine collapse [TRUE POSITIVE: decoder always returns one constructor] ----------------
+
+data CollapseGenuine = CG_ConA Text | CG_ConB Int
+  deriving stock (Eq)
+
+instance ToJSON CollapseGenuine where
+  toJSON (CG_ConA x) = toJSON x
+  toJSON (CG_ConB x) = toJSON x
+
+instance FromJSON CollapseGenuine where
+  parseJSON _ = pure (CG_ConA "")
+
+---------------- Encoder with .= keys + decoder delegating to local function [NO ERROR: decoder keys unknown] ----------------
+
+data LocalFuncDecKeys = LocalFuncDecKeys
+  { lfdkField1 :: Text
+  , lfdkField2 :: Maybe Int
+  } deriving stock (Eq)
+
+instance ToJSON LocalFuncDecKeys where
+  toJSON x = object
+    [ "field1" .= lfdkField1 x
+    , "field2" .= lfdkField2 x
+    ]
+
+instance FromJSON LocalFuncDecKeys where
+  parseJSON v = parseLocalFuncDecKeys v
+
+parseLocalFuncDecKeys :: Value -> Parser LocalFuncDecKeys
+parseLocalFuncDecKeys = withObject "LocalFuncDecKeys" $ \o -> LocalFuncDecKeys
+  <$> o .: "field1"
+  <*> o .:? "field2"
+
+---------------- Encoder with .= keys + decoder delegating to local function with mismatch [TRUE POSITIVE: keys unknown on both sides via delegation, limitation] ----------------
+-- This is a limitation: decoder delegates to local function so keys are unknown,
+-- we can't detect the mismatch. But at least no false positive.
+
+data LocalFuncDecMismatch = LocalFuncDecMismatch
+  { lfdmField1 :: Text
+  } deriving stock (Eq)
+
+instance ToJSON LocalFuncDecMismatch where
+  toJSON x = object
+    [ "field1" .= lfdmField1 x
+    ]
+
+instance FromJSON LocalFuncDecMismatch where
+  parseJSON v = parseLocalFuncDecMismatch v
+
+parseLocalFuncDecMismatch :: Value -> Parser LocalFuncDecMismatch
+parseLocalFuncDecMismatch = withObject "LocalFuncDecMismatch" $ \o -> LocalFuncDecMismatch
+  <$> o .: "wrong_key"
+
+---------------- Where-clause error helper should not be extracted as decoder key [NO ERROR] ----------------
+
+data WhereClauseErrorHelper = WhereClauseErrorHelper
+  { wcehField1 :: Text
+  , wcehField2 :: Maybe Text
+  , wcehNested :: Maybe WhereClauseNested
+  } deriving stock (Generic, Eq)
+
+data WhereClauseNested = WhereClauseNested
+  { wcnInsertId :: Maybe Text
+  , wcnTagId :: Maybe Text
+  , wcnFlagType :: Maybe Text
+  } deriving stock (Generic, Eq)
+    deriving anyclass (ToJSON, FromJSON)
+
+instance ToJSON WhereClauseErrorHelper where
+  toJSON = A.genericToJSON A.defaultOptions
+
+instance FromJSON WhereClauseErrorHelper where
+  parseJSON = withObject "WhereClauseErrorHelper" $ \o -> do
+    field1 <- o .: "wcehField1"
+    field2 <- o .:? "wcehField2"
+    nested <- o .:? "wcehNested" >>= validateNested
+    pure WhereClauseErrorHelper
+      { wcehField1 = field1
+      , wcehField2 = field2
+      , wcehNested = nested
+      }
+    where
+      validateNested Nothing = pure Nothing
+      validateNested (Just n) = do
+        when (isStringAbsent (wcnInsertId n)) $
+          fail $ missingErr "insertId"
+        when (isStringAbsent (wcnTagId n)) $
+          fail $ missingErr "tagId"
+        when (isStringAbsent (wcnFlagType n)) $
+          fail $ missingErr "flagType"
+        pure (Just n)
+
+      missingErr :: Text -> String
+      missingErr fieldName =
+        "{\"errorType\":\"MISSING_FIELD\",\"errField\":\"" <> T.unpack fieldName <> "\"}"
+
+isStringAbsent :: Maybe Text -> Bool
+isStringAbsent Nothing = True
+isStringAbsent (Just "") = True
+isStringAbsent _ = False
+
+---------------- Dollar operator with genericToJSON/genericParseJSON + fieldLabelModifier [NO ERROR] ----------------
+
+data DollarGenOpts = DollarGenOpts
+  { dgoField1 :: Text
+  , dgoField2 :: Maybe Int
+  } deriving stock (Generic, Eq)
+
+modifyDgo :: String -> String
+modifyDgo "dgoField1" = "field_one"
+modifyDgo s = s
+
+instance ToJSON DollarGenOpts where
+  toJSON = genericToJSON $ defaultOptions {fieldLabelModifier = modifyDgo, omitNothingFields = True}
+
+instance FromJSON DollarGenOpts where
+  parseJSON = genericParseJSON $ defaultOptions {fieldLabelModifier = modifyDgo, omitNothingFields = True}
+
+---------------- omitNothingFields differs but fieldLabelModifier same [NO ERROR] ----------------
+
+data OmitNothingMatch2 = OmitNothingMatch2
+  { onm2Field1 :: Text
+  , onm2Field2 :: Maybe Int
+  , onm2Field3 :: Maybe Text
+  } deriving stock (Generic, Eq)
+
+modifyOnm2 :: String -> String
+modifyOnm2 "onm2Field1" = "field_one"
+modifyOnm2 s = s
+
+instance ToJSON OmitNothingMatch2 where
+  toJSON = genericToJSON defaultOptions {fieldLabelModifier = modifyOnm2, omitNothingFields = True}
+
+instance FromJSON OmitNothingMatch2 where
+  parseJSON = genericParseJSON defaultOptions {fieldLabelModifier = modifyOnm2}
+
+---------------- omitNothingFields differs AND sumEncoding differs [TRUE POSITIVE: sumEncoding mismatch] ----------------
+
+data OmitNothingSumMismatch2 = OmitNothingSumMismatch2
+  { onsm2Field1 :: Text
+  } deriving stock (Generic, Eq)
+
+instance ToJSON OmitNothingSumMismatch2 where
+  toJSON = genericToJSON defaultOptions {sumEncoding = UntaggedValue, omitNothingFields = True}
+
+instance FromJSON OmitNothingSumMismatch2 where
+  parseJSON = genericParseJSON defaultOptions
+
+---------------- OverloadedStrings pattern match in decoder [NO ERROR] ----------------
+
+data SingleConstructorSum = SCS_TagA
+  deriving stock (Eq, Show)
+
+instance ToJSON SingleConstructorSum where
+  toJSON SCS_TagA = String "SCS_TAG_A"
+
+instance FromJSON SingleConstructorSum where
+  parseJSON "SCS_TAG_A" = pure SCS_TagA
+  parseJSON other = fail $ "Unsupported: " <> show other
+
+---------------- $ operator with fieldLabelModifier on both sides [NO ERROR] ----------------
+
+data DollarFieldMod = DollarFieldMod
+  { dfmField1 :: Text
+  , dfmField2 :: Maybe Int
+  } deriving stock (Generic, Eq)
+
+modifyDfm :: String -> String
+modifyDfm "dfmField1" = "field_one"
+modifyDfm s = s
+
+instance ToJSON DollarFieldMod where
+  toJSON = genericToJSON $ defaultOptions {fieldLabelModifier = modifyDfm, omitNothingFields = True}
+
+instance FromJSON DollarFieldMod where
+  parseJSON = genericParseJSON $ defaultOptions {fieldLabelModifier = modifyDfm, omitNothingFields = True}
+
+---------------- Qualified omitNothingFields with multi-line ppr [NO ERROR] ----------------
+
+data QualifiedOmitMulti = QualifiedOmitMulti
+  { qomField1 :: Text
+  , qomField2 :: Maybe Int
+  } deriving stock (Generic, Eq)
+
+modifyQom :: String -> String
+modifyQom "qomField1" = "field_one"
+modifyQom s = s
+
+instance ToJSON QualifiedOmitMulti where
+  toJSON = genericToJSON A.defaultOptions {A.fieldLabelModifier = modifyQom, A.omitNothingFields = True}
+
+instance FromJSON QualifiedOmitMulti where
+  parseJSON = genericParseJSON A.defaultOptions {A.fieldLabelModifier = modifyQom}
+
+---------------- $ operator with mismatched fieldLabelModifier [TRUE POSITIVE] ----------------
+
+data DollarMismatch = DollarMismatch
+  { dmField1 :: Text
+  } deriving stock (Generic, Eq)
+
+modifyDmEnc :: String -> String
+modifyDmEnc "dmField1" = "enc_field"
+modifyDmEnc s = s
+
+modifyDmDec :: String -> String
+modifyDmDec "dmField1" = "dec_field"
+modifyDmDec s = s
+
+instance ToJSON DollarMismatch where
+  toJSON = genericToJSON $ defaultOptions {fieldLabelModifier = modifyDmEnc}
+
+instance FromJSON DollarMismatch where
+  parseJSON = genericParseJSON $ defaultOptions {fieldLabelModifier = modifyDmDec}
+
+---------------- omitNothingFields with long qualified names causing multi-line ppr [NO ERROR] ----------------
+
+data QualifiedMultiLineOmit = QualifiedMultiLineOmit
+  { qmloField1 :: Text
+  , qmloField2 :: Maybe Int
+  , qmloField3 :: Maybe Text
+  } deriving stock (Generic, Eq)
+
+modifyQmlo :: String -> String
+modifyQmlo "qmloField1" = "field_one"
+modifyQmlo "qmloField2" = "field_two"
+modifyQmlo "qmloField3" = "field_three"
+modifyQmlo s = s
+
+instance ToJSON QualifiedMultiLineOmit where
+  toJSON = genericToJSON A.defaultOptions {A.fieldLabelModifier = modifyQmlo, A.omitNothingFields = True}
+
+instance FromJSON QualifiedMultiLineOmit where
+  parseJSON = genericParseJSON A.defaultOptions {A.fieldLabelModifier = modifyQmlo}
+
+---------------- Untagged sum type delegating to different inner types [NO ERROR] ----------------
+
+data UntaggedSumA = UntaggedSumA
+  { usaField1 :: Text
+  } deriving stock (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+data UntaggedSumB = UntaggedSumB
+  { usbField1 :: Text
+  , usbResult :: Text
+  } deriving stock (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+data UntaggedSum = UntaggedSumSuccess UntaggedSumA | UntaggedSumFailure UntaggedSumB
+  deriving stock (Eq, Show)
+
+instance ToJSON UntaggedSum where
+  toJSON (UntaggedSumSuccess r) = toJSON r
+  toJSON (UntaggedSumFailure r) = toJSON r
+
+instance FromJSON UntaggedSum where
+  parseJSON = withObject "UntaggedSum" $ \o -> do
+    mbResult <- o .:? "result" :: Parser (Maybe Text)
+    case mbResult of
+      Just "FAIL" -> UntaggedSumFailure <$> parseJSON (Object o)
+      _ -> UntaggedSumSuccess <$> parseJSON (Object o)
+
+---------------- defaultDecode inside case expression [NO ERROR] ----------------
+
+data CaseDefaultDecode = CaseDefaultDecode
+  { cddField1 :: Text
+  , cddResult :: Maybe Text
+  } deriving stock (Generic, Eq)
+
+instance ToJSON CaseDefaultDecode where
+  toJSON = genericToJSON A.defaultOptions
+
+instance FromJSON CaseDefaultDecode where
+  parseJSON x@(A.Object obj) =
+    case KM.lookup "result" obj of
+      Just _  -> genericParseJSON A.defaultOptions (A.Object (KM.delete "result" obj))
+      Nothing -> genericParseJSON A.defaultOptions x
+  parseJSON x = genericParseJSON A.defaultOptions x
+
+---------------- String-encoded sum type with top-level helper [NO ERROR] ----------------
+
+data StrEncSumType
+  = StrEncProceed
+  | StrEncReject
+  | StrEncReview
+  deriving stock (Eq, Show)
+
+strEncToText :: StrEncSumType -> Text
+strEncToText StrEncProceed = "proceed"
+strEncToText StrEncReject  = "reject"
+strEncToText StrEncReview  = "review"
+
+instance ToJSON StrEncSumType where
+  toJSON = A.String . strEncToText
+
+instance FromJSON StrEncSumType where
+  parseJSON = A.withText "StrEncSumType" $ \t ->
+    case T.toLower t of
+      "proceed" -> pure StrEncProceed
+      "reject"  -> pure StrEncReject
+      "review"  -> pure StrEncReview
+      _         -> fail "Invalid"
+
+---------------- Untagged sum type with single delegation [TRUE POSITIVE: key mismatch] ----------------
+
+data UntaggedSingle = UntaggedSingleSuccess UntaggedSingleInner | UntaggedSingleFail
+  deriving stock (Eq, Show)
+
+data UntaggedSingleInner = UntaggedSingleInner
+  { usiField1 :: Text
+  } deriving stock (Generic, Eq, Show)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance ToJSON UntaggedSingle where
+  toJSON (UntaggedSingleSuccess r) = toJSON r
+  toJSON UntaggedSingleFail = A.String "fail"
+
+instance FromJSON UntaggedSingle where
+  parseJSON (A.String "fail") = pure UntaggedSingleFail
+  parseJSON v = UntaggedSingleSuccess <$> parseJSON v
+
+---------------- T.isPrefixOf in where-clause helper [NO ERROR] ----------------
+
+data PrefixCheckSumType
+  = PrefixCheckProceed
+  | PrefixCheckReject
+  | PrefixCheckCall Text
+  deriving stock (Eq, Show)
+
+prefixCheckToText :: PrefixCheckSumType -> Text
+prefixCheckToText PrefixCheckProceed = "proceed"
+prefixCheckToText PrefixCheckReject  = "reject"
+prefixCheckToText (PrefixCheckCall p) = "call_" <> p
+
+instance ToJSON PrefixCheckSumType where
+  toJSON = A.String . prefixCheckToText
+
+instance FromJSON PrefixCheckSumType where
+  parseJSON = A.withText "PrefixCheckSumType" $ \t ->
+    case T.toLower t of
+      "proceed" -> pure PrefixCheckProceed
+      "reject"  -> pure PrefixCheckReject
+      x | T.isPrefixOf "call_" x ->
+        let providerText = T.drop (T.length "call_") x
+        in pure (PrefixCheckCall providerText)
+      _ -> fail "Invalid"
+
+---------------- stripPrefix in inline let/case body [NO ERROR] ----------------
+
+data StripPrefixSumType
+  = StripPrefixSimple
+  | StripPrefixNested Text
+  deriving stock (Eq, Show)
+
+instance ToJSON StripPrefixSumType where
+  toJSON StripPrefixSimple = A.String "SIMPLE"
+  toJSON (StripPrefixNested t) = A.String ("NESTED_" <> T.toUpper t)
+
+instance FromJSON StripPrefixSumType where
+  parseJSON = A.withText "StripPrefixSumType" $ \t ->
+    let txt = T.toUpper t
+    in case txt of
+      "SIMPLE" -> pure StripPrefixSimple
+      _ | Just rest <- T.stripPrefix "NESTED_" txt ->
+            pure (StripPrefixNested rest)
+      _ -> fail "Invalid"
+

--- a/api-contract/test/IdLawTest/IDLawAllTestCases.hs
+++ b/api-contract/test/IdLawTest/IDLawAllTestCases.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 -- | Positive control: a law-abiding type. Must compile cleanly under the plugin.
@@ -16,7 +18,7 @@ import Data.Aeson.Types (Parser)
 import Control.Applicative ((<|>), liftA2, empty)
 import Control.Category ((<<<), (>>>))
 import Control.Monad (when)
-import Data.Text hiding (map, toLower, zip)
+import Data.Text hiding (map, toLower, zip, foldr1, all, any, concatMap, length, null)
 import qualified Data.Text as T
 import GHC.Generics (Generic)
 import Data.Aeson.Key (fromText)
@@ -1241,6 +1243,12 @@ instance FromJSON HelperNested where
   parseJSON = withObject "HelperNested" $ \o ->
     HelperNested <$> o .: "userId"
 
+---------------- Keyless hand-written encoder over a record [NO ERROR: neither side uses keys] ----------------
+-- Canary for the class-default handling: a hand-written ToJSON still leaves
+-- toEncoding to its class default, and that defaulted method must not be read as
+-- "this type is generically derived", or sField would be compared against a
+-- decoder that never reads a key.
+
 data Serialized =
   Serialized
   { sField :: Int
@@ -1254,6 +1262,12 @@ instance FromJSON Serialized where
   parseJSON =
     withText "Serialized" $
       pure . Serialized . read . unpack
+
+---------------- Encoder delegates to a tag-envelope helper [TRUE POSITIVE: encoder writes 'A', decoder expects 'AA'] ----------------
+-- The literal passed to mkTagged is a constructor tag *value*, not a JSON key;
+-- the real keys ("tag"/"payload") live inside the helper, so no key error is
+-- expected here. The tag value is traced through mkTagged's "tag" .= tag
+-- parameter, which is what exposes the HiddenA mismatch.
 
 mkTagged :: Text -> Value -> Value
 mkTagged tag payload =
@@ -1280,6 +1294,8 @@ instance FromJSON HiddenTag where
       "AA" -> HiddenA <$> o .: "payload"
       "B"  -> HiddenB <$> o .: "payload"
       _    -> fail "invalid"
+
+---------------- Sum-type tag case mismatch [TRUE POSITIVE: encoder writes 'leaf', decoder expects 'LEAF'] ----------------
 
 data Tree
   = Leaf Int
@@ -2575,9 +2591,11 @@ parseLocalFuncDecKeys = withObject "LocalFuncDecKeys" $ \o -> LocalFuncDecKeys
   <$> o .: "field1"
   <*> o .:? "field2"
 
----------------- Encoder with .= keys + decoder delegating to local function with mismatch [TRUE POSITIVE: keys unknown on both sides via delegation, limitation] ----------------
--- This is a limitation: decoder delegates to local function so keys are unknown,
--- we can't detect the mismatch. But at least no false positive.
+---------------- Encoder with .= keys + decoder delegating to local function with mismatch [TRUE POSITIVE: traced through the helper] ----------------
+-- The decoder delegates to a local function, so the keys have to be read out of
+-- parseLocalFuncDecMismatch itself.  It is simple enough to read in full (no
+-- nested parseJSON, no dynamic keys), so "wrong_key" is recovered and compared
+-- against the encoder's "field1".
 
 data LocalFuncDecMismatch = LocalFuncDecMismatch
   { lfdmField1 :: Text
@@ -2678,7 +2696,11 @@ instance ToJSON OmitNothingMatch2 where
 instance FromJSON OmitNothingMatch2 where
   parseJSON = genericParseJSON defaultOptions {fieldLabelModifier = modifyOnm2}
 
----------------- omitNothingFields differs AND sumEncoding differs [TRUE POSITIVE: sumEncoding mismatch] ----------------
+---------------- omitNothingFields differs AND sumEncoding differs [NO ERROR: single-constructor record, sumEncoding is inert] ----------------
+-- aeson only writes a constructor tag for a single-constructor type when
+-- tagSingleConstructors is set, so neither sumEncoding nor omitNothingFields
+-- can change a key here.  See SumEncodingMismatch for the multi-constructor
+-- case, where sumEncoding is live.
 
 data OmitNothingSumMismatch2 = OmitNothingSumMismatch2
   { onsm2Field1 :: Text
@@ -2908,3 +2930,253 @@ instance FromJSON StripPrefixSumType where
             pure (StripPrefixNested rest)
       _ -> fail "Invalid"
 
+
+---------------- sumEncoding differs on a multi-constructor type [TRUE POSITIVE: sumEncoding is live for sums] ----------------
+-- Counterpart to OmitNothingSumMismatch2: with more than one constructor the
+-- tag envelope really does change, so this mismatch must still be reported.
+
+data SumEncodingMismatch
+  = SEM_ConA Text
+  | SEM_ConB Int
+  deriving stock (Generic, Eq)
+
+instance ToJSON SumEncodingMismatch where
+  toJSON = genericToJSON defaultOptions {sumEncoding = UntaggedValue}
+
+instance FromJSON SumEncodingMismatch where
+  parseJSON = genericParseJSON defaultOptions
+
+---------------- tagSingleConstructors makes sumEncoding live on one constructor [TRUE POSITIVE] ----------------
+
+data TaggedSingleCtor = TaggedSingleCtor
+  { tscField1 :: Text
+  } deriving stock (Generic, Eq)
+
+instance ToJSON TaggedSingleCtor where
+  toJSON = genericToJSON defaultOptions {tagSingleConstructors = True, sumEncoding = UntaggedValue}
+
+instance FromJSON TaggedSingleCtor where
+  parseJSON = genericParseJSON defaultOptions {tagSingleConstructors = True}
+
+---------------- Encoder delegates to a local helper with matching keys [NO ERROR: helper keys match] ----------------
+-- Positive control for encoder-side helper tracing.  The helper reads record
+-- fields, which must not be mistaken for further delegation.
+
+data LocalFuncEncMatch = LocalFuncEncMatch
+  { lfemField1 :: Text
+  , lfemField2 :: Maybe Int
+  } deriving stock (Eq)
+
+mkLocalEncPayload :: LocalFuncEncMatch -> Value
+mkLocalEncPayload x = object
+  [ "field1" .= lfemField1 x
+  , "field2" .= lfemField2 x
+  ]
+
+instance ToJSON LocalFuncEncMatch where
+  toJSON x = mkLocalEncPayload x
+
+instance FromJSON LocalFuncEncMatch where
+  parseJSON = withObject "LocalFuncEncMatch" $ \o -> LocalFuncEncMatch
+    <$> o .: "field1"
+    <*> o .:? "field2"
+
+---------------- Encoder delegates to a local helper with a key mismatch [TRUE POSITIVE] ----------------
+
+data LocalFuncEncMismatch = LocalFuncEncMismatch
+  { lfemmField1 :: Text
+  } deriving stock (Eq)
+
+mkLocalEncMismatch :: LocalFuncEncMismatch -> Value
+mkLocalEncMismatch x = object
+  [ "written_key" .= lfemmField1 x
+  ]
+
+instance ToJSON LocalFuncEncMismatch where
+  toJSON x = mkLocalEncMismatch x
+
+instance FromJSON LocalFuncEncMismatch where
+  parseJSON = withObject "LocalFuncEncMismatch" $ \o -> LocalFuncEncMismatch
+    <$> o .: "read_key"
+
+---------------- Standalone-derived encoder with a leading-underscore field [NO ERROR: both sides agree on the stripped key] ----------------
+
+data UnderscoreDerivedEnc = UnderscoreDerivedEnc
+  { _UdeField1 :: Text
+  } deriving stock (Generic, Eq)
+
+deriving anyclass instance ToJSON UnderscoreDerivedEnc
+
+instance FromJSON UnderscoreDerivedEnc where
+  parseJSON = genericParseJSON defaultOptions
+
+---------------- Standalone deriving via + hand-written decoder [NO ERROR: via type keys unknown] ----------------
+-- 'deriving via' fills the instance in for you, so the encoder has a local
+-- method binding with no keys in it.  Without consulting the via strategy that
+-- reads as "this encoder writes nothing" and every decoder key looks missing.
+
+data ViaDerived = ViaDerived
+  { vdField1 :: Text
+  } deriving stock (Eq)
+
+newtype ViaCarrier = ViaCarrier ViaDerived
+
+instance ToJSON ViaCarrier where
+  toJSON (ViaCarrier x) = object [ "field_one" .= vdField1 x ]
+
+deriving via ViaCarrier instance ToJSON ViaDerived
+
+instance FromJSON ViaDerived where
+  parseJSON = withObject "ViaDerived" $ \o -> ViaDerived <$> o .: "field_one"
+
+---------------- foldr1 (liftA2 (<|>)) key fallback [NO ERROR: alternate spellings] ----------------
+
+data FoldrAltFallback = FoldrAltFallback
+  { fafOptions :: Maybe Text
+  } deriving stock (Generic, Eq)
+
+instance ToJSON FoldrAltFallback where
+  toJSON FoldrAltFallback{..} = object [ "options.add_full" .= fafOptions ]
+
+instance FromJSON FoldrAltFallback where
+  parseJSON = withObject "FoldrAltFallback" $ \o -> do
+    fafOptions <- foldr1 (liftA2 (<|>))
+      [ o .:? "options.add_full"
+      , o .:? "options_add_full"
+      ]
+    pure FoldrAltFallback{..}
+
+---------------- Required envelope key with a `<|> pure o` default [NO ERROR: envelope is optional] ----------------
+-- `o .: "DataSet" <|> pure o` succeeds whether or not the envelope is present,
+-- so DataSet is not a key the encoder has to write.
+
+data EnvelopeFallback = EnvelopeFallback
+  { efAmount :: Text
+  } deriving stock (Eq)
+
+instance ToJSON EnvelopeFallback where
+  toJSON EnvelopeFallback{..} = object [ "Amount" .= efAmount ]
+
+instance FromJSON EnvelopeFallback where
+  parseJSON = withObject "EnvelopeFallback" $ \o -> do
+    table <- o .: "DataSet" <|> pure o
+    efAmount <- table .: "Amount"
+    pure EnvelopeFallback{..}
+
+---------------- Wrapped-payload alternative reading "contents" [NO ERROR: one branch of <|>] ----------------
+
+data WrappedAltPayload = WrappedAltPayload
+  { wapId :: Text
+  } deriving stock (Eq)
+
+instance ToJSON WrappedAltPayload where
+  toJSON WrappedAltPayload{..} = object [ "id" .= wapId ]
+
+instance FromJSON WrappedAltPayload where
+  parseJSON v =
+    withObject "WrappedAltPayload" parseWapFields v
+      <|> withObject "Wrapped" (\o -> o .: "contents" >>= parseWapFields) v
+    where
+      parseWapFields o = do
+        wapId <- o .: "id"
+        pure WrappedAltPayload{..}
+
+---------------- Optional key fallback expressed with a case [NO ERROR: legacy spelling] ----------------
+
+data CaseKeyFallback = CaseKeyFallback
+  { ckfData :: Maybe Text
+  } deriving stock (Eq)
+
+instance ToJSON CaseKeyFallback where
+  toJSON CaseKeyFallback{..} = object [ "data" .= ckfData ]
+
+instance FromJSON CaseKeyFallback where
+  parseJSON = withObject "CaseKeyFallback" $ \v -> do
+    mbLegacy <- v .:? "booking"
+    d <- case mbLegacy of
+      Just b -> pure (Just b)
+      Nothing -> v .:? "data"
+    pure (CaseKeyFallback d)
+
+---------------- fromMaybe default in the decoder [NO ERROR: literal is a value, not a key] ----------------
+
+data FromMaybeDefault = FromMaybeDefault
+  { fmdMessage :: Text
+  , fmdCode    :: Text
+  } deriving stock (Eq)
+
+instance ToJSON FromMaybeDefault where
+  toJSON FromMaybeDefault{..} = object
+    [ "message" .= fmdMessage
+    , "code"    .= fmdCode
+    ]
+
+instance FromJSON FromMaybeDefault where
+  parseJSON = withObject "FromMaybeDefault" $ \o -> do
+    message <- o .: "message"
+    code <- o .:? "code"
+    pure FromMaybeDefault
+      { fmdMessage = message
+      , fmdCode = fromMaybe "request_failed" code
+      }
+
+---------------- Decoder reads one field through a local helper [NO ERROR: helper keys merged] ----------------
+
+data PartialHelperDec = PartialHelperDec
+  { phdReference :: Maybe Text
+  , phdBalance   :: Maybe Text
+  } deriving stock (Eq)
+
+parsePhdBalance :: Object -> Parser (Maybe Text)
+parsePhdBalance o = o .:? "balance"
+
+instance ToJSON PartialHelperDec where
+  toJSON PartialHelperDec{..} = object
+    [ "reference" .= phdReference
+    , "balance"   .= phdBalance
+    ]
+
+instance FromJSON PartialHelperDec where
+  parseJSON = withObject "PartialHelperDec" $ \o -> do
+    phdReference <- o .:? "reference"
+    phdBalance <- parsePhdBalance o
+    pure PartialHelperDec{..}
+
+---------------- Required decode key genuinely missing from the encoder [TRUE POSITIVE] ----------------
+-- Guard for the optional-key relaxation above: a *required* key the encoder
+-- never writes still makes fromJSON (toJSON x) fail, and must still be caught.
+
+data RequiredKeyMissing = RequiredKeyMissing
+  { rkmField1 :: Text
+  } deriving stock (Eq)
+
+instance ToJSON RequiredKeyMissing where
+  toJSON RequiredKeyMissing{..} = object [ "field1" .= rkmField1 ]
+
+instance FromJSON RequiredKeyMissing where
+  parseJSON = withObject "RequiredKeyMissing" $ \o -> RequiredKeyMissing
+    <$> o .: "field_one"
+
+---------------- Tag-envelope helper whose tags agree [NO ERROR: traced tag matches] ----------------
+-- Positive control for the tag tracing that catches HiddenTag: the tag value
+-- reaches the JSON through mkTagged's first parameter on both constructors and
+-- the decoder matches both spellings exactly, so nothing may be reported.
+
+data VisibleTag
+  = VisibleA Int
+  | VisibleB Int
+
+instance ToJSON VisibleTag where
+  toJSON (VisibleA x) =
+    mkTagged "A" (toJSON x)
+
+  toJSON (VisibleB x) =
+    mkTagged "B" (toJSON x)
+
+instance FromJSON VisibleTag where
+  parseJSON = withObject "VisibleTag" $ \o -> do
+    tag <- o .: "tag"
+    case (tag :: Text) of
+      "A" -> VisibleA <$> o .: "payload"
+      "B" -> VisibleB <$> o .: "payload"
+      _   -> fail "invalid"

--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,7 @@
           settings = {
             beam-core.jailbreak = true;
             sheriff.check = false;
+            api-contract.check = false;
           };
           devShell = {
             mkShellArgs = {
@@ -137,6 +138,7 @@
             # };
             sheriff.check = false;
             http2.check = false;
+            api-contract.check = false;
           };
 
           devShell = {


### PR DESCRIPTION
Added the plugin to catch ID law failures.

ID law suggests that toJSON and fromJSON on a data should result in the same data.
fromJSON . toJSON = id
decode . encode = id

Example type flagged by plugin:
```
data RedeemType = RedeemType
  { _type :: Text
  , value :: Number
  , brand_name :: Maybe Text
  , brand_logo :: Maybe Text
  }
  deriving anyclass (Newtype (RedeemType))

instance FromJSON RedeemType where
  parseJSON = withObject "RedeemType" $ \o -> do
    _type    <- o .: "type"
    value   <- o .: "value"
    brand_name <- o .:? "brandName"
    brand_logo <- o .:? "brandLogo"
    return $ RedeemType{..}

instance ToJSON RedeemType where
  toJSON = defaultEncode
```
This type is failed because it is not following ID law i.e (fromJSON . toJSON RedeemType) != RedeemType

Example type passed by plugin:
```
data CCAuthServiceTokenRepeat = CCAuthServiceTokenRepeat {run :: Text, networkTokenCryptogram :: TagType, aggregatorID :: Maybe TagType}
  deriving anyclass (Newtype (CCAuthServiceTokenRepeat))

instance ToJSON CCAuthServiceTokenRepeat where
  toJSON = defaultEncode

instance FromJSON CCAuthServiceTokenRepeat where
  parseJSON = defaultDecode
```