### PR TITLE
Ghc 9.8.4 main

### DIFF
--- a/api-contract/src/ApiContract/Plugin.hs
+++ b/api-contract/src/ApiContract/Plugin.hs
@@ -21,12 +21,14 @@ import GHC.Data.Bag
 import GHC.HsToCore
 import GHC.Types.SrcLoc
 import GHC.Driver.Errors
+import GHC.Driver.Errors.Types (ghcUnknownMessage)
+import GHC.Utils.Error (mkErrorMsgEnvelope)
 import GHC.Unit.Types
 import GHC.Driver.Backpack.Syntax
 import GHC.Unit.Info
 -- import Streamly.Internal.Data.Stream (fromList,mapM_,mapM,toList)
 import GHC hiding (typeKind)
-import GHC.Driver.Plugins (Plugin(..),CommandLineOption,defaultPlugin,PluginRecompile(..))
+import GHC.Driver.Plugins (Plugin(..),CommandLineOption,defaultPlugin,PluginRecompile(..),ParsedResult(..))
 import GHC.Driver.Env
 import GHC.Tc.Types
 import GHC.Unit.Module.ModSummary
@@ -39,6 +41,7 @@ import qualified Data.Aeson.Key as HM
 import GHC.Core.Opt.Monad
 import GHC.Rename.HsType
 import qualified GHC.Tc.Utils.Monad as TCError
+import GHC.Tc.Errors.Types (mkTcRnUnknownMessage)
 import qualified GHC.Types.SourceError as ParseError
 import qualified GHC.Types.Error as ParseError
 import GHC.Types.Name.Reader (rdrNameOcc ,rdrNameSpace,RdrName(..))
@@ -79,6 +82,7 @@ import ErrUtils
 #endif
 
 import Control.Reference (biplateRef, (^?))
+import Data.Generics.Uniplate.Data ()
 import ApiContract.Types
 -- import Data.Aeson
 import Data.List.Extra (intercalate, isSuffixOf, replace, splitOn,groupBy)
@@ -89,19 +93,28 @@ import qualified Data.Text as T
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Data.Time
 import Data.Map (Map)
+import qualified Data.Foldable as DF
 import Data.Data
 import Data.Maybe (catMaybes,isJust,fromJust)
 import Control.Monad.IO.Class (liftIO)
 import System.IO (writeFile)
 import Streamly.Internal.Data.Stream hiding (concatMap, init, length, map, splitOn,foldl',intercalate)
 import System.Directory (createDirectoryIfMissing, removeFile,doesFileExist)
+import System.Environment (lookupEnv)
 import System.Directory.Internal.Prelude hiding (mapM, mapM_)
 import Prelude hiding (id, mapM, mapM_)
 import Control.Exception (evaluate)
+-- These are only used to compose the record plugins under ENABLE_LR_PLUGINS
+-- (see the plugin definition below). Importing them unconditionally would drag
+-- large-anon's orphan `Outputable (GenLocated l e)` instance into scope, which
+-- overlaps GHC 9.8's `Outputable (GenLocated (SrcSpanAnn' a) e)` and breaks all
+-- AST `ppr` in this module. Guard them so the normal build never sees it.
+#if defined(ENABLE_LR_PLUGINS)
 import qualified Data.Record.Plugin as DRP
 import qualified Data.Record.Anon.Plugin as DRAP
 import qualified Data.Record.Plugin.HasFieldPattern as DRPH
 import qualified RecordDotPreprocessor as RDP
+#endif
 import qualified Data.Yaml as YAML
 import Control.Monad (foldM)
 import Data.Char
@@ -231,8 +244,11 @@ showSDocUnsafe' = showSDocUnsafe . ppr
 defaultCliOptions :: CliOptions
 defaultCliOptions = CliOptions {path="./.juspay/api-contract/",port=4444,host="::1",log=False,tc_funcs=Just False,api_contract=Just True}
 
-collectTypeInfoParser :: [CommandLineOption] -> ModSummary -> HsParsedModule -> Hsc HsParsedModule
-collectTypeInfoParser opts modSummary hpm = do
+-- GHC 9.4 changed parsedResultAction to take/return `ParsedResult` (wrapping the
+-- HsParsedModule + parse messages); unwrap it for analysis and return it unchanged.
+collectTypeInfoParser :: [CommandLineOption] -> ModSummary -> ParsedResult -> Hsc ParsedResult
+collectTypeInfoParser opts modSummary parsedResult = do
+    let hpm = parsedResultModule parsedResult
     let cliOptions = case opts of
                     [] ->  defaultCliOptions
                     (local : _) ->
@@ -272,8 +288,9 @@ collectTypeInfoParser opts modSummary hpm = do
                 case eitherTypeRules of
 #if __GLASGOW_HASKELL__ >= 900
                     Left err -> ParseError.throwErrors
+                                $ ParseError.mkMessages
                                 $ listToBag
-                                    $ [ParseError.mkErr moduleSrcSpan reallyAlwaysQualify (ParseError.mkDecorated [docToSDoc $ Pretty.text $ (modulePath <> ".yaml") <> " is missing for this module : " <> show err])]
+                                    $ [mkErrorMsgEnvelope moduleSrcSpan reallyAlwaysQualify (ghcUnknownMessage (ParseError.mkPlainError ParseError.noHints (docToSDoc $ Pretty.text $ (modulePath <> ".yaml") <> " is missing for this module : " <> show err)))]
 #else
                     Left err -> ParseError.throwErrors
                                 $ listToBag
@@ -302,7 +319,7 @@ collectTypeInfoParser opts modSummary hpm = do
                         if (not $ Prelude.null $ errorsNubbed)
                             then do
 #if __GLASGOW_HASKELL__ >= 900
-                                errorMessages <- pure $ listToBag $ map (\(srcSpan,errorMessage) -> ParseError.mkErr srcSpan reallyAlwaysQualify (ParseError.mkDecorated [docToSDoc $ Pretty.text $ generateErrorMessage (modulePath <> ".yaml") errorMessage])) errorsNubbed
+                                errorMessages <- pure $ ParseError.mkMessages $ listToBag $ map (\(srcSpan,errorMessage) -> mkErrorMsgEnvelope srcSpan reallyAlwaysQualify (ghcUnknownMessage (ParseError.mkPlainError ParseError.noHints (docToSDoc $ Pretty.text $ generateErrorMessage (modulePath <> ".yaml") errorMessage)))) errorsNubbed
                                 ParseError.throwErrors errorMessages
 #else
                                 errorMessages <- 
@@ -314,7 +331,7 @@ collectTypeInfoParser opts modSummary hpm = do
                                 ParseError.throwErrors errorMessages
 #endif
                             else pure ()
-    pure hpm
+    pure parsedResult
 
 #if __GLASGOW_HASKELL__ >= 900
 instance (YAML.ToJSON v) => YAML.ToJSON (OMap.OMap HM.Key v) where
@@ -356,7 +373,7 @@ collectInstanceInfo opts modSummary tcEnv = do
         newModuleList <- liftIO $ readMVar newModuleListMvar
         case eitherTypeRules of
 #if __GLASGOW_HASKELL__ >= 900
-            Left err -> TCError.addErrs $ [(moduleSrcSpan,docToSDoc $ Pretty.text $ (modulePath <> ".yaml") <> " " <> "is missing for this module :" <> show err)]
+            Left err -> TCError.addErrs $ [(moduleSrcSpan, mkTcRnUnknownMessage $ ParseError.mkPlainError ParseError.noHints $ docToSDoc $ Pretty.text $ (modulePath <> ".yaml") <> " " <> "is missing for this module :" <> show err)]
 #else
             Left err -> TCError.addErrs $ [(moduleSrcSpan,docToSDoc $ Pretty.text $ (modulePath <> ".yaml") <> " " <> "is missing for this module :" <> show err)]
 #endif
@@ -413,7 +430,7 @@ collectInstanceInfo opts modSummary tcEnv = do
                         if (not $ Prelude.null $ errorsNubbed)
                             then do
 #if __GLASGOW_HASKELL__ >= 900
-                                TCError.addErrs $ map (\(srcSpan,errorMessage) -> (srcSpan,docToSDoc $ Pretty.text $ generateErrorMessage (modulePath <> ".yaml") errorMessage)) errorsNubbed
+                                TCError.addErrs $ map (\(srcSpan,errorMessage) -> (srcSpan, mkTcRnUnknownMessage $ ParseError.mkPlainError ParseError.noHints $ docToSDoc $ Pretty.text $ generateErrorMessage (modulePath <> ".yaml") errorMessage)) errorsNubbed
 #else
                                 TCError.addErrs $ map (\(srcSpan,errorMessage) -> (srcSpan,docToSDoc $ Pretty.text $ generateErrorMessage (modulePath <> ".yaml") errorMessage)) errorsNubbed
 #endif
@@ -424,7 +441,7 @@ collectInstanceInfo opts modSummary tcEnv = do
 
 processInstance :: LHsBindLR GhcTc GhcTc -> IO [(SrcSpan,String,String,InstanceFromTC)]
 #if __GLASGOW_HASKELL__ >= 900
-processInstance (L l (FunBind _ id' matches _)) = do
+processInstance (L l (FunBind _ id' matches)) = do
 #else
 processInstance (L l (FunBind _ id' matches _ _)) = do
 #endif
@@ -439,7 +456,7 @@ processInstance (L l (FunBind _ id' matches _ _)) = do
     else pure mempty
 processInstance (L _ (VarBind{var_id = var, var_rhs = expr})) = pure mempty
 processInstance (L _ (PatBind{pat_lhs = pat, pat_rhs = expr})) = pure mempty
-processInstance (L _ (AbsBinds{abs_binds = binds})) = do
+processInstance (L _ (XHsBindsLR (AbsBinds{abs_binds = binds}))) = do
   res <- toList $ mapM processInstance $ fromList $ bagToList binds
   pure $ Prelude.concat res
 processInstance _ = pure mempty
@@ -486,23 +503,13 @@ getAppliedOnTypeName "toXML" (FunTy _  arg res) = Just $ (showSDocUnsafe $ ppr a
 getAppliedOnTypeName _ _ = Nothing
 #endif
 
-processHsSplice (HsTypedSplice _ _ name expr) = do
-    -- when (generateTypesRules) $ print ("HsTypedSplice",showSDocUnsafe $ ppr name , showSDocUnsafe $ ppr expr)
-    pure mempty
-processHsSplice (HsUntypedSplice _ _ name expr) = do
+processHsSplice (HsUntypedSpliceExpr _ expr) = do
     let types = expr ^? biplateRef :: [HsExpr GhcPs]
         typeName = map (\(_,y) -> replace "''" "" y) $ Prelude.filter (\(const,_) -> const `Prelude.elem` ["HsBracket"]) $ map (\x -> (show $ toConstr x,showSDocUnsafe $ ppr x)) types
         possibleInstances = map (\(_,y) -> y) $ Prelude.filter (\(const,_) -> const `Prelude.elem` ["HsVar"]) $ map (\x -> (show $ toConstr x,showSDocUnsafe $ ppr x)) types
     pure $ Prelude.concat $ map (\x -> map (\y -> (y,x)) possibleInstances) typeName
-processHsSplice (HsQuasiQuote _ id1 id2 srcSpan fs) = do
-    -- when (generateTypesRules) $ print ("HsQuasiQuote",showSDocUnsafe $ ppr id1 , showSDocUnsafe $ ppr id2)
-    pure mempty
-processHsSplice (HsSpliced _ _ expr) = do
-    -- case expr of
-        -- (HsSplicedExpr expr' ) -> when (generateTypesRules) $ print (showSDocUnsafe $ ppr expr')
-        -- (HsSplicedTy   type_ ) -> when (generateTypesRules) $ print (showSDocUnsafe $ ppr type_)
-        -- (HsSplicedPat  pat)    -> when (generateTypesRules) $ print (showSDocUnsafe $ ppr pat)
-    pure mempty
+-- HsQuasiQuote / XUntypedSplice: no-op, as the typed-splice and HsSpliced cases were before
+processHsSplice _ = pure mempty
 
 #if __GLASGOW_HASKELL__ >= 900
 convertLIdP :: LIdP GhcPs -> Located RdrName
@@ -585,7 +592,7 @@ getTypeInfo (L l (TyClD _ (DataDecl _ lname _ _ defn))) =
     { typeKind = "data"
     , caseType = Nothing
     , instances = mempty
-    , dataConstructors = Map.fromList $ map getDataConInfo (dd_cons defn)
+    , dataConstructors = Map.fromList $ map getDataConInfo (DF.toList (dd_cons defn))
     })]
 getTypeInfo (L l (TyClD _ (SynDecl _ lname _ _ rhs))) =
     [(locA' l ,showSDocUnsafe' lname,TypeRule
@@ -593,7 +600,7 @@ getTypeInfo (L l (TyClD _ (SynDecl _ lname _ _ rhs))) =
     , caseType = Nothing
     , instances = mempty
 #if __GLASGOW_HASKELL__ >= 900
-    , dataConstructors = Map.singleton (showSDocUnsafe' lname) (DataConInfo  (maybe mempty (Map.singleton "synonym" . unpackHDS) (hsTypeToString $ unLoc rhs)) [])
+    , dataConstructors = Map.singleton (showSDocUnsafe' lname) (DataConInfo  (maybe mempty (Map.singleton "synonym") (hsTypeToString $ unLoc rhs)) [])
 #else
     , dataConstructors = Map.singleton (showSDocUnsafe' lname) (DataConInfo (Map.singleton "synonym" ((showSDocUnsafe . ppr . unLoc) rhs)) [])
 #endif
@@ -607,10 +614,10 @@ getDataConInfo (L _ ConDeclH98{ con_name = lname, con_args = args }) =
       , sumTypes = [] -- For H98-style data constructors, sum types are not applicable
       })
 getDataConInfo (L _ ConDeclGADT{ con_names = lnames, con_res_ty = ty }) =
-  (intercalate ", " (map showSDocUnsafe' lnames),DataConInfo
+  (intercalate ", " (map showSDocUnsafe' (DF.toList lnames)),DataConInfo
     {
 #if __GLASGOW_HASKELL__ >= 900
-    fields' = maybe (mempty) (\x -> Map.singleton "gadt" $ unpackHDS x) (hsTypeToString $ unLoc ty)
+    fields' = maybe (mempty) (\x -> Map.singleton "gadt" x) (hsTypeToString $ unLoc ty)
 #else
     fields' = Map.singleton "gadt" (showSDocUnsafe $ ppr ty)
 #endif
@@ -618,13 +625,13 @@ getDataConInfo (L _ ConDeclGADT{ con_names = lnames, con_res_ty = ty }) =
     })
 
 #if __GLASGOW_HASKELL__ >= 900
-hsTypeToString :: HsType GhcPs -> Maybe HsDocString
+hsTypeToString :: HsType GhcPs -> Maybe String
 hsTypeToString = f
   where
-    f :: HsType GhcPs -> Maybe HsDocString
-    f (HsDocTy _ _ lds) = Just (unLoc lds)
-    f (HsBangTy _ _ (L _ (HsDocTy _ _ lds))) = Just (unLoc lds)
-    f x = Just (mkHsDocString $ showSDocUnsafe $ ppr x)
+    f :: HsType GhcPs -> Maybe String
+    f (HsDocTy _ _ lds) = Just (renderHsDocString $ hsDocString $ unLoc lds)
+    f (HsBangTy _ _ (L _ (HsDocTy _ _ lds))) = Just (renderHsDocString $ hsDocString $ unLoc lds)
+    f x = Just (showSDocUnsafe $ ppr x)
 
 extractInfixCon :: [HsType GhcPs] -> Map.Map String String
 extractInfixCon x =
@@ -644,7 +651,7 @@ extractConDeclField x = Map.fromList (go x)
     go ((ConDeclField _ cd_fld_names cd_fld_type _):xs) =
         [((intercalate "," $ convertRdrNameToString cd_fld_names),(showSDocUnsafe $ ppr cd_fld_type))] <> (go xs)
 
-    convertRdrNameToString x = map (showSDocUnsafe . ppr . rdrNameOcc . unLoc . reLocN . rdrNameFieldOcc . unLoc') x
+    convertRdrNameToString x = map (showSDocUnsafe . ppr . rdrNameOcc . unLoc . reLocN . foLabel . unLoc') x
 
 getFieldMap :: HsConDeclH98Details GhcPs -> Map.Map String String
 getFieldMap con_args =

--- a/api-contract/src/ApiContract/Plugin.hs
+++ b/api-contract/src/ApiContract/Plugin.hs
@@ -505,7 +505,10 @@ getAppliedOnTypeName _ _ = Nothing
 
 processHsSplice (HsUntypedSpliceExpr _ expr) = do
     let types = expr ^? biplateRef :: [HsExpr GhcPs]
-        typeName = map (\(_,y) -> replace "''" "" y) $ Prelude.filter (\(const,_) -> const `Prelude.elem` ["HsBracket"]) $ map (\x -> (show $ toConstr x,showSDocUnsafe $ ppr x)) types
+        -- GHC 9.4 renamed the bracket constructor HsBracket -> HsUntypedBracket
+        -- (typed splices got HsTypedBracket); match both so the ''Type quote in
+        -- $(deriveJSON ... ''Type) splices is still detected on every version.
+        typeName = map (\(_,y) -> replace "''" "" y) $ Prelude.filter (\(const,_) -> const `Prelude.elem` ["HsBracket","HsUntypedBracket"]) $ map (\x -> (show $ toConstr x,showSDocUnsafe $ ppr x)) types
         possibleInstances = map (\(_,y) -> y) $ Prelude.filter (\(const,_) -> const `Prelude.elem` ["HsVar"]) $ map (\x -> (show $ toConstr x,showSDocUnsafe $ ppr x)) types
     pure $ Prelude.concat $ map (\x -> map (\y -> (y,x)) possibleInstances) typeName
 -- HsQuasiQuote / XUntypedSplice: no-op, as the typed-splice and HsSpliced cases were before

--- a/cabal.project
+++ b/cabal.project
@@ -1,11 +1,11 @@
 packages:
   ./fdep
-  ./fieldInspector
   ./sheriff
   ./paymentFlow
-  ./api-contract
   ./dc
   ./endpoints
   ./warner
   ./keyLookupTracker
   ./socket_lib
+  ./fieldInspector
+  ./api-contract

--- a/dc/src/DC/DefaultCheck.hs
+++ b/dc/src/DC/DefaultCheck.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DeriveAnyClass, CPP, TypeApplications #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE DeriveGeneric, ScopedTypeVariables, TypeFamilies, RecordWildCards, PartialTypeSignatures #-}
 -- {-# OPTIONS_GHC -ddump-parsed-ast #-}
 
@@ -50,6 +51,60 @@ import TcRnTypes (TcGblEnv (..), TcM)
 import GhcPlugins hiding ((<>)) --(Plugin(..), defaultPlugin, purePlugin, CommandLineOption, ModSummary(..), Module (..), liftIO, moduleNameString, showSDocUnsafe, ppr, nameStableString, varName)
 #endif
 import           Data.IORef (readIORef, writeIORef, IORef, newIORef)
+#if __GLASGOW_HASKELL__ >= 904
+import GHC.Hs.Expr (XXExprGhcTc(..))
+import GHC.Tc.Errors.Types (TcRnMessage, mkTcRnUnknownMessage)
+import GHC.Types.Error (mkPlainError, noHints)
+#endif
+
+-- Version-stable pattern synonyms bridging the GHC 9.4 AST changes so the call
+-- sites below stay identical to the pre-9.4 code.
+#if __GLASGOW_HASKELL__ >= 904
+-- The `HsConLikeOut` constructor was removed in GHC 9.4; the typechecked conlike
+-- is now carried by the `ConLikeTc` extension constructor.
+pattern HsConLikeOut :: [Var] -> ConLike -> HsExpr GhcTc
+pattern HsConLikeOut tvs con <- XExpr (ConLikeTc con tvs _)
+
+pattern PatHsPar :: LHsExpr (GhcPass p) -> HsExpr (GhcPass p)
+pattern PatHsPar e <- HsPar _ _ e _
+
+pattern PAbsBinds :: LHsBinds GhcTc -> HsBindLR GhcTc GhcTc
+pattern PAbsBinds binds <- XHsBindsLR (AbsBinds{abs_binds = binds})
+
+-- GHC 9.4 renamed `HsRecField'`/`HsRecField` to `HsFieldBind` (fields
+-- hsRecFieldLbl/hsRecFieldArg -> hfbLHS/hfbRHS). Keep the old shapes usable.
+type HsRecFieldCompat id arg = HsFieldBind id arg
+pattern PHsField lbl arg <- HsFieldBind {hfbLHS = lbl, hfbRHS = arg}
+
+-- GHC 9.4 replaced the `Either regular overloaded` record-update field payload
+-- with the `LHsRecUpdFields` GADT; normalise it back to the old `Either` so the
+-- downstream logic is unchanged.
+recUpdFieldsToEither :: LHsRecUpdFields GhcTc -> Either [LHsRecUpdFieldTc] [LHsRecUpdProj GhcTc]
+recUpdFieldsToEither (RegularRecUpdFields _ fs)    = Left fs
+recUpdFieldsToEither (OverloadedRecUpdFields _ fs) = Right fs
+
+-- GHC 9.4 gave LHsRecUpdField a second (rhs) type parameter.
+type LHsRecUpdFieldTc = LHsRecUpdField GhcTc GhcTc
+#else
+pattern PatHsPar :: LHsExpr (GhcPass p) -> HsExpr (GhcPass p)
+pattern PatHsPar e <- HsPar _ e
+
+pattern PAbsBinds :: LHsBinds GhcTc -> HsBindLR GhcTc GhcTc
+pattern PAbsBinds binds <- AbsBinds{abs_binds = binds}
+
+type HsRecFieldCompat id arg = HsRecField' id arg
+pattern PHsField lbl arg <- HsRecField {hsRecFieldLbl = lbl, hsRecFieldArg = arg}
+
+type LHsRecUpdFieldTc = LHsRecUpdField GhcTc
+#endif
+
+#if __GLASGOW_HASKELL__ >= 904
+-- GHC 9.4 removed `instance Outputable Char`; restore its pre-9.4 definition so
+-- that `ppr` on String-typed values resolves and renders exactly as it did on
+-- 9.2 (via the unchanged Outputable [a] / Maybe a instances).
+instance Outputable Char where
+  ppr c = text [c]
+#endif
 
 plugin :: Plugin
 plugin =
@@ -151,7 +206,7 @@ lookupEachKey hm alreadyVisited x = case HM.lookup (name x) hm of
 
 processAllLetPats :: LHsBindLR GhcTc GhcTc -> (Maybe (String, [FunctionInfo]))
 #if __GLASGOW_HASKELL__ >= 900
-processAllLetPats (L _ (FunBind _ name matches _)) = do
+processAllLetPats (L _ (FunBind {fun_id = name, fun_matches = matches})) = do
 #else
 processAllLetPats (L _ (FunBind _ name matches _ _)) = do
 #endif
@@ -163,7 +218,7 @@ processAllLetPats (L _ _) = do
 
 
 loopOverLHsBindLRTot :: [String] -> CheckerConfig -> String -> UpdateInfo -> String -> IORef (HM.HashMap String UpdateInfoAsText) -> LHsBindLR GhcTc GhcTc -> TcM ErrorCase
-loopOverLHsBindLRTot allPaths conf path allFuns moduleName' hmIORef vals@(L _ AbsBinds {abs_binds = binds}) = do
+loopOverLHsBindLRTot allPaths conf path allFuns moduleName' hmIORef vals@(L _ (PAbsBinds binds)) = do
   case conf of
     FunctionCheck (FunctionCheckConfig{..}) ->
       if moduleName' == moduleNameToCheck
@@ -341,7 +396,9 @@ throwFunctionErrorRules x allPaths path moduleName' (UpdateInfo _ _ _ _ _ otherF
 
 getLocGhc :: _ -> SrcSpan
 getLocGhc val =
-#if __GLASGOW_HASKELL__ >= 900
+#if __GLASGOW_HASKELL__ >= 904
+  getLocA val
+#elif __GLASGOW_HASKELL__ >= 900
   RealSrcSpan (la2r $ getLoc val) Nothing
 #else
   getLoc val
@@ -489,7 +546,7 @@ checkInOtherModsWithoutErrorFuns allPaths checkerCase moduleName' fun@(FunctionI
     _ -> pure []
 
 #if __GLASGOW_HASKELL__ >= 900
-extractLHsRecUpdField :: Either [LHsRecUpdField GhcTc] [LHsRecUpdProj GhcTc] -> [FunctionInfo]
+extractLHsRecUpdField :: Either [LHsRecUpdFieldTc] [LHsRecUpdProj GhcTc] -> [FunctionInfo]
 extractLHsRecUpdField fields =
   case fields of
     Left fun -> concatMap (processExprCases) (fun)
@@ -502,11 +559,11 @@ extractLHsRecUpdField (L _ (HsRecField {hsRecFieldArg = fun})) = processExpr fun
 #endif
 
 #if __GLASGOW_HASKELL__ >= 900
-processExprUps :: HsRecField' id (GenLocated SrcSpanAnnA (HsExpr GhcTc)) -> [FunctionInfo]
-processExprUps (HsRecField {hsRecFieldArg = fun}) = processExpr fun
+processExprUps :: HsRecFieldCompat id (GenLocated SrcSpanAnnA (HsExpr GhcTc)) -> [FunctionInfo]
+processExprUps (PHsField _ fun) = processExpr fun
 
-processExprCases :: GenLocated l (HsRecField' id (GenLocated SrcSpanAnnA (HsExpr GhcTc))) -> [FunctionInfo]
-processExprCases (L _ (HsRecField {hsRecFieldArg = fun})) = processExpr fun
+processExprCases :: GenLocated l (HsRecFieldCompat id (GenLocated SrcSpanAnnA (HsExpr GhcTc))) -> [FunctionInfo]
+processExprCases (L _ (PHsField _ fun)) = processExpr fun
 #endif
 
 
@@ -528,12 +585,22 @@ processExpr (L _ (OpApp _ funl funm funr)) =
   processExpr funl <> processExpr funm <> processExpr funr
 processExpr (L _ (NegApp _ funl _)) =
   processExpr funl
+#if __GLASGOW_HASKELL__ >= 904
+processExpr (L _ (XExpr (HsTick _ fun))) =
+  processExpr fun
+#else
 processExpr (L _ (HsTick _ _ fun)) =
   processExpr fun
+#endif
 processExpr (L _ (HsStatic _ fun)) =
   processExpr fun
+#if __GLASGOW_HASKELL__ >= 904
+processExpr (L _ (XExpr (HsBinTick _ _ fun))) =
+  processExpr fun
+#else
 processExpr (L _ (HsBinTick _ _ _ fun)) =
   processExpr fun
+#endif
 #if __GLASGOW_HASKELL__ < 900
 processExpr (L _ (HsTickPragma _ _ _ _ fun)) =
   processExpr fun
@@ -564,24 +631,42 @@ processExpr (L _ (ExplicitList _ funList)) =
 processExpr (L _ (HsIf exprLStmt funl funm funr)) =
   let stmts = (exprLStmt ^? biplateRef :: [LHsExpr GhcTc])
    in nub (concatMap processExpr $ [funl, funm, funr] <> stmts)
+#if __GLASGOW_HASKELL__ >= 904
+-- GHC 9.4 removed HsTcBracketOut; typed/untyped brackets are now distinct
+-- constructors. Traverse their sub-expressions as before.
+processExpr (L _ (HsTypedBracket _ funl)) = processExpr funl
+processExpr (L _ (HsUntypedBracket _ q)) =
+  let stmts = (q ^? biplateRef :: [LHsExpr GhcTc])
+   in nub (concatMap processExpr stmts)
+processExpr (L _ (RecordUpd _ rupd_expr rupd_flds)) = processExpr rupd_expr <> extractLHsRecUpdField (recUpdFieldsToEither rupd_flds)
+#else
 processExpr (L _ (HsTcBracketOut _ _ exprLStmtL exprLStmtR)) =
   let stmtsL = (exprLStmtL ^? biplateRef :: [LHsExpr GhcTc])
       stmtsR = (exprLStmtR ^? biplateRef :: [LHsExpr GhcTc])
    in nub (concatMap processExpr (stmtsL <> stmtsR))
 processExpr (L _ (RecordUpd _ rupd_expr rupd_flds)) = processExpr rupd_expr <> extractLHsRecUpdField rupd_flds
 #endif
+#endif
 processExpr (L _ (ExprWithTySig _ fun _)) =
   processExpr fun
 processExpr (L _ (HsDo _ _ exprLStmt)) =
   let stmts = exprLStmt ^? biplateRef :: [LHsExpr GhcTc]
    in nub $ concatMap processExpr stmts
+#if __GLASGOW_HASKELL__ >= 904
+processExpr (L _ (HsLet _ _ exprLStmt _ func)) =
+#else
 processExpr (L _ (HsLet _ exprLStmt func)) =
+#endif
   let stmts = exprLStmt ^? biplateRef :: [LHsExpr GhcTc]
    in processExpr func <> nub (concatMap processExpr stmts)
 processExpr (L _ (HsMultiIf _ exprLStmt)) =
   let stmts = exprLStmt ^? biplateRef :: [LHsExpr GhcTc]
    in nub (concatMap processExpr stmts)
+#if __GLASGOW_HASKELL__ >= 904
+processExpr (L _ (HsCase _ funl exprLStmt@(MG _ (L _ _)))) =
+#else
 processExpr (L _ (HsCase _ funl exprLStmt@(MG _ (L _ _) _))) =
+#endif
    let stmts = (exprLStmt ^? biplateRef :: [LHsExpr GhcTc])
    in nub (concatMap processExpr $ [funl] <> stmts)
 processExpr (L _ (ExplicitSum _ _ _ fun)) = processExpr fun
@@ -589,9 +674,17 @@ processExpr (L _ (SectionR _ funl funr)) = processExpr funl <> processExpr funr
 processExpr (L _ (ExplicitTuple _ exprLStmt _)) =
   let stmts = (exprLStmt ^? biplateRef :: [LHsExpr GhcTc])
    in nub (concatMap processExpr stmts)
-processExpr (L _ (HsPar _ fun)) = processExpr fun
+processExpr (L _ (PatHsPar fun)) = processExpr fun
+#if __GLASGOW_HASKELL__ >= 904
+processExpr (L _ (HsAppType _ fun _ _)) = processExpr fun
+#else
 processExpr (L _ (HsAppType _ fun _)) = processExpr fun
+#endif
+#if __GLASGOW_HASKELL__ >= 904
+processExpr (L _ (HsLamCase _ _ exprLStmt)) =
+#else
 processExpr (L _ (HsLamCase _ exprLStmt)) =
+#endif
   let stmts = (exprLStmt ^? biplateRef :: [LHsExpr GhcTc])
    in nub (concatMap processExpr stmts)
 processExpr (L _ (HsLam _ exprLStmt)) =
@@ -604,10 +697,18 @@ processExpr x@(L _ (HsLit _ liter)) =
 processExpr (L _ (HsOverLit _ exprLStmt)) =
   let stmts = (exprLStmt ^? biplateRef :: [LHsExpr GhcTc])
    in nub (concatMap processExpr stmts)
+#if __GLASGOW_HASKELL__ >= 904
+processExpr (L _ (HsRecSel _ exprLStmt)) =
+#else
 processExpr (L _ (HsRecFld _ exprLStmt)) =
+#endif
   let stmts = (exprLStmt ^? biplateRef :: [LHsExpr GhcTc])
    in nub (concatMap processExpr stmts)
+#if __GLASGOW_HASKELL__ >= 904
+processExpr (L _ (HsUntypedSplice exprLStmtL exprLStmtR)) =
+#else
 processExpr (L _ (HsSpliceE exprLStmtL exprLStmtR)) =
+#endif
   let stmtsL = (exprLStmtL ^? biplateRef :: [LHsExpr GhcTc])
       stmtsR = (exprLStmtR ^? biplateRef :: [LHsExpr GhcTc])
    in nub (concatMap processExpr (stmtsL <> stmtsR))
@@ -618,10 +719,12 @@ processExpr (L _ (ArithSeq _ (Just exprLStmtL) exprLStmtR)) =
 processExpr (L _ (ArithSeq _ Nothing exprLStmtR)) =
   let stmtsR = (exprLStmtR ^? biplateRef :: [LHsExpr GhcTc])
    in nub (concatMap processExpr stmtsR)
+#if __GLASGOW_HASKELL__ < 904
 processExpr (L _ (HsRnBracketOut _ exprLStmtL exprLStmtR)) =
   let stmtsL = (exprLStmtL ^? biplateRef :: [LHsExpr GhcTc])
       stmtsR = (exprLStmtR ^? biplateRef :: [LHsExpr GhcTc])
    in nub (concatMap processExpr (stmtsL <> stmtsR))
+#endif
 -- processExpr (L _ (RecordCon _ (L _ (iD)) rcon_flds)) = Just ((extractRecordBinds (rcon_flds)), False)
 -- processExpr (L _ (RecordUpd _ rupd_expr rupd_flds)
 -- processExpr (L _ (HsTcBracketOut _ exprLStmtL exprLStmtR)) =
@@ -640,7 +743,11 @@ isVarPatMatch (L _ match) =
     in any isVarPat argBinds
 
 isVarPatExprBool :: LHsExpr GhcTc -> Bool
+#if __GLASGOW_HASKELL__ >= 904
+isVarPatExprBool (L _ (HsCase _ _ (MG _ (L _ mg_alts)))) =
+#else
 isVarPatExprBool (L _ (HsCase _ _ (MG _ (L _ mg_alts) _))) =
+#endif
     any isVarPatMatch mg_alts
     -- in L loc (HsCase m funl (MG mg_ext (L loc1 y) mg_org))
 isVarPatExprBool _ = False
@@ -680,9 +787,14 @@ getDataTypeDetails recordTypeArr allLetPats allArgs (RecordCon _ iD rcon_flds) =
 #else
 getDataTypeDetails recordTypeArr allLetPats allArgs (RecordCon _ iD rcon_flds) = pure $ if any (\perRecord -> (recordType perRecord) `elem` ((splitOn " " $ replace "->" "" $ showSDocUnsafe $ ppr $ idType $ unLoc iD)) || recordType perRecord == "ALL") recordTypeArr then Just (extractRecordBinds rcon_flds allLetPats allArgs enumList fieldType enumType) else Nothing
 #endif
-getDataTypeDetails recordTypeArr allLetPats allArgs (RecordUpd _ rupd_expr rupd_flds) = 
+getDataTypeDetails recordTypeArr allLetPats allArgs (RecordUpd _ rupd_expr rupd_flds) =
   let allVals = mapMaybe getExprTypeAsType $ rupd_expr ^? biplateRef
-  in pure $ if any (\x -> any (\perRecord -> (recordType perRecord) `elem` ((splitOn " " $ replace "->" "" $ showSDocUnsafe $ ppr x))) recordTypeArr) allVals || any (\perRecord -> recordType perRecord == "ALL") recordTypeArr then Just (getFieldUpdates rupd_flds allLetPats allArgs recordTypeArr) else Nothing
+#if __GLASGOW_HASKELL__ >= 904
+      rupd_flds' = recUpdFieldsToEither rupd_flds
+#else
+      rupd_flds' = rupd_flds
+#endif
+  in pure $ if any (\x -> any (\perRecord -> (recordType perRecord) `elem` ((splitOn " " $ replace "->" "" $ showSDocUnsafe $ ppr x))) recordTypeArr) allVals || any (\perRecord -> recordType perRecord == "ALL") recordTypeArr then Just (getFieldUpdates rupd_flds' allLetPats allArgs recordTypeArr) else Nothing
 getDataTypeDetails recordTypeArr allLetPats allArgs x@(OpApp _ funl funm _) = do
     -- trace (show (showSDocUnsafe $ ppr x, showSDocUnsafe $ ppr funl,showSDocUnsafe $ ppr funm, showSDocUnsafe $ ppr funr)) Nothing
     if (showSDocUnsafe $ ppr funm) == "(#)"
@@ -711,7 +823,7 @@ getDataTypeDetails recordTypeArr _ _ pat@(HsApp _ app1 (L _ _)) = do
     else pure Nothing
     -- if showSDocUnsafe $ ppr app1 
     -- pure Nothing
-getDataTypeDetails recordTypeArr allLetPats _ (HsPar _ (L _ pat)) = do
+getDataTypeDetails recordTypeArr allLetPats _ (PatHsPar (L _ pat)) = do
     -- liftIO $ print (allLetPats)
     if "setField" `isInfixOf` (showSDocUnsafe $ ppr pat) then do
       let allVals = mapMaybe getExprTypeAsType $ pat ^? biplateRef
@@ -779,7 +891,7 @@ conLikeType (PatSynCon pat_syn)    = patSynResultType pat_syn
 #endif
 
 #if __GLASGOW_HASKELL__ >= 900
-getFieldUpdates :: Either [LHsRecUpdField GhcTc] [LHsRecUpdProj GhcTc] -> HM.HashMap String Bool -> [String] -> [RecordType] -> TypeOfUpdate
+getFieldUpdates :: Either [LHsRecUpdFieldTc] [LHsRecUpdProj GhcTc] -> HM.HashMap String Bool -> [String] -> [RecordType] -> TypeOfUpdate
 getFieldUpdates fields allLetPats allArgs recordTypeArr =
   case fields of
     Left x -> 
@@ -794,8 +906,8 @@ getFieldUpdates fields allLetPats allArgs recordTypeArr =
         else if Update `elem` allUpdates then Update
         else NoChange
     where
-    extractField :: LHsRecUpdField GhcTc -> TypeOfUpdate
-    extractField (L _ (HsRecField{hsRecFieldLbl = lbl, hsRecFieldArg = expr})) =
+    extractField :: LHsRecUpdFieldTc -> TypeOfUpdate
+    extractField (L _ (PHsField lbl expr)) =
         let allNrFuns = nub $ ((concatMap processExpr (map noLocA $ expr ^? biplateRef)))
             allValsTypes = mapMaybe getExprType (expr ^? biplateRef)
         in if any (\perRecord -> (isInfixOf (fieldType perRecord) (showSDocUnsafe $ ppr lbl) || (fieldType perRecord) == "ALL") && ((Just (enumType perRecord)) == (lastMaybe (splitOn " " $ replace "->" "" $ showSDocUnsafe $ ppr (lastMaybe allValsTypes))))) recordTypeArr then
@@ -812,7 +924,7 @@ getFieldUpdates fields allLetPats allArgs recordTypeArr =
             else Update
         else NoChange
     -- extractField' :: HsRecUpdField GhcTc -> TypeOfUpdate
-    extractField' ((HsRecField{hsRecFieldLbl = lbl, hsRecFieldArg = expr})) =
+    extractField' ((PHsField lbl expr)) =
         let allNrFuns = nub $ ((concatMap processExpr (map noLocA $ expr ^? biplateRef)))
             allValsTypes = mapMaybe getExprType (expr ^? biplateRef)
         in if any (\perRecord -> isInfixOf (fieldType perRecord) (showSDocUnsafe $ ppr lbl) || (fieldType perRecord) == "ALL" && ((Just (enumType perRecord)) == (lastMaybe (splitOn " " $ replace "->" "" $ showSDocUnsafe $ ppr (lastMaybe allValsTypes))))) recordTypeArr then
@@ -829,15 +941,15 @@ getFieldUpdates fields allLetPats allArgs recordTypeArr =
             else Update
         else NoChange
 #else
-getFieldUpdates :: [LHsRecUpdField GhcTc] -> HM.HashMap String Bool -> [String] -> [String] -> String -> String -> TypeOfUpdate
+getFieldUpdates :: [LHsRecUpdFieldTc] -> HM.HashMap String Bool -> [String] -> [String] -> String -> String -> TypeOfUpdate
 getFieldUpdates fields allLetPats allArgs enumList fieldType enumType =
     let allUpdates = map extractField fields
     in if UpdateWithFailure `elem` allUpdates then UpdateWithFailure 
        else if Update `elem` allUpdates then Update
        else NoChange
     where
-    extractField :: LHsRecUpdField GhcTc -> TypeOfUpdate
-    extractField (L _ (HsRecField{hsRecFieldLbl = lbl, hsRecFieldArg = expr})) =
+    extractField :: LHsRecUpdFieldTc -> TypeOfUpdate
+    extractField (L _ (PHsField lbl expr)) =
         let allNrFuns = nub $ ((concatMap processExpr (map noLoc $ expr ^? biplateRef)))
             allValsTypes = mapMaybe getExprType (expr ^? biplateRef)
         in if isInfixOf fieldType (showSDocUnsafe $ ppr lbl) || fieldType == "ALL" && ((Just enumType) == (lastMaybe (splitOn " " $ replace "->" "" $ showSDocUnsafe $ ppr (lastMaybe allValsTypes)))) then
@@ -863,7 +975,7 @@ extractRecordBinds (HsRecFields{rec_flds = fields}) allLetPats allArgs recordTyp
        else NoChange
     where
     extractField :: LHsRecField GhcTc (LHsExpr GhcTc) -> TypeOfUpdate
-    extractField (L _ (HsRecField{hsRecFieldLbl = lbl, hsRecFieldArg = expr})) = do
+    extractField (L _ (PHsField lbl expr)) = do
 #if __GLASGOW_HASKELL__ >= 900
         let allNrFuns = nub $ ((concatMap processExpr (map (noLocA) $ expr ^? biplateRef)))
 #else
@@ -890,18 +1002,18 @@ getFunctionName :: LHsBindLR GhcTc GhcTc -> [String]
 #if __GLASGOW_HASKELL__ < 900
 getFunctionName (L _ (FunBind _ idt _ _ _)) = [nameStableString $ getName idt]
 #else
-getFunctionName (L _ (FunBind _ idt _ _)) = [nameStableString $ getName idt]
+getFunctionName (L _ (FunBind {fun_id = idt})) = [nameStableString $ getName idt]
 #endif
 getFunctionName (L _ (VarBind{var_id = var})) = [nameStableString $ varName var]
 getFunctionName (L _ (PatBind{})) = [""]
-getFunctionName (L _ (AbsBinds{abs_binds = binds})) = concatMap getFunctionName $ bagToList binds
+getFunctionName (L _ (PAbsBinds binds)) = concatMap getFunctionName $ bagToList binds
 getFunctionName _ = []
 
 getFunctionNameIfFailure :: [String] -> CheckerConfig -> [RecordType] -> String -> LHsBindLR GhcTc GhcTc -> IORef (HM.HashMap String UpdateInfoAsText) -> TcM (TypeOfUpdate, [String])
 #if __GLASGOW_HASKELL__ < 900
 getFunctionNameIfFailure allPaths checkerCase recordType moduleName' (L _ x@(FunBind _ idT _ _ _)) hmIORef = do
 #else
-getFunctionNameIfFailure allPaths checkerCase recordTypeArr moduleName' (L _ x@(FunBind _ idT _ _)) hmIORef = do
+getFunctionNameIfFailure allPaths checkerCase recordTypeArr moduleName' (L _ x@(FunBind {fun_id = idT})) hmIORef = do
 #endif
   let allValsTypes = mapMaybe getExprType (x ^? biplateRef)
   let allVals = (map unLoc (x ^? biplateRef :: [LHsExpr GhcTc]))
@@ -954,7 +1066,7 @@ getFunctionNameIfFailure allPaths checkerCase recordTypeArr moduleName' (L _ x@(
     else if any(\perRecord -> any (\val -> isInfixOf val (showSDocUnsafe $ ppr x) ) (enumList perRecord) && (Just (enumType perRecord)) == (lastMaybe (splitOn " " $ replace "->" "" $ showSDocUnsafe $ ppr (lastMaybe allValsTypes)))) recordTypeArr
           then (Default, funName)
     else (NoChange,[])
-getFunctionNameIfFailure allPaths checkerCase recordTypeArr moduleName' (L _ x@(AbsBinds{abs_binds = binds})) hmIORef = do
+getFunctionNameIfFailure allPaths checkerCase recordTypeArr moduleName' (L _ x@(PAbsBinds binds)) hmIORef = do
   let allValsTypes = mapMaybe getExprType (x ^? biplateRef)
   let allVals = (map unLoc (bagToList binds ^? biplateRef :: [LHsExpr GhcTc]))
   let allLetPats = HM.fromList $ ((mapMaybe processAllLetPats (bagToList binds ^? biplateRef :: [LHsBindLR GhcTc GhcTc])))
@@ -986,7 +1098,7 @@ getFunctionNameIfFailure allPaths checkerCase recordTypeArr moduleName' (L _ x@(
 getFunctionNameIfFailure _ _ _hasFld _ _ _ = pure $ (NoChange,[])
 
 loopOverLHsBindLR :: [String] -> CheckerConfig -> String -> IORef (HM.HashMap String UpdateInfoAsText) -> LHsBindLR GhcTc GhcTc  -> TcM ((Maybe UpdateInfo), (HM.HashMap String [FunctionInfo]))
-loopOverLHsBindLR allPaths checkerCase moduleName' hmIORef x@(L _ AbsBinds {abs_binds = binds1}) = do
+loopOverLHsBindLR allPaths checkerCase moduleName' hmIORef x@(L _ (PAbsBinds binds1)) = do
   case checkerCase of
     FieldsCheck (EnumCheck{..})   -> do
       let binds = ( bagToList binds1 ^? biplateRef)
@@ -1095,7 +1207,7 @@ getAllNeededFun recordTypeArr _ _ allBinds processedPats match = do
 --   liftIO $ print (name, showSDocUnsafe <$> ppr <$> allValsTypes, any (\val -> isInfixOf val (showSDocUnsafe $ ppr x) ) enumList , map (\val -> (lastMaybe (splitOn " " $ replace "->" "" $ showSDocUnsafe $ ppr val))) allValsTypes)
 
 loopAndColect :: HM.HashMap String [FunctionInfo] -> LHsBindLR GhcTc GhcTc -> IO ((HM.HashMap String [FunctionInfo]))
-loopAndColect allFunsList x@(L _ AbsBinds {abs_binds = binds}) = do
+loopAndColect allFunsList x@(L _ (PAbsBinds binds)) = do
   let fname = map name $ map (\y -> transformFromNameStableString (y) (showSDocUnsafe $ ppr $ getLoc $ x) False) $ (getFunctionName x)
       allVals = ((bagToList binds ^? biplateRef :: [LHsExpr GhcTc]))
 --   liftIO $ print (fname, showSDocUnsafe $ ppr x)
@@ -1108,7 +1220,7 @@ loopOverFunBindM :: LHsBindLR GhcTc GhcTc -> (IO (Maybe [String]))
 #if __GLASGOW_HASKELL__ < 900
 loopOverFunBindM (L _ (FunBind _ _ matches _ _)) = do
 #else
-loopOverFunBindM (L _ (FunBind _ _ matches _)) = do
+loopOverFunBindM (L _ (FunBind {fun_matches = matches})) = do
 #endif
     let inte = unLoc $ mg_alts matches
     -- print ("iam here", showSDocUnsafe $ ppr x, length inte)
@@ -1123,7 +1235,7 @@ processAllLetPatsM :: LHsBindLR GhcTc GhcTc -> (Maybe (String, [FunctionInfo]))
 #if __GLASGOW_HASKELL__ < 900
 processAllLetPatsM (L _ (FunBind _ name matches _ _)) = do
 #else
-processAllLetPatsM (L _ (FunBind _ name matches _)) = do
+processAllLetPatsM (L _ (FunBind {fun_id = name, fun_matches = matches})) = do
 #endif
     let inte = unLoc $ mg_alts matches
     if null inte then Nothing
@@ -1136,7 +1248,7 @@ loopOverFunBind :: LHsBindLR GhcTc GhcTc -> (Maybe [String])
 #if __GLASGOW_HASKELL__ < 900
 loopOverFunBind (L _ (FunBind _ _ matches _ _)) = do
 #else
-loopOverFunBind (L _ (FunBind _ _ matches _)) = do
+loopOverFunBind (L _ (FunBind {fun_matches = matches})) = do
 #endif
     let inte = unLoc $ mg_alts matches
     if null inte then Nothing else do
@@ -1155,8 +1267,15 @@ loopOverVarPatM (L _ _) = do
     -- print ("loopOverVarPatM", show $ toConstr x)
     pure Nothing
 
+#if __GLASGOW_HASKELL__ >= 904
+-- GHC 9.4 changed the error API from raw `SDoc` to structured `TcRnMessage`;
+-- wrap the same rendered text so the emitted error content is unchanged.
+mkGhcCompileError :: CompileError -> (SrcSpan, TcRnMessage)
+mkGhcCompileError err = (src_span err, mkTcRnUnknownMessage $ mkPlainError noHints $ OP.text $ err_msg err)
+#else
 mkGhcCompileError :: CompileError -> (SrcSpan, OP.SDoc)
 mkGhcCompileError err = (src_span err, OP.text $ err_msg err)
+#endif
 
 transformFromNameStableString :: (String) -> String -> Bool -> FunctionInfo
 transformFromNameStableString ( str) loc isF  =

--- a/fdep/src/Fdep/Plugin.hs
+++ b/fdep/src/Fdep/Plugin.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE NamedFieldPuns,PartialTypeSignatures #-}
 {-# OPTIONS_GHC -Werror=unused-imports -Werror=incomplete-patterns -Werror=name-shadowing #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 module Fdep.Plugin (plugin,collectDecls) where
 
@@ -34,12 +35,19 @@ import GHC.IO (unsafePerformIO)
 import GHC.Tc.Utils.TcType
 import GHC.Core.Type hiding (tyConsOfType)
 import GHC.Core.TyCo.Rep
+#if __GLASGOW_HASKELL__ >= 904
+import GHC.Data.Bag hiding (headMaybe)
+#else
 import GHC.Data.Bag
+#endif
 import GHC.Core.TyCon
 import GHC.Core.DataCon
 import GHC.Hs.Pat
 import GHC.Unit.Types
 import GHC
+#if __GLASGOW_HASKELL__ >= 904
+import GHC.Plugins (CoreToDo(..))
+#endif
 import GHC.Types.SourceText
 import GHC.Driver.Plugins
 import GHC.Types.Name.Reader
@@ -47,7 +55,7 @@ import GHC.Driver.Env
 import GHC.Tc.Types
 import GHC.Unit.Module.ModSummary
 import GHC.Utils.Outputable (showSDocUnsafe,ppr)
-import GHC.Types.Name hiding (varName)
+import GHC.Types.Name hiding (varName, fieldName)
 import GHC.Types.Var
 import qualified Data.Aeson.KeyMap as HM
 import GHC.Types.Id
@@ -55,6 +63,10 @@ import GHC.Core
 import GHC.Core.Opt.Monad
 import GHC.Unit.Module.ModGuts 
 import GHC.Data.FastString
+#if __GLASGOW_HASKELL__ >= 904
+import GHC.Types.PkgQual (RawPkgQual(..))
+import GHC.Core.ConLike (ConLike)
+#endif
 #else
 import CoreMonad
 import CoreSyn
@@ -70,6 +82,38 @@ import GhcPlugins hiding ((<>),tyConsOfType,tyConsOfType)
 import Outputable ()
 import TcRnTypes (TcGblEnv (..), TcM)
 #endif
+
+-- Version-stable pattern synonyms / helpers bridging the GHC 9.4 AST changes.
+#if __GLASGOW_HASKELL__ >= 904
+pattern HsConLikeOut :: [Var] -> ConLike -> HsExpr GhcTc
+pattern HsConLikeOut tvs con <- XExpr (ConLikeTc con tvs _)
+
+pattern PatHsPar :: LHsExpr (GhcPass p) -> HsExpr (GhcPass p)
+pattern PatHsPar e <- HsPar _ _ e _
+
+pattern PatHsAppType :: LHsExpr (GhcPass p) -> HsExpr (GhcPass p)
+pattern PatHsAppType e <- HsAppType _ e _ _
+
+pattern PHsRecField :: lhs -> rhs -> Bool -> HsFieldBind lhs rhs
+pattern PHsRecField lbl expr pun <- HsFieldBind{hfbLHS=lbl, hfbRHS=expr, hfbPun=pun}
+
+type LHsRecUpdFieldTc = LHsRecUpdField GhcTc GhcTc
+
+recUpdFieldsToEither :: LHsRecUpdFields GhcTc -> Either [LHsRecUpdFieldTc] [LHsRecUpdProj GhcTc]
+recUpdFieldsToEither (RegularRecUpdFields _ fs)    = Left fs
+recUpdFieldsToEither (OverloadedRecUpdFields _ fs) = Right fs
+#else
+pattern PatHsPar :: LHsExpr (GhcPass p) -> HsExpr (GhcPass p)
+pattern PatHsPar e <- HsPar _ e
+
+pattern PatHsAppType :: LHsExpr (GhcPass p) -> HsExpr (GhcPass p)
+pattern PatHsAppType e <- HsAppType _ e _
+
+pattern PHsRecField lbl expr pun <- HsRecField{hsRecFieldLbl=lbl, hsRecFieldArg=expr, hsRecPun=pun}
+
+type LHsRecUpdFieldTc = LHsRecUpdField GhcTc
+#endif
+{-# COMPLETE PHsRecField #-}
 
 plugin :: Plugin
 plugin =
@@ -114,8 +158,16 @@ toLBind (NonRec binder expr) = [(nameStableString $ idName binder,filter (\(name
 toLBind (Rec binds) = map (\(b, e) -> (nameStableString $ idName b,filter (\(name,_) -> "$f" `Data.List.isPrefixOf` name) $ map (\x -> (showSDocUnsafe $ ppr $ varName x,showSDocUnsafe $ ppr $ varType x)) (e ^? biplateRef :: [Id])) ) binds
 
 
+#if __GLASGOW_HASKELL__ >= 904
+-- GHC 9.4 changed parsedResultAction to take/return `ParsedResult` (wrapping the
+-- HsParsedModule + parse messages); unwrap it and return it unchanged.
+collectDecls :: [CommandLineOption] -> ModSummary -> ParsedResult -> Hsc ParsedResult
+collectDecls opts modSummary parsedResult = do
+    let hsParsedModule = parsedResultModule parsedResult
+#else
 collectDecls :: [CommandLineOption] -> ModSummary -> HsParsedModule -> Hsc HsParsedModule
 collectDecls opts modSummary hsParsedModule = do
+#endif
     let cliOptions = case opts of
                     [] ->  defaultCliOptions
                     (local : _) -> 
@@ -140,8 +192,38 @@ collectDecls opts modSummary hsParsedModule = do
             -- writeFile (modulePath <> ".types_code.json") (encodePretty $ typesCodeString)
             -- writeFile (modulePath <> ".class_code.json") (encodePretty $ classCodeString)
             -- writeFile (modulePath <> ".instance_code.json") (encodePretty $ instanceCodeString)
+#if __GLASGOW_HASKELL__ >= 904
+    pure parsedResult
+#else
     pure hsParsedModule
+#endif
 
+#if __GLASGOW_HASKELL__ >= 904
+-- GHC 9.4 reworked ImportDecl: ideclPkgQual -> RawPkgQual, ideclImplicit moved
+-- into ideclExt, ideclHiding -> ideclImportList (ImportListInterpretation).
+fromGHCImportDecl :: LImportDecl GhcPs -> [SimpleImportDecl]
+fromGHCImportDecl (L _span ImportDecl{..}) = [SimpleImportDecl {
+    moduleName' = moduleNameToText (unLoc ideclName),
+    packageName = case ideclPkgQual of
+            RawPkgQual sl -> Just (stringLiteralToText sl)
+            NoRawPkgQual  -> Nothing,
+    isBootSource = case ideclSource of
+            IsBoot -> True
+            NotBoot -> False,
+    isSafe = ideclSafe,
+    qualifiedStyle = convertQualifiedStyle ideclQualified,
+    isImplicit = ideclImplicit ideclExt,
+    asModuleName = fmap (moduleNameToText . unLoc) ideclAs,
+    hidingSpec = case ideclImportList of
+        Nothing -> Nothing
+        Just (interp, names) -> Just $ HidingSpec {
+            isHiding = interp == EverythingBut,
+            names = convertLIEsToText names
+        },
+    line_number = spanToLine _span
+}]
+fromGHCImportDecl (L span (XImportDecl _)) = []
+#else
 fromGHCImportDecl :: LImportDecl GhcPs -> [SimpleImportDecl]
 fromGHCImportDecl (L _span ImportDecl{..}) = [SimpleImportDecl {
     moduleName' = moduleNameToText (unLoc ideclName),
@@ -166,6 +248,7 @@ fromGHCImportDecl (L _span ImportDecl{..}) = [SimpleImportDecl {
     line_number = spanToLine _span
 }]
 fromGHCImportDecl (L span (XImportDecl _)) = []
+#endif
 
 moduleNameToText :: ModuleName -> T.Text
 moduleNameToText = T.pack . moduleNameString
@@ -173,7 +256,11 @@ moduleNameToText = T.pack . moduleNameString
 stringLiteralToText :: StringLiteral -> T.Text
 stringLiteralToText StringLiteral {sl_st} =
     case sl_st  of
+#if __GLASGOW_HASKELL__ >= 904
+        SourceText s -> T.pack (unpackFS s)
+#else
         SourceText s -> T.pack s
+#endif
         _ -> T.pack "NoSourceText"
 
 convertQualifiedStyle :: ImportDeclQualifiedStyle -> QualifiedStyle
@@ -184,7 +271,9 @@ convertQualifiedStyle QualifiedPost    = Fdep.Types.Qualified
 -- (GenLocated (Anno [GenLocated l (IE GhcPs)]) [GenLocated l (IE GhcPs)])
 convertLIEsToText :: _ -> [T.Text]
 convertLIEsToText lies = 
-#if __GLASGOW_HASKELL__ >= 900
+#if __GLASGOW_HASKELL__ >= 904
+    concatMap (ieNameToText . unLoc) (unXRec @(GhcPs) lies :: [LIE GhcPs])
+#elif __GLASGOW_HASKELL__ >= 900
     concatMap (ieNameToText . unLoc) (unXRec @(GhcPs) lies)
 #else
     concatMap (ieNameToText . unLoc) (unLoc lies)
@@ -204,6 +293,11 @@ processDecls decls = do
          , concatMap (\(_,_,_,i) -> i) results
          )
 
+#if __GLASGOW_HASKELL__ >= 904
+-- GHC 9.4 removed the `la2r` helper (SrcSpanAnn' -> RealSrcSpan).
+la2r :: SrcSpanAnn' a -> RealSrcSpan
+la2r = realSrcSpan . locA
+#endif
 #if __GLASGOW_HASKELL__ >= 900
 spanToLine :: _ -> (Int,Int)
 spanToLine s = (srcSpanStartLine $ la2r s,srcSpanEndLine $ la2r s)
@@ -507,13 +601,17 @@ instance Show PayloadType where
   show FUNCTION_IO    = "functionIO"
 
 loopOverLHsBindLR :: CliOptions -> _ -> (Maybe Text) -> Text -> LHsBindLR GhcTc GhcTc -> IO ()
+#if __GLASGOW_HASKELL__ >= 904
+loopOverLHsBindLR cliOptions con mParentName path (L _ (XHsBindsLR AbsBinds{abs_binds = binds})) =
+#else
 loopOverLHsBindLR cliOptions con mParentName path (L _ AbsBinds{abs_binds = binds}) =
+#endif
     void $ mapM (loopOverLHsBindLR cliOptions con mParentName path) $ bagToList binds
 loopOverLHsBindLR cliOptions con mParentName _path (L location bind) = do
     let typesUsed = (map varType $ (bind ^? biplateRef :: [Var])) <> (map idType $ (bind ^? biplateRef :: [Id])) <> (bind ^? biplateRef :: [Type])
     case bind of
 #if __GLASGOW_HASKELL__ >= 900
-        (FunBind _ id matches _) -> do
+        (FunBind {fun_id = id, fun_matches = matches}) -> do
 #else
         (FunBind _ id matches _ _) -> do
 #endif
@@ -591,7 +689,11 @@ loopOverLHsBindLR cliOptions con mParentName _path (L location bind) = do
             name <- pure (fName <> "**" <> (T.pack ((showSDocUnsafe . ppr) $ locA location)))
             nestedNameWithParent <- pure $ (maybe (name) (\x -> x <> "::" <> name) mParentName)
             processAndSendTypeDetails cliOptions con _path nestedNameWithParent typesUsed
+#if __GLASGOW_HASKELL__ >= 904
+            processFunctionInputOutput (fst pat_ext) cliOptions con _path nestedNameWithParent
+#else
             processFunctionInputOutput (pat_ext) cliOptions con _path nestedNameWithParent
+#endif
             if (maybeBool $ tc_funcs cliOptions)
                 then void $ mapM (processExpr nestedNameWithParent _path) (stmts <> map (\v -> wrapXRec @(GhcTc) $ HsVar noExtField v) (tail' ids))
                 else when (not $ "$$" `T.isInfixOf` name) $
@@ -643,15 +745,29 @@ loopOverLHsBindLR cliOptions con mParentName _path (L location bind) = do
             processExpr keyFunction path funr
         processExpr keyFunction path (L _ (NegApp _ funl _)) =
             processExpr keyFunction path funl
+#if __GLASGOW_HASKELL__ >= 904
+        processExpr keyFunction path (L _ (XExpr (HsTick _ fun))) =
+            processExpr keyFunction path fun
+#else
         processExpr keyFunction path (L _ (HsTick _ _ fun)) =
             processExpr keyFunction path fun
+#endif
         processExpr keyFunction path (L _ (HsStatic _ fun)) =
             processExpr keyFunction path fun
+#if __GLASGOW_HASKELL__ >= 904
+        processExpr keyFunction path (L _ (XExpr (HsBinTick _ _ fun))) =
+            processExpr keyFunction path fun
+#else
         processExpr keyFunction path (L _ (HsBinTick _ _ _ fun)) =
             processExpr keyFunction path fun
+#endif
         processExpr keyFunction path (L _ (ExprWithTySig _ fun _)) =
             processExpr keyFunction path fun
+#if __GLASGOW_HASKELL__ >= 904
+        processExpr keyFunction path (L _ (HsLet _ _ exprLStmt _ func)) = do
+#else
         processExpr keyFunction path (L _ (HsLet _ exprLStmt func)) = do
+#endif
 #if __GLASGOW_HASKELL__ >= 900
             processHsLocalBinds keyFunction path exprLStmt
 #else
@@ -665,10 +781,14 @@ loopOverLHsBindLR cliOptions con mParentName _path (L location bind) = do
             void $ mapM (processMatch keyFunction path) (unLoc $ mg_alts exprLStmt)
         processExpr keyFunction path (L _ (ExplicitSum _ _ _ fun)) = processExpr keyFunction path fun
         processExpr keyFunction path (L _ (SectionR _ funl funr)) = processExpr keyFunction path funl <> processExpr keyFunction path funr
-        processExpr keyFunction path (L _ (HsPar _ fun)) =
+        processExpr keyFunction path (L _ (PatHsPar fun)) =
             processExpr keyFunction path fun
-        processExpr keyFunction path (L _ (HsAppType _ fun _)) = processExpr keyFunction path fun
+        processExpr keyFunction path (L _ (PatHsAppType fun)) = processExpr keyFunction path fun
+#if __GLASGOW_HASKELL__ >= 904
+        processExpr keyFunction path (L _ x@(HsLamCase _ _ exprLStmt)) =
+#else
         processExpr keyFunction path (L _ x@(HsLamCase _ exprLStmt)) =
+#endif
             void $ mapM (processMatch keyFunction path) (unLoc $ mg_alts exprLStmt)
         processExpr keyFunction path (L _ x@(HsLam _ exprLStmt)) =
             void $ mapM (processMatch keyFunction path) (unLoc $ mg_alts exprLStmt)
@@ -682,8 +802,10 @@ loopOverLHsBindLR cliOptions con mParentName _path (L location bind) = do
         --     let stmtsL = (exprLStmtL ^? biplateRef :: [LHsExpr GhcTc])
         --         stmtsR = (exprLStmtR ^? biplateRef :: [LHsExpr GhcTc])
         --     in void $ mapM (processExpr keyFunction path) (stmtsL <> stmtsR)
+#if __GLASGOW_HASKELL__ < 904
         processExpr keyFunction path (L _ (HsSpliceE _ splice)) =
             void $ mapM (processExpr keyFunction path) (extractExprsFromSplice splice)
+#endif
         processExpr keyFunction path y@(L _ x@(HsConLikeOut _ hsType)) = do
             expr <- pure $ toJSON $ transformFromNameStableString (Just $ ("$_type$" <> (T.pack $ showSDocUnsafe $ ppr hsType)), (Just $ T.pack $ getLocTC' $ y), (Just $ T.pack $ show $ toConstr hsType), mempty)
             sendTextData' cliOptions con path (transformPayload path keyFunction EXPR expr)
@@ -724,11 +846,17 @@ loopOverLHsBindLR cliOptions con mParentName _path (L location bind) = do
                     processExpr keyFunction path l
                     processExpr keyFunction path m
                     processExpr keyFunction path r
+#if __GLASGOW_HASKELL__ < 904
         processExpr keyFunction path (L _ (HsRnBracketOut _ exprLStmtL exprLStmtR)) =
             let stmtsLNoLoc = (exprLStmtL ^? biplateRef :: [HsExpr GhcTc])
                 stmtsRNoLoc = (exprLStmtR ^? biplateRef :: [HsExpr GhcTc])
             in void $ mapM (processExpr keyFunction path) (map (wrapXRec @(GhcTc)) $ (stmtsLNoLoc <> stmtsRNoLoc))
+#endif
+#if __GLASGOW_HASKELL__ >= 904
+        processExpr keyFunction path x@(L _ (HsRecSel _ exprLStmt)) = getDataTypeDetails keyFunction path x
+#else
         processExpr keyFunction path x@(L _ (HsRecFld _ exprLStmt)) = getDataTypeDetails keyFunction path x
+#endif
         processExpr keyFunction path y@(L _ x@(RecordCon expr (L _ (iD)) rcon_flds)) = getDataTypeDetails keyFunction path y
         processExpr keyFunction path x@(L _ (RecordUpd _ rupd_expr rupd_flds)) = getDataTypeDetails keyFunction path x
         processExpr keyFunction path (L _ (ExplicitTuple _ exprLStmt _)) =
@@ -739,13 +867,25 @@ loopOverLHsBindLR cliOptions con mParentName _path (L location bind) = do
                         _ -> pure ()) l
         processExpr keyFunction path y@(L _ (XExpr overLitVal)) = do
             processXXExpr keyFunction path overLitVal
+#if __GLASGOW_HASKELL__ >= 904
+        processExpr keyFunction path y@(L _ x@(HsOverLabel _ _ fs)) = do
+#else
         processExpr keyFunction path y@(L _ x@(HsOverLabel _ fs)) = do
+#endif
             expr <- pure $ toJSON $ transformFromNameStableString (Just $ ("$_overLabel$" <> (T.pack $ showSDocUnsafe $ ppr fs)), (Just $ T.pack $ getLocTC' $ y), (Just $ T.pack $ show $ toConstr x), mempty)
             sendTextData' cliOptions con path (transformPayload path keyFunction EXPR expr)
+#if __GLASGOW_HASKELL__ >= 904
+        processExpr keyFunction path (L _ (HsTypedBracket _ funl)) =
+            processExpr keyFunction path funl
+        processExpr keyFunction path (L _ (HsUntypedBracket _ hsQuote)) =
+            let stmts = (hsQuote ^? biplateRef :: [LHsExpr GhcTc])
+            in void $ mapM (processExpr keyFunction path) stmts
+#else
         processExpr keyFunction path (L _ (HsTcBracketOut b mQW exprLStmtL exprLStmtR)) =
             let stmtsL = (exprLStmtL ^? biplateRef :: [LHsExpr GhcTc])
                 stmtsR = (exprLStmtR ^? biplateRef :: [LHsExpr GhcTc])
             in void $ mapM (processExpr keyFunction path) (stmtsL <> stmtsR)
+#endif
         processExpr keyFunction path (L _ x) =
             let stmts = (x ^? biplateRef :: [LHsExpr GhcTc])
                 stmtsNoLoc = (x ^? biplateRef :: [HsExpr GhcTc])
@@ -929,7 +1069,11 @@ loopOverLHsBindLR cliOptions con mParentName _path (L location bind) = do
         extractExprsFromCmdLStmt keyFunction path (L _ stmt) = extractExprsFromStmtLR keyFunction path stmt
 
         extractExprsFromMatchGroup :: Text -> Text -> MatchGroup GhcTc (LHsCmd GhcTc) -> IO ()
+#if __GLASGOW_HASKELL__ >= 904
+        extractExprsFromMatchGroup keyFunction path (MG _ (L _ matches)) = void $ mapM (extractExprsFromMatch keyFunction path) matches
+#else
         extractExprsFromMatchGroup keyFunction path (MG _ (L _ matches) _) = void $ mapM (extractExprsFromMatch keyFunction path) matches
+#endif
         extractExprsFromMatchGroup keyFunction path (_) = pure ()
 
         extractExprsFromMatch :: Text -> Text ->  LMatch GhcTc (LHsCmd GhcTc) -> IO ()
@@ -1041,7 +1185,11 @@ loopOverLHsBindLR cliOptions con mParentName _path (L location bind) = do
                 extractExprsFromLHsCmd keyFunction path cmd'
                 processExpr keyFunction path e
             HsCmdLam _ mg -> extractExprsFromMatchGroup keyFunction path mg
+#if __GLASGOW_HASKELL__ >= 904
+            HsCmdPar _ _ cmd' _ ->
+#else
             HsCmdPar _ cmd' ->
+#endif
                 extractExprsFromLHsCmd keyFunction path cmd'
             HsCmdCase _ e mg -> do
                 extractExprsFromMatchGroup keyFunction path mg
@@ -1099,7 +1247,11 @@ loopOverLHsBindLR cliOptions con mParentName _path (L location bind) = do
                 _ -> pure ()
             where
             extractExprsFromOverLit :: HsOverLit GhcTc -> IO ()
+#if __GLASGOW_HASKELL__ >= 904
+            extractExprsFromOverLit (OverLit (OverLitTc _ e _) _) = processExpr keyFunction path (noLoc e)
+#else
             extractExprsFromOverLit (OverLit _ _ e) = processExpr keyFunction path (noLoc e)
+#endif
             extractExprsFromOverLit _ = pure ()
 
             extractExprsFromHsConPatDetails :: Text -> Text -> HsConPatDetails GhcTc -> IO ()
@@ -1140,7 +1292,7 @@ loopOverLHsBindLR cliOptions con mParentName _path (L location bind) = do
 #else
         getDataTypeDetails keyFunction path (L _ (RecordCon _ (iD) rcon_flds)) = (extractRecordBinds keyFunction path (T.pack $ nameStableString $ getName (GHC.unLoc iD)) (rcon_flds))
 #endif
-        getDataTypeDetails keyFunction path y@(L _ (RecordUpd x@(RecordUpdTc rupd_cons rupd_in_tys rupd_out_tys rupd_wrap) rupd_expr rupd_flds)) = do
+        getDataTypeDetails keyFunction path y@(L _ (RecordUpd x rupd_expr rupd_flds)) = do
             let names = (x ^? biplateRef :: [DataCon])
                 types = (x ^? biplateRef :: [Type])
             void $ mapM (\xx -> do
@@ -1153,8 +1305,16 @@ loopOverLHsBindLR cliOptions con mParentName _path (L location bind) = do
                 expr <- pure $ toJSON $ transformFromNameStableString (Just $ ("$_type$" <> (T.pack $ showSDocUnsafe $ ppr xx)), (Just $ T.pack $ getLocTC' $ y), (Just $ T.pack $ show $ toConstr xx), mempty)
                 sendTextData' cliOptions con path (transformPayload path keyFunction EXPR expr)
                 ) types
+#if __GLASGOW_HASKELL__ >= 904
+            (getFieldUpdates y keyFunction path (T.pack $ showSDocUnsafe $ ppr rupd_expr) (recUpdFieldsToEither rupd_flds))
+#else
             (getFieldUpdates y keyFunction path (T.pack $ showSDocUnsafe $ ppr rupd_expr) rupd_flds)
+#endif
+#if __GLASGOW_HASKELL__ >= 904
+        getDataTypeDetails keyFunction path y@(L _ (HsRecSel _ (FieldOcc id' lnrdrname))) = do
+#else
         getDataTypeDetails keyFunction path y@(L _ (HsRecFld _ (Unambiguous id' lnrdrname))) = do
+#endif
             let name = T.pack $ nameStableString $ varName id'
                 _type = T.pack $ showSDocUnsafe $ ppr $ varType id'
             expr <- pure $ toJSON $ transformFromNameStableString (Just name, Just $ T.pack $ getLocTC' $ y, Just _type, mempty)
@@ -1162,6 +1322,7 @@ loopOverLHsBindLR cliOptions con mParentName _path (L location bind) = do
             -- case reLocN lnrdrname of
             --     (L l rdrname) -> do
             --         print $ (handleRdrName rdrname,showSDocUnsafe $ ppr id')
+#if __GLASGOW_HASKELL__ < 904
         getDataTypeDetails keyFunction path y@(L _ (HsRecFld _ (Ambiguous   id'  lnrdrname))) = do
             let name = T.pack $ nameStableString $ varName id'
                 _type = T.pack $ showSDocUnsafe $ ppr $ varType id'
@@ -1170,13 +1331,22 @@ loopOverLHsBindLR cliOptions con mParentName _path (L location bind) = do
             -- case reLocN lnrdrname of
             --     (L l rdrname) -> do
             --         print $ (handleRdrName rdrname,showSDocUnsafe $ ppr id')
+#endif
+#if __GLASGOW_HASKELL__ >= 904
+        getDataTypeDetails keyFunction path (L _ y@(HsRecSel _ _)) = pure ()
+#else
         getDataTypeDetails keyFunction path (L _ y@(HsRecFld _ _)) = pure ()
+#endif
         getDataTypeDetails keyFunction path _ = pure ()
 
         -- inferFieldType :: Name -> String
         inferFieldTypeFieldOcc (L _ (FieldOcc _ (L _ rdrName))) = handleRdrName rdrName
         inferFieldTypeFieldOcc (L _ (XFieldOcc _)) = mempty--handleRdrName rdrName
+#if __GLASGOW_HASKELL__ >= 904
+        inferFieldTypeAFieldOcc = (handleRdrName . ambiguousFieldOccRdrName . unLoc)
+#else
         inferFieldTypeAFieldOcc = (handleRdrName . rdrNameAmbiguousFieldOcc . unLoc)
+#endif
 
         handleRdrName :: RdrName -> String
         handleRdrName rdrName = case rdrName of
@@ -1193,14 +1363,14 @@ loopOverLHsBindLR cliOptions con mParentName _path (L location bind) = do
         --         Exact name -> nameStableString name
 
 #if __GLASGOW_HASKELL__ >= 900
-        getFieldUpdates :: GenLocated (SrcSpanAnn' a) e -> Text -> Text -> Text -> Either [LHsRecUpdField GhcTc] [LHsRecUpdProj GhcTc] -> IO ()
+        getFieldUpdates :: GenLocated (SrcSpanAnn' a) e -> Text -> Text -> Text -> Either [LHsRecUpdFieldTc] [LHsRecUpdProj GhcTc] -> IO ()
         getFieldUpdates _ keyFunction path type_ fields =
             case fields of
                 Left x -> void $ mapM (extractField) x
                 Right x -> (void $ mapM (processRecordProj) x)
             where
             processRecordProj :: LHsRecProj GhcTc (LHsExpr GhcTc) -> IO ()
-            processRecordProj (L _ (HsRecField { hsRecFieldAnn, hsRecFieldLbl=lbl , hsRecFieldArg=expr ,hsRecPun=pun })) = do
+            processRecordProj (L _ (PHsRecField lbl expr pun)) = do
                 let fieldName = (T.pack $ showSDocUnsafe $ ppr lbl)
                 case lbl of
                     (L _ (FieldLabelStrings ll)) -> void $ mapM (processHsFieldLabel keyFunction path) ll
@@ -1208,24 +1378,32 @@ loopOverLHsBindLR cliOptions con mParentName _path (L location bind) = do
                 processExpr keyFunction path expr
 
             -- extractField :: HsRecUpdField GhcTc -> IO ()
-            extractField y@(L _ (HsRecField{hsRecFieldLbl = lbl, hsRecFieldArg = expr, hsRecPun = pun})) =do
+            extractField y@(L _ (PHsRecField lbl expr pun)) =do
                 let fieldName = (T.pack $ showSDocUnsafe $ ppr lbl)
                     fieldType = (T.pack $ inferFieldTypeAFieldOcc lbl)
                 processExpr keyFunction path expr
                 expr' <- pure $ toJSON $ transformFromNameStableString (Just $ ("$_fieldName$" <> fieldName), (Just $ T.pack $ getLocTC' $ y), (Just $ fieldType), mempty)
                 sendTextData' cliOptions con path (transformPayload path keyFunction EXPR expr')
 
+#if __GLASGOW_HASKELL__ >= 904
+        processHsFieldLabel :: Text -> Text -> XRec GhcTc (DotFieldOcc GhcTc) -> IO ()
+        processHsFieldLabel keyFunction path y@(L l x@(DotFieldOcc _ (L _ hflLabel))) = do
+            expr <- pure $ toJSON $ transformFromNameStableString (Just $ ("$_fieldName$" <> (T.pack $ showSDocUnsafe $ ppr hflLabel)), (Just $ T.pack $ showSDocUnsafe $ ppr $ getLocA $ y), (Just $ T.pack $ show $ toConstr x), mempty)
+            sendTextData' cliOptions con path (transformPayload path keyFunction EXPR expr)
+        processHsFieldLabel keyFunction path (L _ (XDotFieldOcc _)) = pure ()
+#else
         processHsFieldLabel :: Text -> Text -> Located (HsFieldLabel GhcTc) -> IO ()
         processHsFieldLabel keyFunction path y@(L l x@(HsFieldLabel _ (L _ hflLabel))) = do
             expr <- pure $ toJSON $ transformFromNameStableString (Just $ ("$_fieldName$" <> (T.pack $ showSDocUnsafe $ ppr hflLabel)), (Just $ T.pack $ showSDocUnsafe $ ppr $ getLoc $ y), (Just $ T.pack $ show $ toConstr x), mempty)
             sendTextData' cliOptions con path (transformPayload path keyFunction EXPR expr)
         processHsFieldLabel keyFunction path (L _ (XHsFieldLabel _)) = pure ()
+#endif
 #else
         getFieldUpdates :: _ -> Text -> Text -> Text -> [LHsRecUpdField GhcTc]-> IO ()
         getFieldUpdates y keyFunction path type_ fields = void $ mapM extractField fields
             where
             extractField :: LHsRecUpdField GhcTc -> IO ()
-            extractField (L l x@(HsRecField{hsRecFieldLbl = lbl, hsRecFieldArg = expr', hsRecPun = pun})) =do
+            extractField (L l x@(PHsRecField lbl expr' pun)) =do
                 let fieldName = (T.pack $ showSDocUnsafe $ ppr lbl)
                     fieldType = (T.pack $ inferFieldTypeAFieldOcc lbl)
                 processExpr keyFunction path expr'
@@ -1238,7 +1416,7 @@ loopOverLHsBindLR cliOptions con mParentName _path (L location bind) = do
             void $ mapM extractField fields
             where
             extractField :: LHsRecField GhcTc (LHsExpr GhcTc) -> IO ()
-            extractField (L l x@(HsRecField{hsRecFieldLbl = lbl, hsRecFieldArg = expr, hsRecPun = pun})) = do
+            extractField (L l x@(PHsRecField lbl expr pun)) = do
                 let fieldName = (T.pack $ showSDocUnsafe $ ppr lbl)
                     fieldType = (T.pack $ inferFieldTypeFieldOcc lbl)
                 processExpr keyFunction path expr
@@ -1260,7 +1438,11 @@ loopOverLHsBindLR cliOptions con mParentName _path (L location bind) = do
         extractExprsFromCmdLStmt keyFunction path (L _ stmt) = extractExprsFromStmtLR keyFunction path stmt
 
         extractExprsFromMatchGroup :: Text -> Text -> MatchGroup GhcTc (LHsCmd GhcTc) -> IO ()
+#if __GLASGOW_HASKELL__ >= 904
+        extractExprsFromMatchGroup keyFunction path (MG _ (L _ matches)) = void $ mapM (extractExprsFromMatch keyFunction path) matches
+#else
         extractExprsFromMatchGroup keyFunction path (MG _ (L _ matches) _) = void $ mapM (extractExprsFromMatch keyFunction path) matches
+#endif
 
         extractExprsFromMatch :: Text -> Text ->  LMatch GhcTc (LHsCmd GhcTc) -> IO ()
         extractExprsFromMatch keyFunction path (L _ (Match _ _ _ grhs)) = extractExprsFromGRHSs keyFunction path grhs
@@ -1365,18 +1547,30 @@ loopOverLHsBindLR cliOptions con mParentName _path (L location bind) = do
                 extractExprsFromLHsCmd keyFunction path cmd'
                 processExpr keyFunction path e
             HsCmdLam _ mg -> extractExprsFromMatchGroup keyFunction path mg
+#if __GLASGOW_HASKELL__ >= 904
+            HsCmdPar _ _ cmd' _ ->
+#else
             HsCmdPar _ cmd' ->
+#endif
                 extractExprsFromLHsCmd keyFunction path cmd'
             HsCmdCase _ e mg -> do
                 extractExprsFromMatchGroup keyFunction path mg
                 processExpr keyFunction path e
+#if __GLASGOW_HASKELL__ >= 904
+            HsCmdLamCase _ _ mg ->
+#else
             HsCmdLamCase _ mg ->
+#endif
                 extractExprsFromMatchGroup keyFunction path mg
             HsCmdIf _ _ predExpr thenCmd elseCmd -> do
                 extractExprsFromLHsCmd keyFunction path elseCmd
                 extractExprsFromLHsCmd keyFunction path thenCmd
                 processExpr keyFunction path predExpr
+#if __GLASGOW_HASKELL__ >= 904
+            HsCmdLet _ _ binds _ cmd' -> do
+#else
             HsCmdLet _ binds cmd' -> do
+#endif
                 processHsLocalBinds keyFunction path binds
                 extractExprsFromLHsCmd keyFunction path cmd'
             HsCmdDo _ stmts ->
@@ -1391,10 +1585,18 @@ loopOverLHsBindLR cliOptions con mParentName _path (L location bind) = do
                     sendTextData' cliOptions con path (transformPayload path keyFunction EXPR expr)
                 VarPat _ var    -> processExpr keyFunction path ((wrapXRec @(GhcTc)) (HsVar noExtField (var)))
                 LazyPat _ p   -> (extractExprsFromPat keyFunction path) p
+#if __GLASGOW_HASKELL__ >= 904
+                AsPat _ var _ p   -> do
+#else
                 AsPat _ var p   -> do
+#endif
                     processExpr keyFunction path ((wrapXRec @(GhcTc)) (HsVar noExtField (var)))
                     (extractExprsFromPat keyFunction path) p
+#if __GLASGOW_HASKELL__ >= 904
+                ParPat _ _ p _    -> (extractExprsFromPat keyFunction path) p
+#else
                 ParPat _ p    -> (extractExprsFromPat keyFunction path) p
+#endif
                 BangPat _ p   -> (extractExprsFromPat keyFunction path) p
                 ListPat _ ps  -> void $ mapM (extractExprsFromPat keyFunction path) ps
                 TuplePat _ ps _ -> void $ mapM (extractExprsFromPat keyFunction path) ps
@@ -1422,7 +1624,11 @@ loopOverLHsBindLR cliOptions con mParentName _path (L location bind) = do
                 XPat _         -> pure ()
             where
             extractExprsFromOverLit :: HsOverLit GhcTc -> IO ()
+#if __GLASGOW_HASKELL__ >= 904
+            extractExprsFromOverLit (OverLit (OverLitTc _ e _) _) = processExpr keyFunction path $ wrapXRec @(GhcTc) e
+#else
             extractExprsFromOverLit (OverLit _ _ e) = processExpr keyFunction path $ wrapXRec @(GhcTc) e
+#endif
             extractExprsFromOverLit _ = pure ()
 
             extractExprsFromHsConPatDetails :: Text -> Text -> HsConPatDetails GhcTc -> IO ()
@@ -1447,6 +1653,11 @@ loopOverLHsBindLR cliOptions con mParentName _path (L location bind) = do
             processExpr keyFunction path (wrapXRec @(GhcTc) hsExpr)
         processXXExpr keyFunction path (ExpansionExpr (HsExpanded _ expansionExpr)) =
             void $ mapM (processExpr keyFunction path . (wrapXRec @(GhcTc))) [expansionExpr]
+#if __GLASGOW_HASKELL__ >= 904
+        -- ConLikeTc/HsTick/HsBinTick joined XXExprGhcTc in GHC 9.4; they are
+        -- already handled at the HsExpr level in processExpr, so ignore here.
+        processXXExpr _ _ _ = pure ()
+#endif
 
 getLocTC' :: GenLocated (SrcSpanAnn' a) e -> String
 getLocTC' = (showSDocUnsafe . ppr . la2r . getLoc)
@@ -1458,9 +1669,16 @@ getLocTC' = (showSDocUnsafe . ppr . getLoc)
 getLoc' = (showSDocUnsafe . ppr . getLoc)
 #endif
 
+#if __GLASGOW_HASKELL__ >= 904
+-- GHC 9.4 split HsSplice into HsUntypedSplice (expr splices / quasiquotes).
+extractExprsFromSplice :: HsUntypedSplice GhcTc -> [LHsExpr GhcTc]
+extractExprsFromSplice (HsUntypedSpliceExpr _ e) = [e]
+extractExprsFromSplice _ = []
+#else
 extractExprsFromSplice :: HsSplice GhcTc -> [LHsExpr GhcTc]
 extractExprsFromSplice (HsTypedSplice _ _ _ e) = [e]
 extractExprsFromSplice (HsUntypedSplice _ _ _ e) = [e]
 extractExprsFromSplice (HsQuasiQuote _ _ _ _ _) = []
 extractExprsFromSplice (HsSpliced _ _ _) = []
 extractExprsFromSplice _ = []
+#endif

--- a/fieldInspector/src/FieldInspector/PluginFields.hs
+++ b/fieldInspector/src/FieldInspector/PluginFields.hs
@@ -26,6 +26,7 @@ import GHC.Types.Name hiding (varName)
 import GHC.Types.Var
 import qualified Data.Aeson.KeyMap as HM
 import GHC.Core.Opt.Monad
+import GHC.Core.Opt.Pipeline.Types (CoreToDo(..))
 import GHC.Core
 import GHC.Unit.Module.ModGuts
 import GHC.Types.Name.Reader
@@ -314,7 +315,7 @@ getAllTypeManipulations binds = do
 
     -- inferFieldType :: Name -> String
     inferFieldTypeFieldOcc (L _ (FieldOcc _ (L _ rdrName))) = handleRdrName rdrName
-    inferFieldTypeAFieldOcc = (handleRdrName . rdrNameAmbiguousFieldOcc . unLoc)
+    inferFieldTypeAFieldOcc = (handleRdrName . ambiguousFieldOccRdrName . unLoc)
 
     handleRdrName :: RdrName -> String
     handleRdrName x =
@@ -325,14 +326,17 @@ getAllTypeManipulations binds = do
             Exact name -> nameStableString name
 
 #if __GLASGOW_HASKELL__ >= 900
-    getFieldUpdates :: Either [LHsRecUpdField GhcTc] [LHsRecUpdProj GhcTc] -> Either [FieldRep] [Text]
-    getFieldUpdates fields = 
+    -- GHC 9.8 replaced `rupd_flds :: Either [LHsRecUpdField] [LHsRecUpdProj]`
+    -- with the `LHsRecUpdFields` GADT (RegularRecUpdFields | OverloadedRecUpdFields);
+    -- the two constructors map 1:1 onto the old Left/Right, so behavior is preserved.
+    getFieldUpdates :: LHsRecUpdFields GhcTc -> Either [FieldRep] [Text]
+    getFieldUpdates fields =
         case fields of
-           Left x -> (Left . map (extractField . unLoc)) x 
-           Right x -> (Right . map (T.pack . showSDocUnsafe . ppr)) x
+           RegularRecUpdFields{recUpdFields = x} -> (Left . map (extractField . unLoc)) x
+           OverloadedRecUpdFields{olRecUpdFields = x} -> (Right . map (T.pack . showSDocUnsafe . ppr)) x
       where
-        extractField :: HsRecUpdField GhcTc -> FieldRep
-        extractField (HsRecField{hsRecFieldLbl = lbl, hsRecFieldArg = expr, hsRecPun = pun}) =
+        extractField :: HsRecUpdField GhcTc GhcTc -> FieldRep
+        extractField (HsFieldBind{hfbLHS = lbl, hfbRHS = expr, hfbPun = pun}) =
             if pun
                 then (FieldRep (T.pack $ showSDocUnsafe $ ppr lbl) (T.pack $ showSDocUnsafe $ ppr lbl) (T.pack $ inferFieldTypeAFieldOcc lbl))
                 else (FieldRep (T.pack $ showSDocUnsafe $ ppr lbl) (T.pack $ showSDocUnsafe $ ppr (unLoc expr)) (T.pack $ inferFieldTypeAFieldOcc lbl))
@@ -352,20 +356,20 @@ getAllTypeManipulations binds = do
         Left $ map extractField fields
       where
         extractField :: LHsRecField GhcTc (LHsExpr GhcTc) -> FieldRep
-        extractField (L _ (HsRecField{hsRecFieldLbl = lbl, hsRecFieldArg = expr, hsRecPun = pun})) =
+        extractField (L _ (HsFieldBind{hfbLHS = lbl, hfbRHS = expr, hfbPun = pun})) =
             if pun
                 then (FieldRep (T.pack $ showSDocUnsafe $ ppr lbl) (T.pack $ showSDocUnsafe $ ppr lbl) (T.pack $ inferFieldTypeFieldOcc lbl))
                 else (FieldRep (T.pack $ showSDocUnsafe $ ppr lbl) (T.pack $ showSDocUnsafe $ ppr $ unLoc expr) (T.pack $ inferFieldTypeFieldOcc lbl))
 
     getFunctionName :: LHsBindLR GhcTc GhcTc -> [Text]
 #if __GLASGOW_HASKELL__ >= 900
-    getFunctionName (L _ x@(FunBind fun_ext id matches _)) = [T.pack $ nameStableString $ getName id]
+    getFunctionName (L _ x@(FunBind fun_ext id matches)) = [T.pack $ nameStableString $ getName id]
 #else
     getFunctionName (L _ x@(FunBind fun_ext id matches _ _)) = [T.pack $ nameStableString $ getName id]
 #endif
     getFunctionName (L _ (VarBind{var_id = var, var_rhs = expr})) = [T.pack $ nameStableString $ getName var]
     getFunctionName (L _ (PatBind{pat_lhs = pat, pat_rhs = expr})) = [""]
-    getFunctionName (L _ (AbsBinds{abs_binds = binds})) = Prelude.concatMap getFunctionName $ bagToList binds
+    getFunctionName (L _ (XHsBindsLR (AbsBinds{abs_binds = binds}))) = Prelude.concatMap getFunctionName $ bagToList binds
 
 processPat :: LPat GhcTc -> [(Name, Maybe Text)]
 processPat (L _ pat) = case pat of
@@ -375,7 +379,7 @@ processPat (L _ pat) = case pat of
     ConPatIn _ details -> processDetails details
 #endif
     VarPat _ x@(L _ var) -> [(varName var, Just $ T.pack $ showSDocUnsafe $ ppr $ getLoc $ x)]
-    ParPat _ pat' -> processPat pat'
+    ParPat _ _ pat' _ -> processPat pat'
     _ -> []
 
 processDetails :: HsConPatDetails GhcTc -> [(Name, Maybe Text)]
@@ -388,7 +392,7 @@ processDetails (InfixCon arg1 arg2) = processPat arg1 <> processPat arg2
 processDetails (RecCon rec) = Prelude.concatMap processPatField (rec_flds rec)
 
 processPatField :: LHsRecField GhcTc (LPat GhcTc) -> [(Name, Maybe Text)]
-processPatField (L _ HsRecField{hsRecFieldArg = arg}) = processPat arg
+processPatField (L _ HsFieldBind{hfbRHS = arg}) = processPat arg
 
 #if __GLASGOW_HASKELL__ >= 900
 getFilePath :: SrcSpan -> String

--- a/fieldInspector/src/FieldInspector/PluginTypes.hs
+++ b/fieldInspector/src/FieldInspector/PluginTypes.hs
@@ -16,9 +16,12 @@ import GHC.Utils.Outputable ()
 import qualified Data.IntMap.Internal as IntMap
 import GHC
 import GHC.Unit.Types
-import GHC.Driver.Plugins (Plugin(..),CommandLineOption,defaultPlugin,PluginRecompile(..))
+import GHC.Driver.Plugins (Plugin(..),CommandLineOption,defaultPlugin,PluginRecompile(..),ParsedResult(..))
+import qualified Data.Foldable as DF
+import Language.Haskell.Syntax.Basic (field_label)
 import GHC.Driver.Env
 import GHC.Tc.Types
+import GHC.Types.Unique.FM (plusUFM)
 import GHC.Unit.Module.ModSummary
 import GHC.Utils.Outputable (showSDocUnsafe,ppr,SDoc,Outputable)
 import GHC.Data.Bag (bagToList)
@@ -88,9 +91,15 @@ import System.Directory (createDirectoryIfMissing, removeFile)
 import System.Directory.Internal.Prelude hiding (mapM, mapM_,log)
 import Prelude hiding (id, mapM_,log)
 import Control.Exception (evaluate)
+-- Only imported to compose the LR plugins under ENABLE_LR_PLUGINS. Importing them
+-- unconditionally pulls large-anon's orphan `Outputable (GenLocated l e)` instance,
+-- which overlaps GHC 9.8's AST instance and breaks all `ppr` here. RecordDotPreprocessor
+-- (composed unconditionally below) is a separate package that does not pull large-anon.
+#if defined(ENABLE_LR_PLUGINS)
 import qualified Data.Record.Plugin as DRP
 import qualified Data.Record.Anon.Plugin as DRAP
 import qualified Data.Record.Plugin.HasFieldPattern as DRPH
+#endif
 import qualified RecordDotPreprocessor as RDP
 import qualified ApiContract.Plugin as ApiContract
 -- import qualified Fdep.Plugin as Fdep
@@ -140,22 +149,26 @@ instance Semigroup Plugin where
           (Nothing, Nothing) -> Nothing
           (Just tp, Nothing) -> Just tp
           (Nothing, Just tq) -> Just tq
-          (Just (TcPlugin tcPluginInit1 tcPluginSolve1 tcPluginStop1), Just (TcPlugin tcPluginInit2 tcPluginSolve2 tcPluginStop2)) -> Just $ TcPlugin 
+          (Just (TcPlugin tcPluginInit1 tcPluginSolve1 tcPluginRewrite1 tcPluginStop1), Just (TcPlugin tcPluginInit2 tcPluginSolve2 tcPluginRewrite2 tcPluginStop2)) -> Just $ TcPlugin
             { tcPluginInit = do
                 ip <- tcPluginInit1
                 iq <- tcPluginInit2
                 return (ip, iq)
-            , tcPluginSolve = \(sp,sq) given derived wanted -> do
-                solveP <- tcPluginSolve1 sp given derived wanted
-                solveQ <- tcPluginSolve2 sq given derived wanted
+            -- GHC 9.4+: tcPluginSolve dropped the `derived` list and gained an
+            -- EvBindsVar; tcPluginRewrite is a new field. Union the two plugins'
+            -- rewriter maps (left-biased on TyCon clashes) — behavior-preserving.
+            , tcPluginSolve = \(sp,sq) evBindsVar given wanted -> do
+                solveP <- tcPluginSolve1 sp evBindsVar given wanted
+                solveQ <- tcPluginSolve2 sq evBindsVar given wanted
                 return $ combineTcPluginResults solveP solveQ
+            , tcPluginRewrite = \(sp,sq) -> plusUFM (tcPluginRewrite1 sp) (tcPluginRewrite2 sq)
             , tcPluginStop = \(solveP,solveQ) -> do
                 tcPluginStop1 solveP
                 tcPluginStop2 solveQ
             }
     }
 
-combineTcPluginResults :: TcPluginResult -> TcPluginResult -> TcPluginResult
+combineTcPluginResults :: TcPluginSolveResult -> TcPluginSolveResult -> TcPluginSolveResult
 combineTcPluginResults resP resQ =
   case (resP, resQ) of
     (TcPluginContradiction ctsP, TcPluginContradiction ctsQ) ->
@@ -183,8 +196,11 @@ pprDataCon = ppr
 defaultCliOptions :: CliOptions
 defaultCliOptions = CliOptions {path="./tmp/fdep/",port=4444,host="::1",log=False,tc_funcs=Just False,api_conteact=Just True}
 
-collectTypeInfoParser :: [CommandLineOption] -> ModSummary -> HsParsedModule -> Hsc HsParsedModule
-collectTypeInfoParser opts modSummary hpm = do
+-- GHC 9.4 changed parsedResultAction to take/return `ParsedResult` (wrapping the
+-- HsParsedModule + parse messages); unwrap it for analysis and return it unchanged.
+collectTypeInfoParser :: [CommandLineOption] -> ModSummary -> ParsedResult -> Hsc ParsedResult
+collectTypeInfoParser opts modSummary parsedResult = do
+    let hpm = parsedResultModule parsedResult
     _ <- liftIO $ forkIO $
             do
                 let cliOptions = case opts of
@@ -201,7 +217,7 @@ collectTypeInfoParser opts modSummary hpm = do
                 types <- mapM (pure . getTypeInfo moduleName') (hsmodDecls hm_module)
                 -- DBS.writeFile (modulePath <> ".type.parser.json") (toStrict $ A.encode $ Map.fromList $ Prelude.concat types)
                 sendViaUnixSocket (path cliOptions) (T.pack $ "/" <> modulePath <> ".types.parser.json") (decodeUtf8 $ toStrict $ A.encode $ Map.fromList $ Prelude.concat types)
-    pure hpm
+    pure parsedResult
 
 collectTypesTC :: [CommandLineOption] -> ModSummary -> TcGblEnv -> TcM TcGblEnv
 collectTypesTC opts modSummary tcg = do
@@ -229,7 +245,7 @@ getTypeInfo modName (L _ decl) = case decl of
         [(showSDocUnsafe' lname, TypeInfo
             { name = showSDocUnsafe' lname
             , typeKind = "data"
-            , dataConstructors = map (getDataConInfo modName) (dd_cons defn)
+            , dataConstructors = map (getDataConInfo modName) (DF.toList (dd_cons defn))
             })]
     TyClD _ (SynDecl _ lname _ _ rhs) ->
         [(showSDocUnsafe' lname, TypeInfo
@@ -277,7 +293,11 @@ getTypeInfo modName (L _ decl) = case decl of
 
 
 
+-- GHC 9.8's GHC.Utils.Outputable provides `instance Outputable Void`; only
+-- declare our own on older compilers that lack it, to avoid a duplicate instance.
+#if __GLASGOW_HASKELL__ < 908
 instance Outputable Void where
+#endif
 
 getDataConInfo :: String -> LConDecl GhcPs -> DataConInfo
 #if __GLASGOW_HASKELL__ >= 900
@@ -290,7 +310,7 @@ getDataConInfo modName (L _ decl) = case decl of
             }
     ConDeclGADT{con_names = lnames, con_res_ty = ty} ->
         DataConInfo
-            { dataConNames = intercalate ", " (map showSDocUnsafe' lnames)
+            { dataConNames = intercalate ", " (map showSDocUnsafe' (DF.toList lnames))
             , fields = Map.singleton "gadt" (StructuredTypeRep (pack $ showSDocUnsafe $ ppr $ unLoc ty) (parseTypeToComplexType $ unLoc ty))
             , sumTypes = []
             }
@@ -458,8 +478,9 @@ parseTypeToComplexType typ = case typ of
     
     HsQualTy _ mContext body -> 
         let contextTypes = case mContext of
-                            Nothing -> []
-                            Just (L _ ctx) -> map (parseTypeToComplexType . unLoc) ctx
+                            -- GHC 9.8: HsQualTy's context is `LHsContext` (was `Maybe LHsContext`);
+                            -- an empty context is now `L _ []`, so this still yields [] for none.
+                            (L _ ctx) -> map (parseTypeToComplexType . unLoc) ctx
             bodyType = parseTypeToComplexType $ unLoc body
         in QualType contextTypes bodyType
     
@@ -471,7 +492,7 @@ parseTypeToComplexType typ = case typ of
             argType = parseTypeToComplexType (unLoc x)
         in AppType baseType [argType]
     
-    HsAppKindTy _ ty kind ->
+    HsAppKindTy _ ty _ kind ->
         let baseType = parseTypeToComplexType (unLoc ty)
             kindType = parseTypeToComplexType (unLoc kind)
         in KindSigType baseType kindType
@@ -488,15 +509,15 @@ parseTypeToComplexType typ = case typ of
     HsSumTy _ types ->
         TupleType (map (parseTypeToComplexType . unLoc) types)
     
-    HsOpTy _ ty1 op ty2 ->
+    HsOpTy _ _ ty1 op ty2 ->
         let left = parseTypeToComplexType $ unLoc ty1
             right = parseTypeToComplexType $ unLoc ty2
             opComp = AtomicType $ extractTypeComponent $ convertLIdP op
         in AppType opComp [left, right]
-    
+
     HsParTy _ ty ->
         parseTypeToComplexType (unLoc ty)
-    
+
     HsIParamTy _ (L _ name) ty ->
         IParamType (showSDocUnsafe $ ppr name) (parseTypeToComplexType $ unLoc ty)
     
@@ -507,10 +528,10 @@ parseTypeToComplexType typ = case typ of
         KindSigType (parseTypeToComplexType $ unLoc ty) (parseTypeToComplexType $ unLoc kind)
     
     HsSpliceTy _ splice ->
-        UnknownType $ pack $ "Splice: " ++ showSDocUnsafe (ppr splice)
+        UnknownType $ pack $ "Splice: " ++ showSDocUnsafe (pprUntypedSplice True Nothing splice)
     
     HsDocTy _ ty (L _ doc) ->
-        DocType (parseTypeToComplexType $ unLoc ty) (unpackHDS doc)
+        DocType (parseTypeToComplexType $ unLoc ty) (renderHsDocString $ hsDocString doc)
     
     HsBangTy _ _ ty ->
         BangType (parseTypeToComplexType $ unLoc ty)
@@ -592,7 +613,7 @@ parseTypeToComplexType typ = case typ of
         KindSigType (parseTypeToComplexType $ unLoc ty) (parseTypeToComplexType $ unLoc kind)
     
     HsSpliceTy _ splice ->
-        UnknownType $ pack $ "Splice: " ++ showSDocUnsafe (ppr splice)
+        UnknownType $ pack $ "Splice: " ++ showSDocUnsafe (pprUntypedSplice True Nothing splice)
     
 #if __GLASGOW_HASKELL__ >= 810
     HsDocTy _ ty doc ->
@@ -935,7 +956,7 @@ dataConToDataConInfo dflags dc = do
             -- Normal case: build field map with real labels
             Map.fromList <$> zipWithM (\l t -> do
                     structType <- typeToStructuredTypeRep dflags (scaledThing t)
-                    return (unpackFS (flLabel l), structType)
+                    return (unpackFS (field_label (flLabel l)), structType)
                 ) fieldLabels fieldTypes
         else
             -- For non-record constructors, we still need to capture the arguments

--- a/fieldInspector/src/FieldInspector/PluginTypesPlain.hs
+++ b/fieldInspector/src/FieldInspector/PluginTypesPlain.hs
@@ -16,9 +16,12 @@ import GHC.Utils.Outputable ()
 import qualified Data.IntMap.Internal as IntMap
 import GHC
 import GHC.Unit.Types
-import GHC.Driver.Plugins (Plugin(..),CommandLineOption,defaultPlugin,PluginRecompile(..))
+import GHC.Driver.Plugins (Plugin(..),CommandLineOption,defaultPlugin,PluginRecompile(..),ParsedResult(..))
+import qualified Data.Foldable as DF
+import Language.Haskell.Syntax.Basic (field_label)
 import GHC.Driver.Env
 import GHC.Tc.Types
+import GHC.Types.Unique.FM (plusUFM)
 import GHC.Unit.Module.ModSummary
 import GHC.Utils.Outputable (showSDocUnsafe,ppr,SDoc,Outputable)
 import GHC.Data.Bag (bagToList)
@@ -125,22 +128,26 @@ instance Semigroup Plugin where
           (Nothing, Nothing) -> Nothing
           (Just tp, Nothing) -> Just tp
           (Nothing, Just tq) -> Just tq
-          (Just (TcPlugin tcPluginInit1 tcPluginSolve1 tcPluginStop1), Just (TcPlugin tcPluginInit2 tcPluginSolve2 tcPluginStop2)) -> Just $ TcPlugin 
+          (Just (TcPlugin tcPluginInit1 tcPluginSolve1 tcPluginRewrite1 tcPluginStop1), Just (TcPlugin tcPluginInit2 tcPluginSolve2 tcPluginRewrite2 tcPluginStop2)) -> Just $ TcPlugin
             { tcPluginInit = do
                 ip <- tcPluginInit1
                 iq <- tcPluginInit2
                 return (ip, iq)
-            , tcPluginSolve = \(sp,sq) given derived wanted -> do
-                solveP <- tcPluginSolve1 sp given derived wanted
-                solveQ <- tcPluginSolve2 sq given derived wanted
+            -- GHC 9.4+: tcPluginSolve dropped the `derived` list and gained an
+            -- EvBindsVar; tcPluginRewrite is a new field. Union the two plugins'
+            -- rewriter maps (left-biased on TyCon clashes) — behavior-preserving.
+            , tcPluginSolve = \(sp,sq) evBindsVar given wanted -> do
+                solveP <- tcPluginSolve1 sp evBindsVar given wanted
+                solveQ <- tcPluginSolve2 sq evBindsVar given wanted
                 return $ combineTcPluginResults solveP solveQ
+            , tcPluginRewrite = \(sp,sq) -> plusUFM (tcPluginRewrite1 sp) (tcPluginRewrite2 sq)
             , tcPluginStop = \(solveP,solveQ) -> do
                 tcPluginStop1 solveP
                 tcPluginStop2 solveQ
             }
     }
 
-combineTcPluginResults :: TcPluginResult -> TcPluginResult -> TcPluginResult
+combineTcPluginResults :: TcPluginSolveResult -> TcPluginSolveResult -> TcPluginSolveResult
 combineTcPluginResults resP resQ =
   case (resP, resQ) of
     (TcPluginContradiction ctsP, TcPluginContradiction ctsQ) ->
@@ -168,8 +175,11 @@ pprDataCon = ppr
 defaultCliOptions :: CliOptions
 defaultCliOptions = CliOptions {path="./tmp/fdep/",port=4444,host="::1",log=False,tc_funcs=Just False,api_conteact=Just True}
 
-collectTypeInfoParser :: [CommandLineOption] -> ModSummary -> HsParsedModule -> Hsc HsParsedModule
-collectTypeInfoParser opts modSummary hpm = do
+-- GHC 9.4 changed parsedResultAction to take/return `ParsedResult` (wrapping the
+-- HsParsedModule + parse messages); unwrap it for analysis and return it unchanged.
+collectTypeInfoParser :: [CommandLineOption] -> ModSummary -> ParsedResult -> Hsc ParsedResult
+collectTypeInfoParser opts modSummary parsedResult = do
+    let hpm = parsedResultModule parsedResult
     _ <- liftIO $ forkIO $
             do
                 let cliOptions = case opts of
@@ -186,7 +196,7 @@ collectTypeInfoParser opts modSummary hpm = do
                 types <- mapM (pure . getTypeInfo moduleName') (hsmodDecls hm_module)
                 -- DBS.writeFile (modulePath <> ".type.parser.json") (toStrict $ A.encode $ Map.fromList $ Prelude.concat types)
                 sendViaUnixSocket (path cliOptions) (T.pack $ "/" <> modulePath <> ".types.parser.json") (decodeUtf8 $ toStrict $ A.encode $ Map.fromList $ Prelude.concat types)
-    pure hpm
+    pure parsedResult
 
 collectTypesTC :: [CommandLineOption] -> ModSummary -> TcGblEnv -> TcM TcGblEnv
 collectTypesTC opts modSummary tcg = do
@@ -214,7 +224,7 @@ getTypeInfo modName (L _ decl) = case decl of
         [(showSDocUnsafe' lname, TypeInfo
             { name = showSDocUnsafe' lname
             , typeKind = "data"
-            , dataConstructors = map (getDataConInfo modName) (dd_cons defn)
+            , dataConstructors = map (getDataConInfo modName) (DF.toList (dd_cons defn))
             })]
     TyClD _ (SynDecl _ lname _ _ rhs) ->
         [(showSDocUnsafe' lname, TypeInfo
@@ -262,7 +272,11 @@ getTypeInfo modName (L _ decl) = case decl of
 
 
 
+-- GHC 9.8's GHC.Utils.Outputable provides `instance Outputable Void`; only
+-- declare our own on older compilers that lack it, to avoid a duplicate instance.
+#if __GLASGOW_HASKELL__ < 908
 instance Outputable Void where
+#endif
 
 getDataConInfo :: String -> LConDecl GhcPs -> DataConInfo
 #if __GLASGOW_HASKELL__ >= 900
@@ -275,7 +289,7 @@ getDataConInfo modName (L _ decl) = case decl of
             }
     ConDeclGADT{con_names = lnames, con_res_ty = ty} ->
         DataConInfo
-            { dataConNames = intercalate ", " (map showSDocUnsafe' lnames)
+            { dataConNames = intercalate ", " (map showSDocUnsafe' (DF.toList lnames))
             , fields = Map.singleton "gadt" (StructuredTypeRep (pack $ showSDocUnsafe $ ppr $ unLoc ty) (parseTypeToComplexType $ unLoc ty))
             , sumTypes = []
             }
@@ -443,8 +457,9 @@ parseTypeToComplexType typ = case typ of
     
     HsQualTy _ mContext body -> 
         let contextTypes = case mContext of
-                            Nothing -> []
-                            Just (L _ ctx) -> map (parseTypeToComplexType . unLoc) ctx
+                            -- GHC 9.8: HsQualTy's context is `LHsContext` (was `Maybe LHsContext`);
+                            -- an empty context is now `L _ []`, so this still yields [] for none.
+                            (L _ ctx) -> map (parseTypeToComplexType . unLoc) ctx
             bodyType = parseTypeToComplexType $ unLoc body
         in QualType contextTypes bodyType
     
@@ -456,7 +471,7 @@ parseTypeToComplexType typ = case typ of
             argType = parseTypeToComplexType (unLoc x)
         in AppType baseType [argType]
     
-    HsAppKindTy _ ty kind ->
+    HsAppKindTy _ ty _ kind ->
         let baseType = parseTypeToComplexType (unLoc ty)
             kindType = parseTypeToComplexType (unLoc kind)
         in KindSigType baseType kindType
@@ -473,15 +488,15 @@ parseTypeToComplexType typ = case typ of
     HsSumTy _ types ->
         TupleType (map (parseTypeToComplexType . unLoc) types)
     
-    HsOpTy _ ty1 op ty2 ->
+    HsOpTy _ _ ty1 op ty2 ->
         let left = parseTypeToComplexType $ unLoc ty1
             right = parseTypeToComplexType $ unLoc ty2
             opComp = AtomicType $ extractTypeComponent $ convertLIdP op
         in AppType opComp [left, right]
-    
+
     HsParTy _ ty ->
         parseTypeToComplexType (unLoc ty)
-    
+
     HsIParamTy _ (L _ name) ty ->
         IParamType (showSDocUnsafe $ ppr name) (parseTypeToComplexType $ unLoc ty)
     
@@ -492,10 +507,10 @@ parseTypeToComplexType typ = case typ of
         KindSigType (parseTypeToComplexType $ unLoc ty) (parseTypeToComplexType $ unLoc kind)
     
     HsSpliceTy _ splice ->
-        UnknownType $ pack $ "Splice: " ++ showSDocUnsafe (ppr splice)
+        UnknownType $ pack $ "Splice: " ++ showSDocUnsafe (pprUntypedSplice True Nothing splice)
     
     HsDocTy _ ty (L _ doc) ->
-        DocType (parseTypeToComplexType $ unLoc ty) (unpackHDS doc)
+        DocType (parseTypeToComplexType $ unLoc ty) (renderHsDocString $ hsDocString doc)
     
     HsBangTy _ _ ty ->
         BangType (parseTypeToComplexType $ unLoc ty)
@@ -577,7 +592,7 @@ parseTypeToComplexType typ = case typ of
         KindSigType (parseTypeToComplexType $ unLoc ty) (parseTypeToComplexType $ unLoc kind)
     
     HsSpliceTy _ splice ->
-        UnknownType $ pack $ "Splice: " ++ showSDocUnsafe (ppr splice)
+        UnknownType $ pack $ "Splice: " ++ showSDocUnsafe (pprUntypedSplice True Nothing splice)
     
 #if __GLASGOW_HASKELL__ >= 810
     HsDocTy _ ty doc ->
@@ -920,7 +935,7 @@ dataConToDataConInfo dflags dc = do
             -- Normal case: build field map with real labels
             Map.fromList <$> zipWithM (\l t -> do
                     structType <- typeToStructuredTypeRep dflags (scaledThing t)
-                    return (unpackFS (flLabel l), structType)
+                    return (unpackFS (field_label (flLabel l)), structType)
                 ) fieldLabels fieldTypes
         else
             -- For non-record constructors, we still need to capture the arguments

--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1733312601,
-        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "lastModified": 1785627969,
+        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
         "type": "github"
       },
       "original": {
@@ -54,11 +54,11 @@
     },
     "haskell-flake": {
       "locked": {
-        "lastModified": 1733672669,
-        "narHash": "sha256-cJa3mhmWLj1+DLmb3Bkq+5cCkeBAsbTkSKf0XvlMo9w=",
+        "lastModified": 1785340889,
+        "narHash": "sha256-W3VSD3CKNF/WSLwS+A4ru1pXb2J8GN1xi4MjWacpwJA=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "b13eb3f9b8f4666e2d7c9641d1f914e45afe575c",
+        "rev": "ec69967e95d7e93b58d9f7cdd384432cb42d37ee",
         "type": "github"
       },
       "original": {
@@ -84,6 +84,24 @@
         "type": "github"
       }
     },
+    "large-records": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780502084,
+        "narHash": "sha256-BZb6KLAj3K4kfF+O+1oGcUUjNEwAeKri12EeoGkocBA=",
+        "ref": "ghc984-port",
+        "rev": "35005b63a183ca8da3d05b22cefbf41d6a1ba3cf",
+        "revCount": 343,
+        "type": "git",
+        "url": "https://github.com/infinitumkiran/large-records.git"
+      },
+      "original": {
+        "ref": "ghc984-port",
+        "rev": "35005b63a183ca8da3d05b22cefbf41d6a1ba3cf",
+        "type": "git",
+        "url": "https://github.com/infinitumkiran/large-records.git"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1763421233,
@@ -102,14 +120,17 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1733096140,
-        "narHash": "sha256-1qRH7uAUsyQI7R1Uwl4T+XvdNv778H0Nb5njNrqvylY=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+        "lastModified": 1785031560,
+        "narHash": "sha256-OmshNvn2vupOFpYinLUu+1Dnpu4n7Q5N3ggGVNHpkUI=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "record-dot-preprocessor": {
@@ -153,6 +174,7 @@
         "ghc-hasfield-plugin": "ghc-hasfield-plugin",
         "haskell-flake": "haskell-flake",
         "instance-control": "instance-control",
+        "large-records": "large-records",
         "nixpkgs": "nixpkgs",
         "record-dot-preprocessor": "record-dot-preprocessor",
         "references": "references",

--- a/flake.lock
+++ b/flake.lock
@@ -115,17 +115,17 @@
     "record-dot-preprocessor": {
       "flake": false,
       "locked": {
-        "lastModified": 1783691947,
-        "narHash": "sha256-o+gypL6omyqKPeO8kQoDlqpKfdivbExDHo8ZiFi9+lQ=",
+        "lastModified": 1784023077,
+        "narHash": "sha256-/2CUBgfMAPqw8EijJ67ElMC/V7qnyH8OJeobmmtiq6Y=",
         "owner": "AyushChaturvedi-7",
         "repo": "record-dot-preprocessor",
-        "rev": "2b126423423fba113547f3a01bc66ef0cf38b263",
+        "rev": "de31a3a89b1d89a94fb4b5f8c0506d2f2cde89bf",
         "type": "github"
       },
       "original": {
         "owner": "AyushChaturvedi-7",
         "repo": "record-dot-preprocessor",
-        "rev": "2b126423423fba113547f3a01bc66ef0cf38b263",
+        "rev": "de31a3a89b1d89a94fb4b5f8c0506d2f2cde89bf",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -1,65 +1,25 @@
 {
   "nodes": {
-    "beam": {
+    "classyplate": {
       "flake": false,
       "locked": {
-        "lastModified": 1696055201,
-        "narHash": "sha256-BIq3ZjZQWQ0w3zWA19zGBggiVVfnOzR5d4b7De0oVZY=",
-        "owner": "juspay",
-        "repo": "beam",
-        "rev": "c4f86057db76640245c3d1fde040176c53e9b9a3",
+        "lastModified": 1770285628,
+        "narHash": "sha256-e9Ji9QkJTJMPz493g1kJqaa1579h1D+Tt2gEBtI1euc=",
+        "owner": "infinitumkiran",
+        "repo": "classyplate",
+        "rev": "71022deb4163c39ef278e30c2c1d3e56a3137812",
         "type": "github"
       },
       "original": {
-        "owner": "juspay",
-        "repo": "beam",
-        "rev": "c4f86057db76640245c3d1fde040176c53e9b9a3",
-        "type": "github"
-      }
-    },
-    "classyplate": {
-      "inputs": {
-        "flake-parts": "flake-parts",
-        "haskell-flake": "haskell-flake",
-        "nixpkgs": "nixpkgs",
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1721385699,
-        "narHash": "sha256-Gof2hSQSX581LA8GGnHGjXWu5F899Cot+Id1SYxlUMY=",
-        "owner": "eswar2001",
+        "owner": "infinitumkiran",
         "repo": "classyplate",
-        "rev": "a360f56820df6ca5284091f318bcddcd3e065243",
-        "type": "github"
-      },
-      "original": {
-        "owner": "eswar2001",
-        "repo": "classyplate",
-        "rev": "a360f56820df6ca5284091f318bcddcd3e065243",
+        "rev": "71022deb4163c39ef278e30c2c1d3e56a3137812",
         "type": "github"
       }
     },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1719994518,
-        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_2": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
         "lastModified": 1733312601,
@@ -75,270 +35,24 @@
         "type": "github"
       }
     },
-    "flake-parts_3": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_3"
-      },
-      "locked": {
-        "lastModified": 1685662779,
-        "narHash": "sha256-cKDDciXGpMEjP1n6HlzKinN0H+oLmNpgeCTzYnsA2po=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "71fb97f0d875fd4de4994dfb849f2c75e17eb6c3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_4": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_4"
-      },
-      "locked": {
-        "lastModified": 1719994518,
-        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_5": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_5"
-      },
-      "locked": {
-        "lastModified": 1719994518,
-        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_6": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_6"
-      },
-      "locked": {
-        "lastModified": 1685662779,
-        "narHash": "sha256-cKDDciXGpMEjP1n6HlzKinN0H+oLmNpgeCTzYnsA2po=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "71fb97f0d875fd4de4994dfb849f2c75e17eb6c3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "ghc-hasfield-plugin": {
-      "inputs": {
-        "flake-parts": "flake-parts_5",
-        "haskell-flake": "haskell-flake_4",
-        "nixpkgs": "nixpkgs_3",
-        "systems": "systems_2"
-      },
+      "flake": false,
       "locked": {
-        "lastModified": 1721371073,
-        "narHash": "sha256-1xTFZRE/vAHV/mLMW5rNyZH1SkkbyFqDxXZvw7JwOHo=",
+        "lastModified": 1769672232,
+        "narHash": "sha256-9KbEqGBfxrLRepbbxBNOAUuEkJjU4k7qnE9l4prd2xc=",
         "owner": "eswar2001",
         "repo": "ghc-hasfield-plugin",
-        "rev": "c932ebc0d7e824129bb70c8a078f3c68feed85c9",
+        "rev": "13887ab3f0d26bc724300521c012bf335e1945c6",
         "type": "github"
       },
       "original": {
         "owner": "eswar2001",
         "repo": "ghc-hasfield-plugin",
-        "rev": "c932ebc0d7e824129bb70c8a078f3c68feed85c9",
-        "type": "github"
-      }
-    },
-    "ghc8-beam": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1689929344,
-        "narHash": "sha256-uE2/Hq8u9+BjABrM9m6qV+H/88aGnRRzhsE0k8QKSL0=",
-        "owner": "juspay",
-        "repo": "beam",
-        "rev": "e50e6dc6a5a83c4c0c50183416fad33084c81d9e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "juspay",
-        "repo": "beam",
-        "rev": "e50e6dc6a5a83c4c0c50183416fad33084c81d9e",
-        "type": "github"
-      }
-    },
-    "ghc8-classyplate": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1678370822,
-        "narHash": "sha256-8AJ/55ShKCe49MEcyMqzJ3ADjs5dvtuTIhuTTq2q5nQ=",
-        "owner": "Chaitanya-nair",
-        "repo": "classyplate",
-        "rev": "46f5e0e7073e1d047f70473bf3c75366a613bfeb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Chaitanya-nair",
-        "repo": "classyplate",
-        "rev": "46f5e0e7073e1d047f70473bf3c75366a613bfeb",
-        "type": "github"
-      }
-    },
-    "ghc8-ghc-hasfield-plugin": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1658487566,
-        "narHash": "sha256-pZ6kFNfRtBWWqJ3zZSJhZQz7hcdgTdpkqUbzRCuRSl8=",
-        "owner": "juspay",
-        "repo": "ghc-hasfield-plugin",
-        "rev": "d82ac5a6c0ad643eebe2b9b32c91f6523d3f30dc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "juspay",
-        "repo": "ghc-hasfield-plugin",
-        "rev": "d82ac5a6c0ad643eebe2b9b32c91f6523d3f30dc",
-        "type": "github"
-      }
-    },
-    "ghc8-large-records": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1719312727,
-        "narHash": "sha256-NLs4yiUh4vNf4sqOQUUTCr0Fpld1y6ZyZJNhqSTzAI0=",
-        "owner": "eswar2001",
-        "repo": "large-records",
-        "rev": "e393f4501d76a98b4482b0a5b35d120ae70e5dd3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "eswar2001",
-        "repo": "large-records",
-        "rev": "e393f4501d76a98b4482b0a5b35d120ae70e5dd3",
-        "type": "github"
-      }
-    },
-    "ghc8-nixpkgs": {
-      "locked": {
-        "lastModified": 1643795778,
-        "narHash": "sha256-sBxYgXu+4JTpXPu3c1QGl2a2zzzDJj4VNsVatF1sEIY=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "43e3b6af08f29c4447a6073e3d5b86a4f45dd420",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "43e3b6af08f29c4447a6073e3d5b86a4f45dd420",
-        "type": "github"
-      }
-    },
-    "ghc8-record-dot-preprocessor": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1644582826,
-        "narHash": "sha256-BXprRyjI4ZTG+Orz858xmttiC8O0yuubaaKmeRAL/UY=",
-        "owner": "ndmitchell",
-        "repo": "record-dot-preprocessor",
-        "rev": "99452d27f35ea1ff677be9af570d834e8fab4caf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ndmitchell",
-        "repo": "record-dot-preprocessor",
-        "rev": "99452d27f35ea1ff677be9af570d834e8fab4caf",
-        "type": "github"
-      }
-    },
-    "ghc8-references": {
-      "inputs": {
-        "flake-parts": "flake-parts_3",
-        "haskell-flake": "haskell-flake_2",
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1686714318,
-        "narHash": "sha256-Ogy9S6cF/8WNfpcQ1k65rPjjTfWlH15Jp5JeraYaAQQ=",
-        "owner": "eswar2001",
-        "repo": "references",
-        "rev": "35912f3cc72b67fa63a8d59d634401b79796469e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "eswar2001",
-        "repo": "references",
-        "rev": "35912f3cc72b67fa63a8d59d634401b79796469e",
-        "type": "github"
-      }
-    },
-    "ghc928": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1734492241,
-        "narHash": "sha256-jGwS13dKtrajHYdxm95OyuTkWUDHBZ/nyqhegqpAZ5A=",
-        "owner": "eswar2001",
-        "repo": "ghc",
-        "rev": "f98881e9034c85d55c276709c9e5b563711dcee9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "eswar2001",
-        "ref": "de_sugar_plugin_support",
-        "repo": "ghc",
+        "rev": "13887ab3f0d26bc724300521c012bf335e1945c6",
         "type": "github"
       }
     },
     "haskell-flake": {
-      "locked": {
-        "lastModified": 1720977934,
-        "narHash": "sha256-k9kwz2lpUqafRUpuCMgkv4AWtHEoJPCds1ZPRkyW2XE=",
-        "owner": "srid",
-        "repo": "haskell-flake",
-        "rev": "cd449f1c04175efdf5b553302d22916640090066",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "haskell-flake",
-        "type": "github"
-      }
-    },
-    "haskell-flake_2": {
-      "locked": {
-        "lastModified": 1686160859,
-        "narHash": "sha256-UE+0TQHyPxF8jhbLEeqvNQAy7B79bBix/rpFrf5nsn0=",
-        "owner": "srid",
-        "repo": "haskell-flake",
-        "rev": "908a59167f78035a123ab71ed77af79bed519771",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "haskell-flake",
-        "type": "github"
-      }
-    },
-    "haskell-flake_3": {
       "locked": {
         "lastModified": 1733672669,
         "narHash": "sha256-cJa3mhmWLj1+DLmb3Bkq+5cCkeBAsbTkSKf0XvlMo9w=",
@@ -353,106 +67,40 @@
         "type": "github"
       }
     },
-    "haskell-flake_4": {
+    "instance-control": {
+      "flake": false,
       "locked": {
-        "lastModified": 1720977934,
-        "narHash": "sha256-k9kwz2lpUqafRUpuCMgkv4AWtHEoJPCds1ZPRkyW2XE=",
-        "owner": "srid",
-        "repo": "haskell-flake",
-        "rev": "cd449f1c04175efdf5b553302d22916640090066",
+        "lastModified": 1769603854,
+        "narHash": "sha256-s6kiRdM/bp0wCqmgok/4ZvWnTPmwUOKkbDoHpEV500c=",
+        "owner": "infinitumkiran",
+        "repo": "instance-control",
+        "rev": "7a0ab66ffa44f8634857440701b8451a20436756",
         "type": "github"
       },
       "original": {
-        "owner": "srid",
-        "repo": "haskell-flake",
-        "type": "github"
-      }
-    },
-    "haskell-flake_5": {
-      "locked": {
-        "lastModified": 1721530802,
-        "narHash": "sha256-eUMmQKXjt4WQq+IBscftg/Y9bXWiOYhasfeH5Yb9Psc=",
-        "owner": "srid",
-        "repo": "haskell-flake",
-        "rev": "f8f38ecd259338167cc0c85fd541479297a315af",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "haskell-flake",
-        "type": "github"
-      }
-    },
-    "haskell-flake_6": {
-      "locked": {
-        "lastModified": 1686160859,
-        "narHash": "sha256-UE+0TQHyPxF8jhbLEeqvNQAy7B79bBix/rpFrf5nsn0=",
-        "owner": "srid",
-        "repo": "haskell-flake",
-        "rev": "908a59167f78035a123ab71ed77af79bed519771",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "haskell-flake",
-        "type": "github"
-      }
-    },
-    "large-records": {
-      "inputs": {
-        "beam": [
-          "beam"
-        ],
-        "flake-parts": "flake-parts_4",
-        "ghc-hasfield-plugin": "ghc-hasfield-plugin",
-        "haskell-flake": "haskell-flake_5",
-        "nixpkgs": "nixpkgs_4",
-        "systems": "systems_3"
-      },
-      "locked": {
-        "lastModified": 1728704762,
-        "narHash": "sha256-Y3Zs8nGfFQLqpkRt8l2M+wkrp8fHkblu4/qMRP1ryu8=",
-        "owner": "eswar2001",
-        "repo": "large-records",
-        "rev": "f7fbffd022c792cd7686bca058a51b08722091dc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "eswar2001",
-        "ref": "ghc928-qualified-prelude",
-        "repo": "large-records",
+        "owner": "infinitumkiran",
+        "repo": "instance-control",
+        "rev": "7a0ab66ffa44f8634857440701b8451a20436756",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1698266953,
-        "narHash": "sha256-jf72t7pC8+8h8fUslUYbWTX5rKsRwOzRMX8jJsGqDXA=",
+        "lastModified": 1763421233,
+        "narHash": "sha256-Stk9ZYRkGrnnpyJ4eqt9eQtdFWRRIvMxpNRf4sIegnw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "75a52265bda7fd25e06e3a67dee3f0354e73243c",
+        "rev": "89c2b2330e733d6cdb5eae7b899326930c2c0648",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "75a52265bda7fd25e06e3a67dee3f0354e73243c",
+        "rev": "89c2b2330e733d6cdb5eae7b899326930c2c0648",
         "type": "github"
       }
     },
     "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1719876945,
-        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
-      }
-    },
-    "nixpkgs-lib_2": {
       "locked": {
         "lastModified": 1733096140,
         "narHash": "sha256-1qRH7uAUsyQI7R1Uwl4T+XvdNv778H0Nb5njNrqvylY=",
@@ -464,186 +112,52 @@
         "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
       }
     },
-    "nixpkgs-lib_3": {
+    "record-dot-preprocessor": {
+      "flake": false,
       "locked": {
-        "dir": "lib",
-        "lastModified": 1685564631,
-        "narHash": "sha256-8ywr3AkblY4++3lIVxmrWZFzac7+f32ZEhH/A8pNscI=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "4f53efe34b3a8877ac923b9350c874e3dcd5dc0a",
+        "lastModified": 1783691947,
+        "narHash": "sha256-o+gypL6omyqKPeO8kQoDlqpKfdivbExDHo8ZiFi9+lQ=",
+        "owner": "AyushChaturvedi-7",
+        "repo": "record-dot-preprocessor",
+        "rev": "2b126423423fba113547f3a01bc66ef0cf38b263",
         "type": "github"
       },
       "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib_4": {
-      "locked": {
-        "lastModified": 1719876945,
-        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
-      }
-    },
-    "nixpkgs-lib_5": {
-      "locked": {
-        "lastModified": 1719876945,
-        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
-      }
-    },
-    "nixpkgs-lib_6": {
-      "locked": {
-        "dir": "lib",
-        "lastModified": 1685564631,
-        "narHash": "sha256-8ywr3AkblY4++3lIVxmrWZFzac7+f32ZEhH/A8pNscI=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "4f53efe34b3a8877ac923b9350c874e3dcd5dc0a",
-        "type": "github"
-      },
-      "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1686582075,
-        "narHash": "sha256-vtflsfKkHtF8IduxDNtbme4cojiqvlvjp5QNYhvoHXc=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "7e63eed145566cca98158613f3700515b4009ce3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1698266953,
-        "narHash": "sha256-jf72t7pC8+8h8fUslUYbWTX5rKsRwOzRMX8jJsGqDXA=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "75a52265bda7fd25e06e3a67dee3f0354e73243c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "75a52265bda7fd25e06e3a67dee3f0354e73243c",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1698266953,
-        "narHash": "sha256-jf72t7pC8+8h8fUslUYbWTX5rKsRwOzRMX8jJsGqDXA=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "75a52265bda7fd25e06e3a67dee3f0354e73243c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "75a52265bda7fd25e06e3a67dee3f0354e73243c",
-        "type": "github"
-      }
-    },
-    "nixpkgs_5": {
-      "locked": {
-        "lastModified": 1698266953,
-        "narHash": "sha256-jf72t7pC8+8h8fUslUYbWTX5rKsRwOzRMX8jJsGqDXA=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "75a52265bda7fd25e06e3a67dee3f0354e73243c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "75a52265bda7fd25e06e3a67dee3f0354e73243c",
-        "type": "github"
-      }
-    },
-    "nixpkgs_6": {
-      "locked": {
-        "lastModified": 1698266953,
-        "narHash": "sha256-jf72t7pC8+8h8fUslUYbWTX5rKsRwOzRMX8jJsGqDXA=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "75a52265bda7fd25e06e3a67dee3f0354e73243c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "75a52265bda7fd25e06e3a67dee3f0354e73243c",
+        "owner": "AyushChaturvedi-7",
+        "repo": "record-dot-preprocessor",
+        "rev": "2b126423423fba113547f3a01bc66ef0cf38b263",
         "type": "github"
       }
     },
     "references": {
-      "inputs": {
-        "flake-parts": "flake-parts_6",
-        "haskell-flake": "haskell-flake_6",
-        "nixpkgs": "nixpkgs_6"
-      },
+      "flake": false,
       "locked": {
-        "lastModified": 1721735703,
-        "narHash": "sha256-0F/xsz64sUwKQvKL5yuU+7+QPiyvlQFUb8zZI1ZTbrI=",
-        "owner": "eswar2001",
+        "lastModified": 1769677302,
+        "narHash": "sha256-4R60gJWd6jRjyHx8yl4eb/NlbnBtzn62fN0BAgdwq38=",
+        "owner": "infinitumkiran",
         "repo": "references",
-        "rev": "120ae7826a7af01a527817952ad0c3f5ef08efd0",
+        "rev": "663c62cddf86d84f5f91568f5504e65e92cf7461",
         "type": "github"
       },
       "original": {
-        "owner": "eswar2001",
+        "owner": "infinitumkiran",
         "repo": "references",
-        "rev": "120ae7826a7af01a527817952ad0c3f5ef08efd0",
+        "rev": "663c62cddf86d84f5f91568f5504e65e92cf7461",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "beam": "beam",
         "classyplate": "classyplate",
-        "flake-parts": "flake-parts_2",
-        "ghc8-beam": "ghc8-beam",
-        "ghc8-classyplate": "ghc8-classyplate",
-        "ghc8-ghc-hasfield-plugin": "ghc8-ghc-hasfield-plugin",
-        "ghc8-large-records": "ghc8-large-records",
-        "ghc8-nixpkgs": "ghc8-nixpkgs",
-        "ghc8-record-dot-preprocessor": "ghc8-record-dot-preprocessor",
-        "ghc8-references": "ghc8-references",
-        "ghc928": "ghc928",
-        "haskell-flake": "haskell-flake_3",
-        "large-records": "large-records",
-        "nixpkgs": "nixpkgs_5",
+        "flake-parts": "flake-parts",
+        "ghc-hasfield-plugin": "ghc-hasfield-plugin",
+        "haskell-flake": "haskell-flake",
+        "instance-control": "instance-control",
+        "nixpkgs": "nixpkgs",
+        "record-dot-preprocessor": "record-dot-preprocessor",
         "references": "references",
         "streamly": "streamly",
-        "systems": "systems_4"
+        "systems": "systems"
       }
     },
     "streamly": {
@@ -664,51 +178,6 @@
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_3": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_4": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -3,175 +3,166 @@
     systems.url = "github:nix-systems/default";
     flake-parts.url = "github:hercules-ci/flake-parts";
     haskell-flake.url = "github:srid/haskell-flake";
+
+    # Same nixpkgs pin as euler-nix-common's ghc984 set, so that `ghc98` == GHC
+    # 9.8.4 and the patched GHC derivation is byte-identical to euler's
+    # `ghc98-perf-events` — hence substitutable from cache.nixos.asia/juspay
+    # rather than requiring a from-source GHC build.
+    nixpkgs.url = "github:nixos/nixpkgs/89c2b2330e733d6cdb5eae7b899326930c2c0648";
+
+    # Only the `core` sub-package is consumed.
     streamly.url = "github:composewell/streamly/12d85026291d9305f93f573d284d0d35abf40968";
     streamly.flake = false;
 
-    # ghc 9.2.8 packages
-    nixpkgs.url = "github:nixos/nixpkgs/75a52265bda7fd25e06e3a67dee3f0354e73243c";
-    classyplate.url = "github:eswar2001/classyplate/a360f56820df6ca5284091f318bcddcd3e065243";
-    references.url = "github:eswar2001/references/120ae7826a7af01a527817952ad0c3f5ef08efd0";
-    beam.url = "github:juspay/beam/c4f86057db76640245c3d1fde040176c53e9b9a3";
-    beam.flake = false;
-    large-records.url = "github:eswar2001/large-records/ghc928-qualified-prelude";
-    large-records.inputs.beam.follows = "beam";
-    ghc928.url = "github:eswar2001/ghc/de_sugar_plugin_support";
-    ghc928.flake = false;
-
-    # ghc 8.10.7 packages
-    ghc8-nixpkgs.url = "github:nixos/nixpkgs/43e3b6af08f29c4447a6073e3d5b86a4f45dd420";
-    ghc8-beam.url = "github:juspay/beam/e50e6dc6a5a83c4c0c50183416fad33084c81d9e";
-    ghc8-beam.flake = false;
-    ghc8-classyplate.url = "github:Chaitanya-nair/classyplate/46f5e0e7073e1d047f70473bf3c75366a613bfeb";
-    ghc8-classyplate.flake = false;
-    ghc8-references.url = "github:eswar2001/references/35912f3cc72b67fa63a8d59d634401b79796469e";
-    ghc8-references.flake = true;
-    ghc8-ghc-hasfield-plugin.url = "github:juspay/ghc-hasfield-plugin/d82ac5a6c0ad643eebe2b9b32c91f6523d3f30dc";
-    ghc8-ghc-hasfield-plugin.flake = false;
-    ghc8-large-records.url = "github:eswar2001/large-records/e393f4501d76a98b4482b0a5b35d120ae70e5dd3";
-    ghc8-large-records.flake = false;
-    ghc8-record-dot-preprocessor.url = "github:ndmitchell/record-dot-preprocessor/99452d27f35ea1ff677be9af570d834e8fab4caf";
-    ghc8-record-dot-preprocessor.flake = false;
+    # GHC 9.8.4-ported dependency forks. Revs match the ones locked by
+    # euler-nix-common's ghc984 set (and the other euler repos), so these resolve
+    # from the shared juspay cache.
+    classyplate = {
+      url = "github:infinitumkiran/classyplate/71022deb4163c39ef278e30c2c1d3e56a3137812";
+      flake = false;
+    };
+    references = {
+      url = "github:infinitumkiran/references/663c62cddf86d84f5f91568f5504e65e92cf7461";
+      flake = false;
+    };
+    # Dependency of `references`; the nixpkgs Hackage version is marked broken.
+    instance-control = {
+      url = "github:infinitumkiran/instance-control/7a0ab66ffa44f8634857440701b8451a20436756";
+      flake = false;
+    };
+    ghc-hasfield-plugin = {
+      url = "github:eswar2001/ghc-hasfield-plugin/13887ab3f0d26bc724300521c012bf335e1945c6";
+      flake = false;
+    };
+    record-dot-preprocessor = {
+      url = "github:AyushChaturvedi-7/record-dot-preprocessor/2b126423423fba113547f3a01bc66ef0cf38b263";
+      flake = false;
+    };
+    # NOTE: the large-anon family (large-anon / large-records / large-generics /
+    # typelet) is intentionally NOT pinned to a fork here. It resolves from
+    # Hackage via the shared all-cabal-hashes pin below (large-anon 0.3.3,
+    # large-records 0.4.4), exactly as euler-nix-common's ghc984 set does — that
+    # is the combination proven to build under GHC 9.8.4. The old
+    # infinitumkiran/large-records fork resolved to large-anon 0.2, which does
+    # not build under 9.8.4.
   };
+
   outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } ({ withSystem, ...}: {
+    flake-parts.lib.mkFlake { inherit inputs; } ({ withSystem, ... }: {
       systems = import inputs.systems;
       imports = [ inputs.haskell-flake.flakeModule ];
-      perSystem = { self', pkgs, system, ... }: 
-      let ghc-desugar-plugin-overlay-ghc9 = self: super: {
-        haskell = super.haskell // {
-          compiler = super.haskell.compiler // {
-            ghc928-desugar-plugin = (super.haskell.compiler.ghc928.overrideAttrs (drv: {
-              patches = drv.patches ++ [ ./ghc-patches/desugar_plugin_support.patch ];
-            }));
-          };
-          packages = super.haskell.packages // {
-            ghc928-desugar-plugin = super.haskell.packages.ghc928.override {
-              buildHaskellPackages = self.buildPackages.haskell.packages.ghc928-desugar-plugin;
-              ghc = self.buildPackages.haskell.compiler.ghc928-desugar-plugin;
+      perSystem = { self', pkgs, system, ... }:
+        let
+          # Patched GHC 9.8.4 adding the `desugarResultAction` plugin hook (used by
+          # the `warner` plugin) and the thread-statistics primop. Applies the exact
+          # same patch set, in the same order, as euler-nix-common's
+          # `ghc98-perf-events`, so the resulting compiler derivation is identical
+          # and substitutable from the juspay cache. The patch is purely additive,
+          # so every other package builds against it unchanged.
+          ghc-desugar-plugin-overlay = final: prev: {
+            haskell = prev.haskell // {
+              compiler = prev.haskell.compiler // {
+                ghc98-desugar-plugin = prev.haskell.compiler.ghc98.overrideAttrs (drv: {
+                  patches = (drv.patches or [ ]) ++ [
+                    ./ghc-patches/0001-Add-a-primop-to-get-the-thread-statistics.patch
+                    ./ghc-patches/added-support-for-desugar-plugin.patch
+                  ];
+                });
+              };
+              packages = prev.haskell.packages // {
+                ghc98-desugar-plugin = prev.haskell.packages.ghc98.override {
+                  buildHaskellPackages = final.buildPackages.haskell.packages.ghc98-desugar-plugin;
+                  ghc = final.buildPackages.haskell.compiler.ghc98-desugar-plugin;
+                };
+              };
             };
           };
-        };
-      };
-      in {
-        _module.args.pkgs = import inputs.nixpkgs {
-          overlays = [
-            ghc-desugar-plugin-overlay-ghc9
-          ];
-          inherit system;
-        };
-        # Typically, you just want a single project named "default". But
-        # multiple projects are also possible, each using different GHC version.
-        # GHC 8 support
-        haskellProjects.ghc8 = {
-          projectFlakeName = "spider";
-          basePackages = inputs.ghc8-nixpkgs.legacyPackages.${system}.haskell.packages.ghc8107;
-          imports = [
-            inputs.ghc8-references.haskellFlakeProjectModules.output
-          ];
-          packages = {
-            classyplate.source = inputs.ghc8-classyplate;
-            ghc-hasfield-plugin.source = inputs.ghc8-ghc-hasfield-plugin;
-            large-records.source = inputs.ghc8-large-records + /large-records;
-            large-generics.source = inputs.ghc8-large-records + /large-generics;
-            large-anon.source = inputs.ghc8-large-records + /large-anon;
-            ghc-tcplugin-api.source = "0.7.1.0";
-            typelet.source = inputs.ghc8-large-records + /typelet;
-            record-dot-preprocessor.source = inputs.ghc8-record-dot-preprocessor;
-            streamly-core.source = inputs.streamly + /core;
-            beam-core.source = inputs.ghc8-beam + /beam-core;
+        in
+        {
+          _module.args.pkgs = import inputs.nixpkgs {
+            overlays = [ ghc-desugar-plugin-overlay ];
+            inherit system;
           };
-          settings = {
-            beam-core.jailbreak = true;
-            sheriff.check = false;
-          };
-          devShell = {
-            mkShellArgs = {
-              name = "ghc8-spider";
+
+          haskellProjects.default = {
+            projectFlakeName = "spider";
+            # `warner` needs the patched GHC (desugarResultAction hook), so it is
+            # the project-wide base. Same all-cabal-hashes pin as euler-nix-common
+            # so Hackage version resolution (ghc-tcplugin-api etc.) lines up.
+            basePackages = pkgs.haskell.packages.ghc98-desugar-plugin.override {
+              all-cabal-hashes = builtins.fetchurl {
+                url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/0c3c1e49cb6c1ba8419d11e259eb72f2e89e76ca.tar.gz";
+                sha256 = "1qs0cxvzjpsysnp5fm5i6b8p9vb2rsdw9pcyqaf8gi8nv6ppv40k";
+              };
             };
-            hlsCheck.enable = inputs.ghc8-nixpkgs.legacyPackages.${system}.stdenv.isDarwin; # On darwin, sandbox is disabled, so HLS can use the network.
-          };
-        };
 
-        haskellProjects.default = {
-          # The base package set representing a specific GHC version.
-          # By default, this is pkgs.haskellPackages.
-          # You may also create your own. See https://community.flake.parts/haskell-flake/package-set
-          # basePackages = pkgs.haskellPackages;
-
-          # Extra package information. See https://community.flake.parts/haskell-flake/dependency
-          #
-          # Note that local packages are automatically included in `packages`
-          # (defined by `defaults.packages` option).
-          #
-          # defaults.enable = false;
-          # devShell.tools = hp: with hp; {
-          #   inherit cabal-install;
-          #   inherit hp;
-          # };
-          projectFlakeName = "spider";
-          # basePackages = pkgs.haskell.packages.ghc8107;
-          # basePackages = pkgs.haskell.packages.ghc92;
-          # ghc-patches/desugar_plugin_support.patch
-          basePackages = pkgs.haskell.packages.ghc928-desugar-plugin;
-          imports = [
-            inputs.references.haskellFlakeProjectModules.output
-            inputs.classyplate.haskellFlakeProjectModules.output
-            inputs.large-records.haskellFlakeProjectModules.output
-          ];
-          packages = {
-            streamly-core.source = inputs.streamly + /core;
-          };
-          settings = {
-            servant.jailbreak = true;
-            servant-server.jailbreak = true;
-            #  aeson = {
-            #    check = false;
-            #  };
-            #  relude = {
-            #    haddock = false;
-            #    broken = false;
-            #  };
-            # primitive-checked = {
-            #     broken = false;
-            #     jailbreak = true;
-            # };
-            sheriff.check = false;
-            http2.check = false;
-          };
-
-          devShell = {
-            # Enabled by default
-            # enable = true;
-
-            # Programs you want to make available in the shell.
-            # Default programs can be disabled by setting to 'null'
-            # tools = hp: { fourmolu = null; ghcid = null; };
-            mkShellArgs = {
-              name = "spider";
+            packages = {
+              streamly-core.source = inputs.streamly + /core;
+              classyplate.source = inputs.classyplate;
+              references.source = inputs.references;
+              instance-control.source = inputs.instance-control;
+              ghc-hasfield-plugin.source = inputs.ghc-hasfield-plugin;
+              record-dot-preprocessor.source = inputs.record-dot-preprocessor;
+              # large-anon / large-records / large-generics / typelet come from
+              # Hackage (all-cabal-hashes pin above), matching euler-nix-common.
+              ghc-tcplugin-api.source = "0.16.1.0";
             };
-            hlsCheck.enable = pkgs.stdenv.isDarwin; # On darwin, sandbox is disabled, so HLS can use the network.
+
+            settings = {
+              classyplate = {
+                jailbreak = true;
+                broken = false;
+              };
+              record-dot-preprocessor.jailbreak = true;
+              # Hackage large-anon 0.3.3 / typelet — same overrides euler-nix-common
+              # uses to build the family under GHC 9.8.4. large-records and
+              # large-generics build with nixpkgs defaults (no override needed).
+              large-anon = {
+                broken = false;
+                check = false;
+              };
+              typelet = {
+                broken = false;
+                jailbreak = true;
+              };
+              servant.jailbreak = true;
+              servant-server.jailbreak = true;
+
+              # Local plugin packages self-apply their plugin in the test-suite
+              # (needs a running collector / extra setup); skip checks.
+              sheriff.check = false;
+              fdep.check = false;
+              api-contract.check = false;
+              fieldInspector.check = false;
+              warner.check = false;
+              paymentFlow.check = false;
+              endpoints.check = false;
+              dc.check = false;
+              keyLookupTracker.check = false;
+              coresyn2chart.check = false;
+
+              # api-contract disables its own profiling library; fieldInspector
+              # imports ApiContract.Plugin at compile time, so match it — otherwise
+              # fieldInspector's profiling pass can't find api-contract's
+              # (never-built) profiling library.
+              api-contract.libraryProfiling = false;
+              fieldInspector.libraryProfiling = false;
+            };
+
+            devShell = {
+              mkShellArgs = {
+                name = "spider-ghc98";
+              };
+              # HLS 2.x fails to configure against this patched GHC and isn't
+              # needed for the build loop.
+              tools = hp: {
+                haskell-language-server = null;
+              };
+              hlsCheck.enable = false;
+            };
           };
+
+          packages.default = self'.packages.sheriff;
         };
-
-        # haskell-flake doesn't set the default package, but you can do it here.
-        packages.default = self'.packages.fdep;
-
-      };
-
-      flake.haskellFlakeProjectModules = {
-        # To use ghc 9 version, use
-        # inputs.spider.haskellFlakeProjectModules.output
-
-        # To use ghc 8 version, use
-        # inputs.spider.haskellFlakeProjectModules.output-ghc8
-
-        output-ghc9 = { pkgs, lib, ... }: withSystem pkgs.system ({ config, ... }:
-            config.haskellProjects."default".defaults.projectModules.output
-        );
-
-        output-ghc8 = { pkgs, lib, ... }: withSystem pkgs.system ({ config, ... }:
-            config.haskellProjects."ghc8".defaults.projectModules.output
-        );
-      };
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
       flake = false;
     };
     record-dot-preprocessor = {
-      url = "github:AyushChaturvedi-7/record-dot-preprocessor/2b126423423fba113547f3a01bc66ef0cf38b263";
+      url = "github:AyushChaturvedi-7/record-dot-preprocessor/de31a3a89b1d89a94fb4b5f8c0506d2f2cde89bf";
       flake = false;
     };
     # NOTE: the large-anon family (large-anon / large-records / large-generics /
@@ -114,6 +114,12 @@
                 broken = false;
               };
               record-dot-preprocessor.jailbreak = true;
+              # The de31a3a record-dot-preprocessor rev no longer auto-injects
+              # GHC.Records(.Extra) imports (downstream modules import them
+              # themselves now). ghc-hasfield-plugin's bundled test suite relied
+              # on that injection and no longer compiles; its library is fine and
+              # spider never runs the test, so skip the check.
+              ghc-hasfield-plugin.check = false;
               # Hackage large-anon 0.3.3 / typelet — same overrides euler-nix-common
               # uses to build the family under GHC 9.8.4. large-records and
               # large-generics build with nixpkgs defaults (no override needed).

--- a/flake.nix
+++ b/flake.nix
@@ -134,18 +134,12 @@
               servant.jailbreak = true;
               servant-server.jailbreak = true;
 
-              # Local plugin packages self-apply their plugin in the test-suite
-              # (needs a running collector / extra setup); skip checks.
+              # sheriff's test-suite self-applies the plugin on files that
+              # intentionally violate its rules (same setting existed pre-9.8.4).
+              # All other plugins' test-suites build & run sandboxed: their
+              # plugins swallow collector-connection failures (socket_lib) and
+              # fall back to defaults on missing .juspay configs.
               sheriff.check = false;
-              fdep.check = false;
-              api-contract.check = false;
-              fieldInspector.check = false;
-              warner.check = false;
-              paymentFlow.check = false;
-              endpoints.check = false;
-              dc.check = false;
-              keyLookupTracker.check = false;
-              coresyn2chart.check = false;
 
               # api-contract disables its own profiling library; fieldInspector
               # imports ApiContract.Plugin at compile time, so match it — otherwise

--- a/flake.nix
+++ b/flake.nix
@@ -38,13 +38,12 @@
       url = "github:AyushChaturvedi-7/record-dot-preprocessor/de31a3a89b1d89a94fb4b5f8c0506d2f2cde89bf";
       flake = false;
     };
-    # NOTE: the large-anon family (large-anon / large-records / large-generics /
-    # typelet) is intentionally NOT pinned to a fork here. It resolves from
-    # Hackage via the shared all-cabal-hashes pin below (large-anon 0.3.3,
-    # large-records 0.4.4), exactly as euler-nix-common's ghc984 set does — that
-    # is the combination proven to build under GHC 9.8.4. The old
-    # infinitumkiran/large-records fork resolved to large-anon 0.2, which does
-    # not build under 9.8.4.
+    # Pin the same GHC 9.8.4 port revision as euler-api-txns. All three packages
+    # are consumed from this monorepo; compatibility settings are applied below.
+    large-records = {
+      url = "git+https://github.com/infinitumkiran/large-records.git?ref=ghc984-port&rev=35005b63a183ca8da3d05b22cefbf41d6a1ba3cf";
+      flake = false;
+    };
   };
 
   outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
@@ -103,8 +102,9 @@
               instance-control.source = inputs.instance-control;
               ghc-hasfield-plugin.source = inputs.ghc-hasfield-plugin;
               record-dot-preprocessor.source = inputs.record-dot-preprocessor;
-              # large-anon / large-records / large-generics / typelet come from
-              # Hackage (all-cabal-hashes pin above), matching euler-nix-common.
+              large-anon.source = inputs.large-records + /large-anon;
+              large-generics.source = inputs.large-records + /large-generics;
+              large-records.source = inputs.large-records + /large-records;
               ghc-tcplugin-api.source = "0.16.1.0";
             };
 
@@ -120,12 +120,18 @@
               # on that injection and no longer compiles; its library is fine and
               # spider never runs the test, so skip the check.
               ghc-hasfield-plugin.check = false;
-              # Hackage large-anon 0.3.3 / typelet — same overrides euler-nix-common
-              # uses to build the family under GHC 9.8.4. large-records and
-              # large-generics build with nixpkgs defaults (no override needed).
+              # The pinned releases still carry pre-GHC-9.8 bounds. large-records
+              # also needs a small ImportDecl compatibility patch for GHC 9.8.
+              large-generics.jailbreak = true;
+              large-records = {
+                check = false;
+                jailbreak = true;
+                patches = [ ./patches/large-records-ghc98.patch ];
+              };
               large-anon = {
                 broken = false;
                 check = false;
+                jailbreak = true;
               };
               typelet = {
                 broken = false;

--- a/ghc-patches/0001-Add-a-primop-to-get-the-thread-statistics.patch
+++ b/ghc-patches/0001-Add-a-primop-to-get-the-thread-statistics.patch
@@ -1,0 +1,444 @@
+From f06be801bedafa4e46845bc6ab5e8842ec7c94e2 Mon Sep 17 00:00:00 2001
+From: Kiransai Abhishek <kiransai.abhishek@juspay.in>
+Date: Fri, 10 Jul 2026 12:00:00 +0530
+Subject: [PATCH] Add a primop to get the thread statistics
+
+Rebased from GHC 9.2.8 onto GHC 9.8.4.
+---
+ compiler/GHC/Builtin/primops.txt.pp |   6 ++
+ compiler/GHC/StgToCmm/Prim.hs       |   1 +
+ compiler/GHC/StgToJS/Prim.hs        |   1 +
+ configure.ac                        |   2 +-
+ rts/PrimOps.cmm                     |  36 +++++++
+ rts/RtsSymbols.c                    |   1 +
+ rts/Schedule.c                      | 139 ++++++++++++++++++++++++++++
+ rts/Schedule.h                      |   8 ++
+ rts/Threads.c                       |   5 +
+ rts/include/rts/storage/TSO.h       |   8 ++
+ rts/include/stg/MiscClosures.h      |   1 +
+ rts/sm/Storage.c                    |  24 +++++
+ rts/sm/Storage.h                    |   3 +
+ utils/deriveConstants/Main.hs       |   6 ++
+ 14 files changed, 240 insertions(+), 1 deletion(-)
+
+diff --git a/compiler/GHC/Builtin/primops.txt.pp b/compiler/GHC/Builtin/primops.txt.pp
+index 0838116..5a10c66 100644
+--- a/compiler/GHC/Builtin/primops.txt.pp
++++ b/compiler/GHC/Builtin/primops.txt.pp
+@@ -3219,6 +3219,12 @@ primop  ThreadStatusOp "threadStatus#" GenPrimOp
+    out_of_line = True
+    has_side_effects = True
+ 
++primop  ThreadCPUTimeOp "threadCPUTime#" GenPrimOp
++   State# RealWorld -> (# State# RealWorld, Int64#, Int64#, Int32#, Int32# #)
++   with
++   out_of_line = True
++   has_side_effects = True
++
+ primop ListThreadsOp "listThreads#" GenPrimOp
+    State# RealWorld -> (# State# RealWorld, Array# ThreadId# #)
+    { Returns an array of the threads started by the program. Note that this
+diff --git a/compiler/GHC/StgToCmm/Prim.hs b/compiler/GHC/StgToCmm/Prim.hs
+index edf5abf..a54d8d8 100644
+--- a/compiler/GHC/StgToCmm/Prim.hs
++++ b/compiler/GHC/StgToCmm/Prim.hs
+@@ -1615,6 +1615,7 @@ emitPrimOp cfg primop =
+   NoDuplicateOp -> alwaysExternal
+   GetThreadLabelOp -> alwaysExternal
+   ThreadStatusOp -> alwaysExternal
++  ThreadCPUTimeOp -> alwaysExternal
+   MkWeakOp -> alwaysExternal
+   MkWeakNoFinalizerOp -> alwaysExternal
+   AddCFinalizerToWeakOp -> alwaysExternal
+diff --git a/compiler/GHC/StgToJS/Prim.hs b/compiler/GHC/StgToJS/Prim.hs
+index 77ba4cf..119c2d4 100644
+--- a/compiler/GHC/StgToJS/Prim.hs
++++ b/compiler/GHC/StgToJS/Prim.hs
+@@ -878,6 +878,7 @@ genPrim prof bound ty op = case op of
+   IsCurrentThreadBoundOp -> \[r] []        -> PrimInline $ r |= one_
+   NoDuplicateOp          -> \[] []         -> PrimInline mempty -- don't need to do anything as long as we have eager blackholing
+   ThreadStatusOp         -> \[stat,cap,locked] [tid] -> PrimInline $ appT [stat, cap, locked] "h$threadStatus" [tid]
++  ThreadCPUTimeOp        -> unhandledPrimop op
+   ListThreadsOp          -> \[r] [] -> PrimInline $ appT [r] "h$listThreads" []
+   GetThreadLabelOp       -> \[r1, r2] [t]  -> PrimInline $ appT [r1, r2] "h$getThreadLabel" [t]
+   LabelThreadOp          -> \[] [t,l]      -> PrimInline $ t .^ "label" |= l
+diff --git a/configure.ac b/configure.ac
+index 9c7faba..af8b806 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -22,7 +22,7 @@ AC_INIT([The Glorious Glasgow Haskell Compilation System], [9.8.4], [glasgow-has
+ AC_CONFIG_MACRO_DIRS([m4])
+ 
+ # Set this to YES for a released version, otherwise NO
+-: ${RELEASE=YES}
++: ${RELEASE=NO}
+ 
+ # The primary version (e.g. 7.5, 7.4.1) is set in the AC_INIT line
+ # above.  If this is not a released version, then we will append the
+diff --git a/rts/PrimOps.cmm b/rts/PrimOps.cmm
+index baa6487..817f748 100644
+--- a/rts/PrimOps.cmm
++++ b/rts/PrimOps.cmm
+@@ -1202,6 +1202,42 @@ stg_threadStatuszh ( gcptr tso )
+     return (ret,cap,locked);
+ }
+ 
++stg_threadCPUTimezh (/* no args */)
++{
++    // I64 sec, nsec;
++    I64 sec_res, nsec_res;
++    I32 count_thread_sched_out, cur_allocated_res;
++    W_ tmp, sec_ptr, nsec_ptr, cur_allocated_ptr;
++
++    // sec   = StgTSO_cur_sec(CurrentTSO);
++    // nsec  = StgTSO_cur_nsec(CurrentTSO);
++
++    // Use the deriveConstants-generated accessor instead of a hardcoded
++    // struct offset, so this stays correct across GHC/TSO layout changes.
++    count_thread_sched_out = StgTSO_count_thread_sched_out(CurrentTSO);
++
++    //ccall traceThreadCPUTime(sec, nsec, SIZEOF_StgHeader+OFFSET_StgTSO_cur_nsec, SIZEOF_StgHeader);
++
++    STK_CHK_GEN_N (20);
++    reserve 20 = tmp {
++        sec_ptr = tmp;
++        nsec_ptr = tmp + 8;
++        cur_allocated_ptr = tmp + 16;
++
++        // Need to close the nursery to update the rCurrentNursery->free so that we
++        // can use it to get the accurate allocation count.
++        CLOSE_NURSERY();
++        ccall updateThreadCPUTimePostPrim(MyCapability(), CurrentTSO "ptr", sec_ptr "ptr", nsec_ptr "ptr", cur_allocated_ptr "ptr");
++        OPEN_NURSERY();
++
++        sec_res = I64[sec_ptr];
++        nsec_res = I64[nsec_ptr];
++        cur_allocated_res = I32[cur_allocated_ptr];
++    }
++
++    return (sec_res, nsec_res, cur_allocated_res, count_thread_sched_out);
++}
++
+ /* -----------------------------------------------------------------------------
+  * TVar primitives
+  * -------------------------------------------------------------------------- */
+diff --git a/rts/RtsSymbols.c b/rts/RtsSymbols.c
+index 92d10a6..1ad8549 100644
+--- a/rts/RtsSymbols.c
++++ b/rts/RtsSymbols.c
+@@ -876,6 +876,7 @@ extern char **environ;
+       SymI_HasDataProto(stg_takeMVarzh)                                     \
+       SymI_HasDataProto(stg_readMVarzh)                                     \
+       SymI_HasDataProto(stg_threadStatuszh)                                 \
++      SymI_HasDataProto(stg_threadCPUTimezh)                                \
+       SymI_HasDataProto(stg_tryPutMVarzh)                                   \
+       SymI_HasDataProto(stg_tryTakeMVarzh)                                  \
+       SymI_HasDataProto(stg_tryReadMVarzh)                                  \
+diff --git a/rts/Schedule.c b/rts/Schedule.c
+index 8f12429..27383f6 100644
+--- a/rts/Schedule.c
++++ b/rts/Schedule.c
+@@ -183,6 +183,137 @@ static void deleteThread_(StgTSO *tso);
+ 
+    ------------------------------------------------------------------------ */
+ 
++#define TEN_POWER9 1000000000
++
++static void updateThreadCPUTimePre (Capability *cap, StgTSO *t)
++{
++/*
++    fprintf (stderr, "PRE.0: \
++tid = %d, \
++t->cur_sec = %ld, \
++t->cur_nsec = %ld, \
++t->cur_allocated = %d\n", t->id, t->cur_sec, t->cur_nsec, t->cur_allocated);
++*/
++    struct timespec ts;
++    int retval;
++    retval = clock_gettime (CLOCK_THREAD_CPUTIME_ID, &ts);
++    if (retval != 0) {
++        fprintf (stderr, "clock_gettime before failed");
++    } else {
++        if (t->cur_sec < 0 || t->cur_nsec < 0) {
++            fprintf (stderr, "ON ENTRY ERROR: \
++tid = %d, \
++t->cur_sec = %ld \
++t->cur_nsec = %ld \
++t->cur_allocated = %d\n", t->id, t->cur_sec, t->cur_nsec, t->cur_allocated);
++        }
++        t->cur_sec -= ts.tv_sec;
++        t->cur_nsec -= ts.tv_nsec;
++
++        // nsec offset is 128
++        //fprintf (stderr, "tso nsec offset: %ld", (char *)(&t->cur_nsec) - (char *)t);
++        //exit (1);
++        // nsec sizeof = 8
++        //fprintf (stderr, "tso nsec size: %d", sizeof(t->cur_nsec));
++    };
++
++    t->cur_allocated -= getCurrentAllocated (cap);
++/*
++    fprintf (stderr, "PRE.-: \
++tid = %d, \
++t->cur_sec = %ld, \
++t->cur_nsec = %ld, \
++t->cur_allocated = %d\n",
++             t->id,
++             ts.tv_sec,
++             ts.tv_nsec,
++             getCurrentAllocated (cap));
++
++    fprintf (stderr, "PRE.1: \
++tid = %d, \
++t->cur_sec = %ld, \
++t->cur_nsec = %ld, \
++t->cur_allocated = %d\n", t->id, t->cur_sec, t->cur_nsec, t->cur_allocated);
++*/
++}
++
++// This is also used in the PrimOps as a foreign call
++void updateThreadCPUTimePostPrim
++    (Capability *cap,
++     StgTSO *t,
++     StgInt64 *cur_sec_res,
++     StgInt64 *cur_nsec_res,
++     StgInt32 *cur_allocated_res)
++{
++/*
++    fprintf (stderr, "POST.0: \
++tid = %d, \
++t->cur_sec = %ld, \
++t->cur_nsec = %ld, \
++t->cur_allocated = %d\n", t->id, t->cur_sec, t->cur_nsec, t->cur_allocated);
++*/
++    *cur_allocated_res = t->cur_allocated + getCurrentAllocated (cap);
++    // fprintf (stderr, "POST: %d\n", t->cur_allocated);
++
++    struct timespec ts;
++    int retval;
++    retval = clock_gettime (CLOCK_THREAD_CPUTIME_ID, &ts);
++    if (retval != 0) {
++        fprintf (stderr, "clock_gettime after failed");
++    } else {
++        //fprintf (stderr, "sec = %ld nsec = %ld\n", ts.tv_sec, ts.tv_nsec);
++        *cur_sec_res = t->cur_sec + ts.tv_sec;
++        *cur_nsec_res = t->cur_nsec + ts.tv_nsec;
++        if (*cur_nsec_res < 0) {
++            *cur_nsec_res += TEN_POWER9;
++            *cur_sec_res -= 1;
++        } else if (*cur_nsec_res >= TEN_POWER9) {
++            *cur_nsec_res -= TEN_POWER9;
++            *cur_sec_res += 1;
++        }
++        // fprintf (stderr, "AFTER DONE: tid = %d, t->cur_sec = %ld t->cur_nsec = %ld\n", t->id, t->cur_sec, t->cur_nsec);
++        if (*cur_sec_res < 0 || *cur_nsec_res < 0) {
++            fprintf (stderr, "ON EXIT ERROR PRIM: \
++tid = %d, \
++t->cur_sec = %ld \
++t->cur_nsec = %ld \
++t->cur_allocated = %d\n",
++             t->id,
++             *cur_sec_res,
++             *cur_nsec_res,
++             *cur_allocated_res);
++        }
++        //fprintf (stderr, "acc sec = %ld acc nsec = %ld\n", t->cur_sec, t->cur_nsec);
++    }
++/*
++    fprintf (stderr, "POST.+: \
++tid = %d, \
++t->cur_sec = %ld, \
++t->cur_nsec = %ld, \
++t->cur_allocated = %d\n",
++             t->id,
++             ts.tv_sec,
++             ts.tv_nsec,
++             getCurrentAllocated (cap));
++
++    fprintf (stderr, "POST.1: \
++tid = %d, \
++t->cur_sec = %ld, \
++t->cur_nsec = %ld, \
++t->cur_allocated = %d\n",
++             t->id,
++             *cur_sec_res,
++             *cur_nsec_res,
++             *cur_allocated_res);
++             */
++}
++
++static void updateThreadCPUTimePost (Capability *cap, StgTSO *t)
++{
++    updateThreadCPUTimePostPrim(cap, t, &t->cur_sec, &t->cur_nsec, &t->cur_allocated);
++    t->count_thread_sched_out += 1;
++}
++
+ static Capability *
+ schedule (Capability *initialCapability, Task *task)
+ {
+@@ -477,8 +608,13 @@ run_thread:
+     case ThreadRunGHC:
+     {
+         StgRegTable *r;
++
++        updateThreadCPUTimePre (cap, t);
+         r = StgRun((StgFunPtr) stg_returnToStackTop, &cap->r);
+         cap = regTableToCapability(r);
++        t = cap->r.rCurrentTSO;
++        updateThreadCPUTimePost (cap, t);
++
+         ret = r->rRet;
+         break;
+     }
+@@ -2492,6 +2628,7 @@ suspendThread (StgRegTable *reg, bool interruptible)
+   task = cap->running_task;
+   tso = cap->r.rCurrentTSO;
+ 
++  updateThreadCPUTimePost (cap, tso);
+   traceEventStopThread(cap, tso, THREAD_SUSPENDED_FOREIGN_CALL, 0);
+ 
+   // XXX this might not be necessary --SDM
+@@ -2591,6 +2728,8 @@ resumeThread (void *task_)
+ 
+     IF_DEBUG(sanity, checkTSO(tso));
+ 
++    updateThreadCPUTimePre (cap, tso);
++
+     return &cap->r;
+ }
+ 
+diff --git a/rts/Schedule.h b/rts/Schedule.h
+index e4f17af..f13ba82 100644
+--- a/rts/Schedule.h
++++ b/rts/Schedule.h
+@@ -23,6 +23,14 @@ void initScheduler (void);
+ void exitScheduler (bool wait_foreign);
+ void freeScheduler (void);
+ 
++// Primitive operation used to update the threadCPUTime prim-op
++void updateThreadCPUTimePostPrim
++    (Capability *cap,
++     StgTSO *t,
++     StgInt64 *cur_sec_res,
++     StgInt64 *cur_nsec_res,
++     StgInt32 *cur_allocated_res);
++
+ // Place a new thread on the run queue of the current Capability
+ void scheduleThread (Capability *cap, StgTSO *tso);
+ 
+diff --git a/rts/Threads.c b/rts/Threads.c
+index 46a70a1..7a7e992 100644
+--- a/rts/Threads.c
++++ b/rts/Threads.c
+@@ -118,6 +118,11 @@ createThread(Capability *cap, W_ size)
+     tso->prof.cccs = CCS_MAIN;
+ #endif
+ 
++    tso->cur_sec = 0;
++    tso->cur_nsec = 0;
++    tso->count_thread_sched_out = 0;
++    tso->cur_allocated = 0;
++
+     // put a stop frame on the stack
+     stack->sp -= sizeofW(StgStopFrame);
+     SET_HDR((StgClosure*)stack->sp,
+diff --git a/rts/include/rts/storage/TSO.h b/rts/include/rts/storage/TSO.h
+index 4ca1985..d0a1a45 100644
+--- a/rts/include/rts/storage/TSO.h
++++ b/rts/include/rts/storage/TSO.h
+@@ -188,6 +188,14 @@ typedef struct StgTSO_ {
+     StgWord32 saved_winerror;
+ #endif
+ 
++    // Can this go in the thread cost centre stack or a similar data structure
++    // for perf stats? We can enable the use of this using an RTS option.
++    // See compiler/profiling/CostCentre.hs
++    StgInt64 cur_sec;
++    StgInt64 cur_nsec;
++    StgInt32 count_thread_sched_out;
++    StgInt32 cur_allocated;
++
+ } *StgTSOPtr; // StgTSO defined in rts/Types.h
+ 
+ /* Note [StgStack dirtiness flags and concurrent marking]
+diff --git a/rts/include/stg/MiscClosures.h b/rts/include/stg/MiscClosures.h
+index 9d52d4b..4905775 100644
+--- a/rts/include/stg/MiscClosures.h
++++ b/rts/include/stg/MiscClosures.h
+@@ -549,6 +549,7 @@ RTS_FUN_DECL(stg_labelThreadzh);
+ RTS_FUN_DECL(stg_isCurrentThreadBoundzh);
+ RTS_FUN_DECL(stg_threadLabelzh);
+ RTS_FUN_DECL(stg_threadStatuszh);
++RTS_FUN_DECL(stg_threadCPUTimezh);
+ RTS_FUN_DECL(stg_listThreadszh);
+ 
+ RTS_FUN_DECL(stg_mkWeakzh);
+diff --git a/rts/sm/Storage.c b/rts/sm/Storage.c
+index 424ab84..8d9a571 100644
+--- a/rts/sm/Storage.c
++++ b/rts/sm/Storage.c
+@@ -1610,6 +1610,30 @@ calcTotalAllocated (void)
+     return tot_alloc;
+ }
+ 
++StgWord64
++getCurrentAllocated (Capability *cap)
++{
++    bdescr *bd;
++    StgWord64 allocated;
++
++    allocated = cap->total_allocated;
++
++    // Add unfinished nursery blocks
++    bd = cap->r.rCurrentNursery;
++    if (bd) {
++      allocated += bd->free - bd->start;
++    }
++    bd = cap->r.rCurrentAlloc;
++    if (bd) {
++      allocated += bd->free - bd->start;
++    }
++    bd = cap->pinned_object_block;
++    if (bd) {
++      allocated += bd->free - bd->start;
++    }
++    return allocated;
++}
++
+ //
+ // Update the per-cap total_allocated numbers with an approximation of
+ // the amount of memory used in each cap's nursery.
+diff --git a/rts/sm/Storage.h b/rts/sm/Storage.h
+index e911d19..f28e0c9 100644
+--- a/rts/sm/Storage.h
++++ b/rts/sm/Storage.h
+@@ -100,6 +100,9 @@ INLINE_HEADER void newNurseryBlock (bdescr *bd) {
+ void     updateNurseriesStats (void);
+ uint64_t calcTotalAllocated   (void);
+ 
++StgWord64
++getCurrentAllocated (Capability *cap);
++
+ /* -----------------------------------------------------------------------------
+    Stats 'n' DEBUG stuff
+    -------------------------------------------------------------------------- */
+diff --git a/utils/deriveConstants/Main.hs b/utils/deriveConstants/Main.hs
+index d037199..053d7ea 100644
+--- a/utils/deriveConstants/Main.hs
++++ b/utils/deriveConstants/Main.hs
+@@ -471,6 +471,12 @@ wanteds os = concat
+           ,closureField_ Both "StgTSO_cccs" "StgTSO" "prof.cccs"
+           ,closureField  Both "StgTSO"      "stackobj"
+ 
++          -- XXX These fields might not be required for our use case
++          ,closureField  C "StgTSO"      "cur_sec"
++          ,closureField  C "StgTSO"      "cur_nsec"
++          ,closureField  C "StgTSO"      "count_thread_sched_out"
++          ,closureField  C "StgTSO"      "cur_allocated"
++
+           ,closureField       Both "StgStack" "sp"
+           ,closureFieldOffset Both "StgStack" "stack"
+           ,closureField       C    "StgStack" "stack_size"
+-- 
+2.51.2
+

--- a/ghc-patches/added-support-for-desugar-plugin.patch
+++ b/ghc-patches/added-support-for-desugar-plugin.patch
@@ -1,8 +1,8 @@
 diff --git a/compiler/GHC/Driver/Main.hs b/compiler/GHC/Driver/Main.hs
-index 4dde0700535..708a511cb36 100644
+index fd7b0c9..cb7d6b0 100644
 --- a/compiler/GHC/Driver/Main.hs
 +++ b/compiler/GHC/Driver/Main.hs
-@@ -657,19 +657,22 @@ tcRnModule' sum save_rn_syntax mod = do
+@@ -773,15 +773,19 @@ tcRnModule' sum save_rn_syntax mod = do
  -- | Convert a typechecked module to Core
  hscDesugar :: HscEnv -> ModSummary -> TcGblEnv -> IO ModGuts
  hscDesugar hsc_env mod_summary tc_result =
@@ -14,22 +14,19 @@ index 4dde0700535..708a511cb36 100644
 +hscDesugar' :: Maybe ModSummary -> ModLocation -> TcGblEnv -> Hsc ModGuts
 +hscDesugar' mod_summary mod_location tc_result = do
      hsc_env <- getHscEnv
-     r <- ioMsgMaybe $
+-    ioMsgMaybe $ hoistDsMessage $
++    r <- ioMsgMaybe $ hoistDsMessage $
        {-# SCC "deSugar" #-}
        deSugar hsc_env mod_location tc_result
  
-+    -- Run plugins' desugar actions
-+    r' <- withPlugins hsc_env (\p opts mod_guts -> desugarResultAction p opts mod_summary tc_result mod_guts) r
++    -- Run plugins' desugar actions on the freshly desugared Core.
++    withPlugins (hsc_plugins hsc_env)
++      (\p opts mod_guts -> desugarResultAction p opts mod_summary tc_result mod_guts) r
 +
-     -- always check -Werror after desugaring, this is the last opportunity for
-     -- warnings to arise before the backend.
-     handleWarnings
--    return r
-+    return r'
- 
  -- | Make a 'ModDetails' from the results of typechecking. Used when
  -- typechecking only, as opposed to full compilation.
-@@ -949,7 +952,7 @@ finish summary tc_result mb_old_hash = do
+ makeSimpleDetails :: Logger -> TcGblEnv -> IO ModDetails
+@@ -1111,7 +1115,7 @@ hscDesugarAndSimplify summary (FrontendTypecheck tc_result) tc_warnings mb_old_h
    -- HsSrcFile Module.
    mb_desugar <-
        if ms_mod summary /= gHC_PRIM && hsc_src == HsSrcFile
@@ -37,10 +34,10 @@ index 4dde0700535..708a511cb36 100644
 +      then Just <$> hscDesugar' (Just summary) (ms_location summary) tc_result
        else pure Nothing
  
-   -- Simplify, if appropriate, and (whether we simplified or not) generate an
-@@ -2003,7 +2006,7 @@ hscParsedDecls hsc_env decls = runInteractiveHsc hsc_env $ do
-                                       ml_hi_file   = panic "hsDeclsWithLocation:ml_hi_file",
-                                       ml_obj_file  = panic "hsDeclsWithLocation:ml_obj_file",
+   -- Report the warnings from both typechecking and desugar together
+@@ -2334,7 +2338,7 @@ hscParsedDecls hsc_env decls = runInteractiveHsc hsc_env $ do
+                                       ml_dyn_obj_file = panic "hsDeclsWithLocation:ml_dyn_obj_file",
+                                       ml_dyn_hi_file = panic "hsDeclsWithLocation:ml_dyn_hi_file",
                                        ml_hie_file  = panic "hsDeclsWithLocation:ml_hie_file" }
 -    ds_result <- hscDesugar' iNTERACTIVELoc tc_gblenv
 +    ds_result <- hscDesugar' Nothing iNTERACTIVELoc tc_gblenv
@@ -48,26 +45,29 @@ index 4dde0700535..708a511cb36 100644
      {- Simplify -}
      simpl_mg <- liftIO $ do
 diff --git a/compiler/GHC/Driver/Plugins.hs b/compiler/GHC/Driver/Plugins.hs
-index 2d8bc0ad856..b6eb3405e53 100644
+index 823ecd9..2dbde1f 100644
 --- a/compiler/GHC/Driver/Plugins.hs
 +++ b/compiler/GHC/Driver/Plugins.hs
-@@ -56,6 +56,7 @@ import GHC.Driver.Phases
+@@ -77,6 +77,7 @@ import GHC.Driver.Plugins.External
  import GHC.Unit.Module
  import GHC.Unit.Module.ModIface
  import GHC.Unit.Module.ModSummary
 +import GHC.Unit.Module.ModGuts
  
- import qualified GHC.Tc.Types
- import GHC.Tc.Types ( TcGblEnv, IfM, TcM, tcg_rn_decls, tcg_rn_exports  )
-@@ -129,6 +130,7 @@ data Plugin = Plugin {
+ import GHC.Parser.Errors.Types (PsWarning, PsError)
+ 
+@@ -184,6 +185,10 @@ data Plugin = Plugin {
      -- the loading of the plugin interface. Tools that rely on information from
      -- modules other than the currently compiled one should implement this
      -- function.
-+  , desugarResultAction :: [CommandLineOption] -> (Maybe ModSummary) -> TcGblEnv -> ModGuts -> Hsc ModGuts
++  , desugarResultAction :: [CommandLineOption] -> Maybe ModSummary -> TcGblEnv -> ModGuts -> Hsc ModGuts
++    -- ^ Modify the desugaring (Core) result before it is optimised. This is
++    -- called by "GHC.Driver.Main" after desugaring produces the initial
++    -- 'ModGuts'.
    }
  
  -- Note [Source plugins]
-@@ -221,6 +223,7 @@ defaultPlugin = Plugin {
+@@ -286,6 +291,7 @@ defaultPlugin = Plugin {
        , typeCheckResultAction = \_ _ -> return
        , spliceRunAction       = \_ -> return
        , interfaceLoadAction   = \_ -> return

--- a/keyLookupTracker/src/KeyLookupTracker/Plugin.hs
+++ b/keyLookupTracker/src/KeyLookupTracker/Plugin.hs
@@ -75,8 +75,13 @@ checkBind :: Rules ->  LHsBindLR GhcTc GhcTc -> TcM [(String, [String])]
 checkBind rule (L _ (FunBind{..} )) = do
   let funMatches = unLoc $ mg_alts fun_matches
   concat <$> mapM (checkMatch rule (getVarNameFromIDP $ unLoc fun_id)) funMatches
+#if __GLASGOW_HASKELL__ >= 904
+checkBind rule (L _ (XHsBindsLR (AbsBinds {abs_binds = binds}))) =
+  concat <$> (mapM (checkBind rule) $ bagToList binds)
+#else
 checkBind rule (L _ (AbsBinds {abs_binds = binds})) =
   concat <$> (mapM (checkBind rule) $ bagToList binds)
+#endif
 checkBind _ _ = pure []
 
 checkMatch :: Rules -> String -> LMatch GhcTc (LHsExpr GhcTc) -> TcM [(String, [String])]
@@ -91,7 +96,11 @@ loopOverExpr rule expr =
   pure $ if any (`isInfixOf` (showS expr)) (["lookup"] <> (additionalEligibleLookupFns rule))
     then
       case expr of
+#if __GLASGOW_HASKELL__ >= 904
+        (HsApp _ _ (L _ (HsOverLit _ (OverLit (OverLitTc _ (HsApp _ _ (L _ (HsLit _ lit))) _) _)))) -> [showS lit]
+#else
         (HsApp _ _ (L _ (HsOverLit _ (OverLit _ _ (HsApp _ _ (L _ (HsLit _ lit))))))) -> [showS lit]
+#endif
         _ -> []
     else []
 

--- a/patches/large-records-ghc98.patch
+++ b/patches/large-records-ghc98.patch
@@ -1,0 +1,876 @@
+diff --git a/src/Data/Record/Internal/GHC/Fresh.hs b/src/Data/Record/Internal/GHC/Fresh.hs
+--- a/src/Data/Record/Internal/GHC/Fresh.hs
++++ b/src/Data/Record/Internal/GHC/Fresh.hs
+@@ -32,7 +32,7 @@
+   freshName' pfx (L l name) = WrapFresh $ ReaderT $ \nc -> do
+       newUniq <- takeUniqFromNameCacheIO nc
+       return $ L l $ Exact $
+-        mkInternalName newUniq (newOccName (rdrNameOcc name)) l
++        mkInternalName newUniq (newOccName (rdrNameOcc name)) (toSrcSpan l)
+     where
+       -- Even when we generate fresh names, ghc can still complain about name
+       -- shadowing, because this check only considers the 'OccName', not the
+@@ -52,4 +52,3 @@
+     env <- getHscEnv
+     liftIO $ runFresh fa (hscNameCacheIO env)
+ 
+-
+diff --git a/src/Data/Record/Internal/GHC/Shim.hs b/src/Data/Record/Internal/GHC/Shim.hs
+--- a/src/Data/Record/Internal/GHC/Shim.hs
++++ b/src/Data/Record/Internal/GHC/Shim.hs
+@@ -141,6 +141,9 @@
+ #if __GLASGOW_HASKELL__ < 904
+     , trace
+ #endif
++#if __GLASGOW_HASKELL__ >= 908
++    , fieldName
++#endif
+     )
+ 
+ #if __GLASGOW_HASKELL__ < 902
+@@ -153,6 +156,10 @@
+ import GHC.Unit.Finder (findImportedModule, FindResult(Found))
+ #endif
+ 
++#if __GLASGOW_HASKELL__ >= 906
++import qualified GHC.Types.Basic
++#endif
++
+ #if __GLASGOW_HASKELL__ < 904
+ import Data.IORef
+ import GHC.Iface.Env (lookupOrigIO)
+@@ -165,6 +172,10 @@
+ 
+ #endif
+ 
++#if __GLASGOW_HASKELL__ >= 906
++import Language.Haskell.Syntax.Basic (FieldLabelString(..))
++#endif
++
+ {-------------------------------------------------------------------------------
+   Name resolution
+ -------------------------------------------------------------------------------}
+@@ -226,8 +237,18 @@
+ -- | Optionally @qualified@ import declaration
+ importDecl :: ModuleName -> Bool -> LImportDecl GhcPs
+ importDecl name qualified = noLocA $ ImportDecl {
++#if __GLASGOW_HASKELL__ < 906
+       ideclExt       = defExt
++#else
++      ideclExt       = XImportDeclPass {
++                           ideclAnn        = defExt
++                         , ideclSourceText = NoSourceText
++                         , ideclImplicit   = False
++                         }
++#endif
++#if __GLASGOW_HASKELL__ < 906
+     , ideclSourceSrc = NoSourceText
++#endif
+     , ideclName      = noLocA name
+ #if __GLASGOW_HASKELL__ >= 904
+     , ideclPkgQual   = NoRawPkgQual
+@@ -235,9 +256,13 @@
+     , ideclPkgQual   = Nothing
+ #endif
+     , ideclSafe      = False
++#if __GLASGOW_HASKELL__ < 906
+     , ideclImplicit  = False
++#endif
+     , ideclAs        = Nothing
++#if __GLASGOW_HASKELL__ < 906
+     , ideclHiding    = Nothing
++#endif
+ #if __GLASGOW_HASKELL__ < 810
+     , ideclQualified = qualified
+ #else
+@@ -248,18 +273,25 @@
+ #else
+     , ideclSource    = NotBoot
+ #endif
++#if __GLASGOW_HASKELL__ >= 906
++    , ideclImportList = Nothing
++#endif
+     }
+ 
+-conPat :: Located RdrName -> HsConPatDetails GhcPs -> Pat GhcPs
++conPat :: LRdrName -> HsConPatDetails GhcPs -> Pat GhcPs
+ #if __GLASGOW_HASKELL__ < 900
+ conPat x y = ConPatIn x y
++#elif __GLASGOW_HASKELL__ >= 908
++conPat x y = ConPat defExt x y
+ #else
+ conPat x y = ConPat defExt (reLocA x) y
+ #endif
+ 
+-mkFunBind :: Located RdrName -> [LMatch GhcPs (LHsExpr GhcPs)] -> HsBind GhcPs
++mkFunBind :: LRdrName -> [LMatch GhcPs (LHsExpr GhcPs)] -> HsBind GhcPs
+ #if __GLASGOW_HASKELL__ < 810
+ mkFunBind = GHC.mkFunBind
++#elif __GLASGOW_HASKELL__ >= 908
++mkFunBind n = GHC.mkFunBind (Generated DoPmc) n
+ #else
+ mkFunBind (reLocA -> n) = GHC.mkFunBind Generated n
+ #endif
+@@ -270,8 +302,16 @@
+ type HsModule = GHC.HsModule
+ #endif
+ 
++#if __GLASGOW_HASKELL__ >= 906
++type LHsModule = Located (HsModule GhcPs)
++#else
+ type LHsModule = Located HsModule
++#endif
++#if __GLASGOW_HASKELL__ >= 908
++type LRdrName  = LIdP GhcPs
++#else
+ type LRdrName  = Located RdrName
++#endif
+ 
+ {-------------------------------------------------------------------------------
+   NameCache
+@@ -331,11 +371,22 @@
+   defExt = noExtField
+ #endif
+ 
+-#if __GLASGOW_HASKELL__ >= 900
++#if __GLASGOW_HASKELL__ >= 906
++instance HasDefaultExt (LayoutInfo GhcPs) where
++  defExt = NoLayoutInfo
++
++instance HasDefaultExt SourceText where
++  defExt = NoSourceText
++#elif __GLASGOW_HASKELL__ >= 900
+ instance HasDefaultExt LayoutInfo where
+   defExt = NoLayoutInfo
+ #endif
+ 
++#if __GLASGOW_HASKELL__ >= 908
++instance HasDefaultExt GHC.Types.Basic.Origin where
++  defExt = Generated DoPmc
++#endif
++
+ instance (HasDefaultExt a, HasDefaultExt b) => HasDefaultExt (a, b) where
+   defExt = (defExt, defExt)
+ 
+@@ -366,7 +417,10 @@
+   Generalized @forall@ in 9.0
+ -------------------------------------------------------------------------------}
+ 
+-#if __GLASGOW_HASKELL__ >= 900
++#if __GLASGOW_HASKELL__ >= 908
++type  HsTyVarBndr pass =  GHC.HsTyVarBndr (HsBndrVis GhcPs) pass
++type LHsTyVarBndr pass = GHC.LHsTyVarBndr (HsBndrVis GhcPs) pass
++#elif __GLASGOW_HASKELL__ >= 900
+ type  HsTyVarBndr pass =  GHC.HsTyVarBndr () pass
+ type LHsTyVarBndr pass = GHC.LHsTyVarBndr () pass
+ #endif
+@@ -382,21 +436,25 @@
+ 
+ userTyVar ::
+      XUserTyVar GhcPs
+-  -> Located (IdP GhcPs)
++  -> LRdrName
+   -> HsTyVarBndr GhcPs
+ #if __GLASGOW_HASKELL__ < 900
+ userTyVar = UserTyVar
++#elif __GLASGOW_HASKELL__ >= 908
++userTyVar ext x = UserTyVar ext HsBndrRequired x
+ #else
+ userTyVar ext x = UserTyVar ext () (reLocA x)
+ #endif
+ 
+ kindedTyVar ::
+      XKindedTyVar GhcPs
+-  -> Located (IdP GhcPs)
++  -> LRdrName
+   -> LHsKind GhcPs
+   -> HsTyVarBndr GhcPs
+ #if __GLASGOW_HASKELL__ < 900
+ kindedTyVar = KindedTyVar
++#elif __GLASGOW_HASKELL__ >= 908
++kindedTyVar ext k = KindedTyVar ext HsBndrRequired k
+ #else
+ kindedTyVar ext k = KindedTyVar ext () (reLocA k)
+ #endif
+@@ -407,6 +465,9 @@
+ hsTyVarLName (UserTyVar   _ n  ) = n
+ hsTyVarLName (KindedTyVar _ n _) = n
+ hsTyVarLName _ = panic "hsTyVarLName"
++#elif __GLASGOW_HASKELL__ >= 908
++hsTyVarLName (UserTyVar   _ _ n  ) = n
++hsTyVarLName (KindedTyVar _ _ n _) = n
+ #else
+ hsTyVarLName (UserTyVar   _ _ n  ) = reLoc n
+ hsTyVarLName (KindedTyVar _ _ n _) = reLoc n
+@@ -418,8 +479,8 @@
+ #else
+ setDefaultSpecificity :: LHsTyVarBndr GhcPs -> GHC.LHsTyVarBndr Specificity GhcPs
+ setDefaultSpecificity = mapXRec @GhcPs $ \v -> case v of
+-    UserTyVar   ext () name      -> UserTyVar   ext SpecifiedSpec name
+-    KindedTyVar ext () name kind -> KindedTyVar ext SpecifiedSpec name kind
++    UserTyVar   ext _ name      -> UserTyVar   ext SpecifiedSpec name
++    KindedTyVar ext _ name kind -> KindedTyVar ext SpecifiedSpec name kind
+ #if __GLASGOW_HASKELL__ < 900
+     XTyVarBndr  ext              -> XTyVarBndr  ext
+ #endif
+@@ -525,7 +586,9 @@
+   Records
+ -------------------------------------------------------------------------------}
+ 
+-#if __GLASGOW_HASKELL__ >= 902
++#if __GLASGOW_HASKELL__ >= 908
++type RupdFlds = LHsRecUpdFields GhcPs
++#elif __GLASGOW_HASKELL__ >= 902
+ type RupdFlds = Either [LHsRecUpdField GhcPs] [LHsRecUpdProj GhcPs]
+ #else
+ type RupdFlds = [LHsRecUpdField GhcPs]
+@@ -538,8 +601,15 @@
+ 
+ simpleRecordUpdates =
+     \case
++#if __GLASGOW_HASKELL__ >= 908
++      RegularRecUpdFields _ flds ->
++        mapM (aux (isUnambigous  . unLoc)) flds
++      OverloadedRecUpdFields _ flds ->
++        mapM (aux (isSingleLabel . unLoc)) flds
++#else
+       Left  flds -> mapM (aux (isUnambigous  . unLoc)) flds
+       Right flds -> mapM (aux (isSingleLabel . unLoc)) flds
++#endif
+   where
+     aux :: forall lhs rhs.
+          (lhs -> Maybe LRdrName)
+@@ -553,14 +623,26 @@
+         (, val) <$> f lbl
+ 
+     isUnambigous :: AmbiguousFieldOcc GhcPs -> Maybe LRdrName
++#if __GLASGOW_HASKELL__ >= 908
++    isUnambigous (Unambiguous _ name) = Just name
++#else
+     isUnambigous (Unambiguous _ name) = Just $ reLoc name
++#endif
+     isUnambigous _                    = Nothing
+ 
+     isSingleLabel :: FieldLabelStrings GhcPs -> Maybe LRdrName
+     isSingleLabel (FieldLabelStrings labels) =
+         case labels of
++#if __GLASGOW_HASKELL__ >= 906
++          [L _ (DotFieldOcc _ (L l (FieldLabelString label)))] ->
++#else
+           [L _ (DotFieldOcc _ (L l label))] ->
++#endif
++#if __GLASGOW_HASKELL__ >= 908
++            Just $ L l (Unqual $ mkVarOccFS label)
++#else
+             Just $ reLoc $ L l (Unqual $ mkVarOccFS label)
++#endif
+           _otherwise ->
+             Nothing
+ 
+@@ -614,4 +696,4 @@
+     isUnambigous (Unambiguous _ name) = Just $ reLoc name
+     isUnambigous _                    = Nothing
+ 
+-#endif
+\ No newline at end of file
++#endif
+diff --git a/src/Data/Record/Internal/GHC/TemplateHaskellStyle.hs b/src/Data/Record/Internal/GHC/TemplateHaskellStyle.hs
+--- a/src/Data/Record/Internal/GHC/TemplateHaskellStyle.hs
++++ b/src/Data/Record/Internal/GHC/TemplateHaskellStyle.hs
+@@ -133,15 +133,15 @@
+ 
+ -- | Equivalent of 'Language.Haskell.TH.Syntax.mkName', for expression vars
+ mkExpVar :: SrcSpan -> String -> LRdrName
+-mkExpVar l = L l . mkRdrUnqual . mkVarOcc
++mkExpVar l = inheritLoc l . mkRdrUnqual . mkVarOcc
+ 
+ -- | Equivalent of 'Language.Haskell.TH.Syntax.mkName', for type vars
+ mkTyVar :: SrcSpan -> String -> LRdrName
+-mkTyVar l = L l . mkRdrUnqual . mkTyVarOcc
++mkTyVar l = inheritLoc l . mkRdrUnqual . mkTyVarOcc
+ 
+ -- | Equivalent of 'Language.Haskell.TH.Syntax.mkName', for type constructors
+ mkTyCon :: SrcSpan -> String -> LRdrName
+-mkTyCon l = L l . mkRdrUnqual . mkTcOcc
++mkTyCon l = inheritLoc l . mkRdrUnqual . mkTcOcc
+ 
+ -- | Inverse to 'mkExpVar'
+ --
+@@ -181,12 +181,20 @@
+ -- | Equivalent of 'Language.Haskell.TH.Lib.varE'
+ varE :: HasCallStack => LRdrName -> LHsExpr GhcPs
+ varE name
++#if __GLASGOW_HASKELL__ >= 908
++  | isTermVar name = inheritLoc name $ HsVar defExt name
++#else
+   | isTermVar name = inheritLoc name $ HsVar defExt (reLocA name)
++#endif
+   | otherwise      = error "varE: incorrect name type"
+ 
+ -- | Inverse to 'varE'
+ viewVarE :: LHsExpr GhcPs -> Maybe LRdrName
++#if __GLASGOW_HASKELL__ >= 908
++viewVarE (L _ (HsVar _ name)) | isTermVar name = Just name
++#else
+ viewVarE (L _ (HsVar _ (reLoc -> name))) | isTermVar name = Just name
++#endif
+ viewVarE _ = Nothing
+ 
+ pattern VarE :: HasCallStack => () => LRdrName -> LHsExpr GhcPs
+@@ -197,12 +205,20 @@
+ -- | Equivalent of 'Language.Haskell.TH.Lib.conE'
+ conE :: HasCallStack => LRdrName -> LHsExpr GhcPs
+ conE name
++#if __GLASGOW_HASKELL__ >= 908
++  | isTermCon name = inheritLoc name $ HsVar defExt name
++#else
+   | isTermCon name = inheritLoc name $ HsVar defExt (reLocA name)
++#endif
+   | otherwise      = error "conE: incorrect name type"
+ 
+ -- | Inverse to 'conE'
+ viewConE :: LHsExpr GhcPs -> Maybe LRdrName
++#if __GLASGOW_HASKELL__ >= 908
++viewConE (L _ (HsVar _ name)) | isTermCon name = Just name
++#else
+ viewConE (L _ (HsVar _ (reLoc -> name))) | isTermCon name = Just name
++#endif
+ viewConE _ = Nothing
+ 
+ pattern ConE :: HasCallStack => () => LRdrName -> LHsExpr GhcPs
+@@ -224,7 +240,11 @@
+   where
+     mkRec :: LRdrName -> [LHsRecField GhcPs (LHsExpr GhcPs)] -> LHsExpr GhcPs
+     mkRec name fields = inheritLoc name $
++#if __GLASGOW_HASKELL__ >= 908
++        RecordCon defExt name (HsRecFields fields Nothing)
++#else
+         RecordCon defExt (reLocA name) (HsRecFields fields Nothing)
++#endif
+ 
+     mkFld :: LRdrName -> LHsExpr GhcPs -> LHsRecField GhcPs (LHsExpr GhcPs)
+     mkFld name val = inheritLoc name $
+@@ -235,21 +255,35 @@
+ #else
+         HsRecField
+ #endif
++#if __GLASGOW_HASKELL__ >= 908
++          (inheritLoc name (mkFieldOcc name)) val False
++#else
+           (inheritLoc name (mkFieldOcc (reLocA name))) val False
++#endif
+ 
+ -- | Equivalent of 'Language.Haskell.TH.Lib.recUpdE'
+ recUpdE :: LHsExpr GhcPs -> [(LRdrName, LHsExpr GhcPs)] -> LHsExpr GhcPs
+ recUpdE = \recExpr -> updRec recExpr . map (uncurry updFld)
+   where
++#if __GLASGOW_HASKELL__ >= 908
++    updRec :: LHsExpr GhcPs -> [LHsRecUpdField GhcPs GhcPs] -> LHsExpr GhcPs
++#else
+     updRec :: LHsExpr GhcPs -> [LHsRecUpdField GhcPs] -> LHsExpr GhcPs
++#endif
+     updRec expr fields = inheritLoc expr $
+         RecordUpd defExt expr
+-#if __GLASGOW_HASKELL__ >= 902
++#if __GLASGOW_HASKELL__ >= 908
++          $ RegularRecUpdFields noExtField
++#elif __GLASGOW_HASKELL__ >= 902
+           $ Left
+ #endif
+             fields
+ 
++#if __GLASGOW_HASKELL__ >= 908
++    updFld :: LRdrName -> LHsExpr GhcPs -> LHsRecUpdField GhcPs GhcPs
++#else
+     updFld :: LRdrName -> LHsExpr GhcPs -> LHsRecUpdField GhcPs
++#endif
+     updFld name val = inheritLoc name $
+ #if __GLASGOW_HASKELL__ >= 904
+         HsFieldBind
+@@ -259,7 +293,11 @@
+ #if __GLASGOW_HASKELL__ >= 902
+           defExt
+ #endif
++#if __GLASGOW_HASKELL__ >= 908
++          (inheritLoc name (mkAmbiguousFieldOcc name)) val False
++#else
+           (inheritLoc name (mkAmbiguousFieldOcc (reLocA name))) val False
++#endif
+ 
+ viewRecUpdE ::
+      LHsExpr GhcPs
+@@ -289,10 +327,14 @@
+ lamE :: NonEmpty (LPat GhcPs) -> LHsExpr GhcPs -> LHsExpr GhcPs
+ lamE pats body = inheritLoc body $
+     HsLam defExt $
++#if __GLASGOW_HASKELL__ >= 906
++      MG defExt (inheritLoc body [inheritLoc body match])
++#else
+       MG defExt (inheritLoc body [inheritLoc body match]) Generated
++#endif
+   where
+     match :: Match GhcPs (LHsExpr GhcPs)
+-    match = Match defExt LambdaExpr (NE.toList pats) (simpleGHRSs body)
++    match = Match defExt LambdaExpr (inheritLoc pats (NE.toList pats)) (simpleGHRSs body)
+ 
+ -- | Convenience wrapper around 'lamE' for a single argument
+ lamE1 :: LPat GhcPs -> LHsExpr GhcPs -> LHsExpr GhcPs
+@@ -301,11 +343,15 @@
+ -- | Equivalent of 'Language.Haskell.TH.Lib.caseE'
+ caseE :: LHsExpr GhcPs -> [(LPat GhcPs, LHsExpr GhcPs)] -> LHsExpr GhcPs
+ caseE x alts = inheritLoc x $
++#if __GLASGOW_HASKELL__ >= 906
++    HsCase defExt x (MG defExt (inheritLoc x (map mkAlt alts)))
++#else
+     HsCase defExt x (MG defExt (inheritLoc x (map mkAlt alts)) Generated)
++#endif
+   where
+     mkAlt :: (LPat GhcPs, LHsExpr GhcPs) -> LMatch GhcPs (LHsExpr GhcPs)
+     mkAlt (pat, body) = inheritLoc x $
+-        Match defExt CaseAlt [pat] (simpleGHRSs body)
++        Match defExt CaseAlt (inheritLoc pat [pat]) (simpleGHRSs body)
+ 
+ -- | Equivalent of 'Language.Haskell.TH.Lib.appsE'
+ appsE :: LHsExpr GhcPs -> [LHsExpr GhcPs] -> LHsExpr GhcPs
+@@ -314,6 +360,9 @@
+ -- | Equivalent of 'Language.Haskell.TH.Lib.appT'
+ appTypeE :: LHsExpr GhcPs -> LHsType GhcPs -> LHsExpr GhcPs
+ appTypeE expr typ = inheritLoc expr $
++#if __GLASGOW_HASKELL__ >= 906
++    HsAppType noExtField expr noHsTok (HsWC defExt typ)
++#else
+     HsAppType
+ #if __GLASGOW_HASKELL__ >= 902
+       (toSrcSpan expr)
+@@ -322,6 +371,7 @@
+ #endif
+       expr
+       (HsWC defExt typ)
++#endif
+ 
+ -- | Equivalent of 'Language.Haskell.TH.Lib.tupE'
+ tupE :: NonEmpty (LHsExpr GhcPs) -> LHsExpr GhcPs
+@@ -353,18 +403,30 @@
+ parensT = noLocA . HsParTy defExt
+ 
+ -- | Equivalent of 'Language.Haskell.TH.Lib.litT'
++#if __GLASGOW_HASKELL__ >= 906
++litT :: HsTyLit GhcPs -> LHsType GhcPs
++#else
+ litT :: HsTyLit -> LHsType GhcPs
++#endif
+ litT = noLocA . HsTyLit defExt
+ 
+ -- | Equivalent of 'Language.Haskell.TH.Lib.varT'
+ varT :: HasCallStack => LRdrName -> LHsType GhcPs
+ varT name
++#if __GLASGOW_HASKELL__ >= 908
++  | isTypeVar name = inheritLoc name (HsTyVar defExt NotPromoted name)
++#else
+   | isTypeVar name = inheritLoc name (HsTyVar defExt NotPromoted (reLocA name))
++#endif
+   | otherwise      = error "varT: incorrect name type"
+ 
+ -- | Inverse to 'varT'
+ viewVarT :: LHsType GhcPs -> Maybe LRdrName
++#if __GLASGOW_HASKELL__ >= 908
++viewVarT (L _ (HsTyVar _ _ name)) | isTypeVar name = Just name
++#else
+ viewVarT (L _ (HsTyVar _ _ (reLoc -> name))) | isTypeVar name = Just name
++#endif
+ viewVarT _otherwise = Nothing
+ 
+ pattern VarT :: HasCallStack => () => LRdrName -> LHsType GhcPs
+@@ -375,12 +437,20 @@
+ -- | Equivalent of 'Language.Haskell.TH.Lib.conT'
+ conT :: HasCallStack => LRdrName -> LHsType GhcPs
+ conT name
++#if __GLASGOW_HASKELL__ >= 908
++  | isTypeCon name = inheritLoc name (HsTyVar defExt NotPromoted name)
++#else
+   | isTypeCon name = inheritLoc name (HsTyVar defExt NotPromoted (reLocA name))
++#endif
+   | otherwise      = error "varT: incorrect name type"
+ 
+ -- | Inverse to 'conT'
+ viewConT :: LHsType GhcPs -> Maybe LRdrName
++#if __GLASGOW_HASKELL__ >= 908
++viewConT (L _ (HsTyVar _ _ name)) | isTypeCon name = Just name
++#else
+ viewConT (L _ (HsTyVar _ _ (reLoc -> name))) | isTypeCon name = Just name
++#endif
+ viewConT _otherwise = Nothing
+ 
+ pattern ConT :: HasCallStack => () => LRdrName -> LHsType GhcPs
+@@ -429,7 +499,11 @@
+ 
+ -- | Equivalent of 'Language.Haskell.TH.Lib.varP'
+ varP :: LRdrName -> LPat GhcPs
++#if __GLASGOW_HASKELL__ >= 908
++varP name = inheritLoc name (VarPat defExt name)
++#else
+ varP name = inheritLoc name (VarPat defExt (reLocA name))
++#endif
+ 
+ -- | Equivalent of 'Language.Haskell.TH.Lib.conP'
+ conP :: LRdrName -> [LPat GhcPs] -> LPat GhcPs
+@@ -503,7 +577,11 @@
+          , con_mb_cxt = Nothing
+          , con_args   = RecCon (L _ fields)
+          }
++#if __GLASGOW_HASKELL__ >= 908
++    ) = (conName ,) <$> mapM viewRecField fields
++#else
+     ) = (reLoc conName ,) <$> mapM viewRecField fields
++#endif
+   where
+     viewRecField :: LConDeclField GhcPs -> Maybe (LRdrName, LHsType GhcPs)
+     viewRecField
+@@ -516,7 +594,11 @@
+     viewRecField _otherwise = Nothing
+ 
+     viewFieldOcc :: FieldOcc GhcPs -> LRdrName
++#if __GLASGOW_HASKELL__ >= 908
++    viewFieldOcc (FieldOcc _ name) = name
++#else
+     viewFieldOcc (FieldOcc _ (reLoc -> name)) = name
++#endif
+ #if __GLASGOW_HASKELL__ < 900
+     viewFieldOcc _ = panic "viewFieldOcc"
+ #endif
+@@ -537,7 +619,11 @@
+   -> LConDecl GhcPs
+ forallRecC vars ctxt conName args = inheritLoc conName $ ConDeclH98 {
+       con_ext    = defExt
++#if __GLASGOW_HASKELL__ >= 908
++    , con_name   = conName
++#else
+     , con_name   = reLocA conName
++#endif
+     , con_forall = inheritLoc conName True
+     , con_ex_tvs = map (setDefaultSpecificity . mkBndr) vars
+     , con_mb_cxt = Just (inheritLoc conName ctxt)
+@@ -551,7 +637,11 @@
+     mkRecField :: LRdrName -> LHsType GhcPs -> LConDeclField GhcPs
+     mkRecField name ty = inheritLoc name $ ConDeclField {
+           cd_fld_ext   = defExt
++#if __GLASGOW_HASKELL__ >= 908
++        , cd_fld_names = [inheritLoc name $ mkFieldOcc name]
++#else
+         , cd_fld_names = [inheritLoc name $ mkFieldOcc $ reLocA name]
++#endif
+         , cd_fld_type  = ty
+         , cd_fld_doc   = Nothing
+         }
+@@ -580,7 +670,11 @@
+ sigD name ty = inheritLoc name $ SigD defExt sig
+   where
+     sig :: Sig GhcPs
++#if __GLASGOW_HASKELL__ >= 908
++    sig = TypeSig defExt [name] $ HsWC defExt (implicitBndrs ty)
++#else
+     sig = TypeSig defExt [reLocA name] $ HsWC defExt (implicitBndrs ty)
++#endif
+ 
+ -- | Equivalent of 'Language.Haskell.TH.Lib.valD'
+ --
+@@ -599,12 +693,18 @@
+ dataD typeName tyVars cons derivs = inheritLoc typeName $
+     TyClD defExt $ DataDecl {
+         tcdDExt     = defExt
++#if __GLASGOW_HASKELL__ >= 908
++      , tcdLName    = typeName
++#else
+       , tcdLName    = reLocA typeName
++#endif
+       , tcdTyVars   = mkHsQTvs tyVars
+       , tcdFixity   = Prefix
+       , tcdDataDefn = HsDataDefn {
+             dd_ext     = defExt
++#if __GLASGOW_HASKELL__ < 906
+           , dd_ND      = DataType
++#endif
+ #if __GLASGOW_HASKELL__ >= 902
+           , dd_ctxt    = Nothing
+ #else
+@@ -612,7 +712,11 @@
+ #endif
+           , dd_cType   = Nothing
+           , dd_kindSig = Nothing
++#if __GLASGOW_HASKELL__ >= 906
++          , dd_cons    = DataTypeCons False cons
++#else
+           , dd_cons    = cons
++#endif
+           , dd_derivs  = inheritLoc typeName derivs
+           }
+       }
+@@ -635,15 +739,25 @@
+            , tcdTyVars   = HsQTvs {hsq_explicit = tyVars}
+            , tcdFixity   = Prefix
+            , tcdDataDefn = HsDataDefn {
++#if __GLASGOW_HASKELL__ < 906
+                    dd_ND      = DataType
++#endif
+ #if __GLASGOW_HASKELL__ >= 902
++#if __GLASGOW_HASKELL__ < 906
+                  , dd_ctxt    = Nothing
+ #else
++                   dd_ctxt    = Nothing
++#endif
++#else
+                  , dd_ctxt    = L _ []
+ #endif
+                  , dd_cType   = Nothing
+                  , dd_kindSig = Nothing
++#if __GLASGOW_HASKELL__ >= 906
++                 , dd_cons    = DataTypeCons False cons
++#else
+                  , dd_cons    = cons
++#endif
+ #if __GLASGOW_HASKELL__ >= 902
+                  , dd_derivs  = derivs
+ #else
+@@ -652,7 +766,11 @@
+                  }
+            }
+        )
++#if __GLASGOW_HASKELL__ >= 908
++    ) = Just (typeName, tyVars, cons, derivs)
++#else
+     ) = Just (reLoc typeName, tyVars, cons, derivs)
++#endif
+ viewDataD _otherwise = Nothing
+ 
+ pattern DataD ::
+@@ -746,12 +864,19 @@
+ classD = \ctx name clsVars sigs -> inheritLoc name $
+     TyClD defExt $ ClassDecl {
+         tcdCExt   = defExt
++#if __GLASGOW_HASKELL__ >= 906 && __GLASGOW_HASKELL__ < 910
++      , tcdLayout = NoLayoutInfo
++#endif
+ #if __GLASGOW_HASKELL__ >= 902
+       , tcdCtxt   = Just (inheritLoc name ctx)
+ #else
+       , tcdCtxt   = inheritLoc name ctx
+ #endif
++#if __GLASGOW_HASKELL__ >= 908
++      , tcdLName  = name
++#else
+       , tcdLName  = reLocA name
++#endif
+       , tcdTyVars = mkHsQTvs clsVars
+       , tcdFixity = Prefix
+       , tcdFDs    = []
+@@ -764,7 +889,11 @@
+   where
+     classOpSig :: LRdrName -> LHsType GhcPs -> LSig GhcPs
+     classOpSig name ty = inheritLoc name $
++#if __GLASGOW_HASKELL__ >= 908
++        ClassOpSig defExt False [name] (implicitBndrs ty)
++#else
+         ClassOpSig defExt False [reLocA name] (implicitBndrs ty)
++#endif
+ 
+ -- | Approximate equivalent of 'Language.Haskell.TH.Lib.tySynEqn'
+ tySynEqn ::
+@@ -780,7 +909,11 @@
+       $ implicitBndrs $
+ #endif
+         FamEqn defExt
++#if __GLASGOW_HASKELL__ >= 908
++               name
++#else
+                (reLocA name)
++#endif
+ #if __GLASGOW_HASKELL__ >= 902
+                (HsOuterImplicit defExt)
+ #else
+@@ -806,11 +939,19 @@
+ 
+ -- | Equivalent of 'Language.Haskell.TH.Lib.typeAnnotation'
+ typeAnnotation :: LRdrName -> AnnProvenancePs
++#if __GLASGOW_HASKELL__ >= 908
++typeAnnotation name = TypeAnnProvenance name
++#else
+ typeAnnotation name = TypeAnnProvenance (reLocA name)
++#endif
+ 
+ -- | Inverse to 'typeAnnotation'
+ viewTypeAnnotation :: AnnProvenancePs -> Maybe LRdrName
++#if __GLASGOW_HASKELL__ >= 908
++viewTypeAnnotation (TypeAnnProvenance name) = Just name
++#else
+ viewTypeAnnotation (TypeAnnProvenance name) = Just (reLoc name)
++#endif
+ viewTypeAnnotation _otherwise               = Nothing
+ 
+ pattern TypeAnnotation :: LRdrName -> AnnProvenancePs
+@@ -821,14 +962,22 @@
+ -- | Equivalent of 'Language.Haskell.TH.Lib.pragAnnD'
+ pragAnnD :: AnnProvenancePs -> LHsExpr GhcPs -> AnnDecl GhcPs
+ pragAnnD prov value =
++#if __GLASGOW_HASKELL__ >= 906
++    HsAnnotation defExt prov value
++#else
+     HsAnnotation
+       defExt
+       NoSourceText
+       prov
+       value
++#endif
+ 
+ viewPragAnnD :: AnnDecl GhcPs -> (AnnProvenancePs, LHsExpr GhcPs)
++#if __GLASGOW_HASKELL__ >= 906
++viewPragAnnD (HsAnnotation _ prov value) = (prov, value)
++#else
+ viewPragAnnD (HsAnnotation _ _ prov value) = (prov, value)
++#endif
+ #if __GLASGOW_HASKELL__ < 900
+ viewPragAnnD _ = panic "viewPragAnnD"
+ #endif
+@@ -871,7 +1020,11 @@
+     match :: LMatch GhcPs (LHsExpr GhcPs)
+     match = inheritLoc fnName $
+         Match defExt
++#if __GLASGOW_HASKELL__ >= 908
++              (FunRhs fnName Prefix NoSrcStrict)
++#else
+               (FunRhs (reLocA fnName) Prefix NoSrcStrict)
++#endif
+               []
+               grhs
+ 
+@@ -881,5 +1034,3 @@
+     GRHSs defExt
+           [inheritLoc body $ GRHS defExt [] body]
+           (inheritLoc body $ EmptyLocalBinds defExt)
+-
+-
+diff --git a/src/Data/Record/Internal/Plugin/CodeGen.hs b/src/Data/Record/Internal/Plugin/CodeGen.hs
+--- a/src/Data/Record/Internal/Plugin/CodeGen.hs
++++ b/src/Data/Record/Internal/Plugin/CodeGen.hs
+@@ -204,7 +204,7 @@
+                     )
+                   , ( wildP
+                        -- VarE unq_error `appE` stringE matchErr
+-                    ,  VarE (noLoc $ mkRdrQual (mkModuleName "Prelude") (mkVarOcc "error")) `appE` stringE matchErr
++                    ,  VarE (withoutLoc $ mkRdrQual (mkModuleName "Prelude") (mkVarOcc "error")) `appE` stringE matchErr
+                     )
+                   ]
+           ]
+diff --git a/src/Data/Record/Internal/Plugin/Names.hs b/src/Data/Record/Internal/Plugin/Names.hs
+--- a/src/Data/Record/Internal/Plugin/Names.hs
++++ b/src/Data/Record/Internal/Plugin/Names.hs
+@@ -1,3 +1,4 @@
++{-# LANGUAGE CPP               #-}
+ {-# LANGUAGE OverloadedStrings #-}
+ {-# LANGUAGE RecordWildCards   #-}
+ 
+@@ -171,7 +172,11 @@
+ 
+   where
+    exact :: Name -> LRdrName
++#if __GLASGOW_HASKELL__ >= 908
++   exact = noLocA . Exact
++#else
+    exact = noLoc . Exact
++#endif
+ 
+    runtime, recordHasField, ghcGenerics, largeGenerics :: ModuleName
+    runtime        = mkModuleName "Data.Record.Plugin.Runtime"
+@@ -207,5 +212,10 @@
+     }
+   where
+     var, tc :: String -> LRdrName
++#if __GLASGOW_HASKELL__ >= 908
++    var x = noLocA $ mkRdrUnqual $ mkVarOcc x
++    tc  x = noLocA $ mkRdrUnqual $ mkTcOcc  x
++#else
+     var x = noLoc $ mkRdrUnqual $ mkVarOcc x
+     tc  x = noLoc $ mkRdrUnqual $ mkTcOcc  x
++#endif
+diff --git a/src/Data/Record/Internal/Plugin/Options.hs b/src/Data/Record/Internal/Plugin/Options.hs
+--- a/src/Data/Record/Internal/Plugin/Options.hs
++++ b/src/Data/Record/Internal/Plugin/Options.hs
+@@ -1,3 +1,4 @@
++{-# LANGUAGE CPP                   #-}
+ {-# LANGUAGE DataKinds             #-}
+ {-# LANGUAGE DeriveDataTypeable    #-}
+ {-# LANGUAGE DerivingStrategies    #-}
+@@ -67,7 +68,11 @@
+ -- | Extract all 'LargeRecordOptions' in a module
+ --
+ -- Additionally returns the location of the ANN pragma.
++#if __GLASGOW_HASKELL__ >= 906
++getLargeRecordOptions :: HsModule GhcPs -> Map String [(SrcSpan, LargeRecordOptions)]
++#else
+ getLargeRecordOptions :: HsModule -> Map String [(SrcSpan, LargeRecordOptions)]
++#endif
+ getLargeRecordOptions =
+       Map.fromListWith (++)
+     . map (second (:[]))
+@@ -77,7 +82,7 @@
+ viewAnnotation :: AnnDecl GhcPs -> Maybe (String, (SrcSpan, LargeRecordOptions))
+ viewAnnotation = \case
+     PragAnnD (TypeAnnotation tyName) (intOptions -> Just options) ->
+-      Just (nameBase tyName, (getLoc tyName, options))
++      Just (nameBase tyName, (toSrcSpan tyName, options))
+     _otherwise ->
+       Nothing
+ 
+diff --git a/src/Data/Record/Plugin.hs b/src/Data/Record/Plugin.hs
+--- a/src/Data/Record/Plugin.hs
++++ b/src/Data/Record/Plugin.hs
+@@ -39,7 +39,9 @@
+   , plugin
+   ) where
+ 
++import Control.Monad (unless, when)
+ import Control.Monad.Except
++import Control.Monad.Trans.Class (lift)
+ import Control.Monad.Trans.Writer.CPS
+ import Data.List (intersperse)
+ import Data.Map.Strict (Map)
+@@ -47,6 +49,11 @@
+ import Data.Traversable (for)
+ import Language.Haskell.TH (Extension(..))
+ 
++#if __GLASGOW_HASKELL__ >= 908
++import GHC.Driver.Config.Diagnostic (initPrintConfig)
++import GHC.Types.Error (mkSimpleUnknownDiagnostic)
++#endif
++
+ import qualified Data.Map.Strict as Map
+ import qualified Data.Set        as Set
+ 
+@@ -213,6 +220,12 @@
+ #if __GLASGOW_HASKELL__ == 902
+     throwOneError $
+       mkErr l neverQualify (mkDecorated [errMsg])
++#elif __GLASGOW_HASKELL__ >= 908
++    throwOneError $
++      mkErrorMsgEnvelope
++        l
++        neverQualify
++        (GhcUnknownMessage $ mkSimpleUnknownDiagnostic $ mkPlainError [] errMsg)
+ #elif __GLASGOW_HASKELL__ >= 904
+     throwOneError $
+       mkErrorMsgEnvelope
+@@ -232,6 +245,15 @@
+     logger <- getLogger
+     liftIO $ printOrThrowWarnings logger dynFlags . bag $
+       mkWarnMsg l neverQualify errMsg
++#elif __GLASGOW_HASKELL__ >= 908
++    logger <- getLogger
++    let printConfig = initPrintConfig dynFlags
++    liftIO $ printOrThrowDiagnostics logger printConfig (initDiagOpts dynFlags) . mkMessages . bag $
++      mkMsgEnvelope
++        (initDiagOpts dynFlags)
++        l
++        neverQualify
++        (GhcUnknownMessage $ mkSimpleUnknownDiagnostic $ mkPlainDiagnostic WarningWithoutFlag [] errMsg)
+ #elif __GLASGOW_HASKELL__ >= 904
+     logger <- getLogger
+     liftIO $ printOrThrowDiagnostics logger (initDiagOpts dynFlags) . mkMessages . bag $

--- a/paymentFlow/src/PaymentFlow/Patterns.hs
+++ b/paymentFlow/src/PaymentFlow/Patterns.hs
@@ -14,10 +14,18 @@ import TcEvidence
 import TyCoRep
 #endif
 
+#if __GLASGOW_HASKELL__ >= 904
+-- GHC 9.4 removed the `HsConLikeOut` constructor; the typechecked conlike is now
+-- carried by the `ConLikeTc` extension constructor.
+import GHC.Hs.Expr (XXExprGhcTc(..))
+import GHC.Core.ConLike (ConLike)
+import GHC.Types.Var (Var)
+#endif
+
 #if __GLASGOW_HASKELL__ >= 900
 
 pattern PatHsWrap :: HsWrapper -> HsExpr GhcTc -> HsExpr GhcTc
-pattern PatHsWrap wrapper expr <- (XExpr (WrapExpr (HsWrap wrapper expr))) 
+pattern PatHsWrap wrapper expr <- (XExpr (WrapExpr (HsWrap wrapper expr)))
 
 pattern PatHsExpansion :: HsExpr GhcRn -> HsExpr GhcTc -> HsExpr GhcTc
 pattern PatHsExpansion orig expanded <- (XExpr (ExpansionExpr (HsExpanded orig expanded)))
@@ -27,4 +35,25 @@ pattern PatHsExpansion orig expanded <- (XExpr (ExpansionExpr (HsExpanded orig e
 pattern PatHsWrap :: HsWrapper -> HsExpr (GhcPass p) -> HsExpr (GhcPass p)
 pattern PatHsWrap wrapper expr <- (HsWrap _ wrapper expr)
 
+#endif
+
+-- `HsPar`/`HsAppType` gained token fields in GHC 9.4; expose version-stable
+-- patterns that bind only the meaningful sub-terms so call sites stay identical.
+#if __GLASGOW_HASKELL__ >= 904
+pattern PatHsPar :: LHsExpr (GhcPass p) -> HsExpr (GhcPass p)
+pattern PatHsPar e <- HsPar _ _ e _
+
+pattern PatHsAppType :: LHsExpr (GhcPass p) -> LHsWcType (NoGhcTc (GhcPass p)) -> HsExpr (GhcPass p)
+pattern PatHsAppType e t <- HsAppType _ e _ t
+
+-- Restores the `HsConLikeOut ext con` shape removed in GHC 9.4; the first field
+-- binds the (unused) coercion type variables.
+pattern HsConLikeOut :: [Var] -> ConLike -> HsExpr GhcTc
+pattern HsConLikeOut tvs con <- XExpr (ConLikeTc con tvs _)
+#else
+pattern PatHsPar :: LHsExpr (GhcPass p) -> HsExpr (GhcPass p)
+pattern PatHsPar e <- HsPar _ e
+
+pattern PatHsAppType :: LHsExpr (GhcPass p) -> LHsWcType (NoGhcTc (GhcPass p)) -> HsExpr (GhcPass p)
+pattern PatHsAppType e t <- HsAppType _ e t
 #endif

--- a/paymentFlow/src/PaymentFlow/Plugin.hs
+++ b/paymentFlow/src/PaymentFlow/Plugin.hs
@@ -102,10 +102,25 @@ paymentFlow opts modSummary tcEnv = do
     else do
       errors <- concat <$> mapM (checkBind ruleList) (bagToList binds)
 
-      let sortedErrors = sortBy (leftmost_smallest `on` srcSpan) errors
-          groupedErrors = groupBy (\a b -> srcSpan a == srcSpan b) sortedErrors
+      -- A violation's own span is unusable when GHC marks the expression as
+      -- compiler-generated: on GHC >= 9.4 a record-dot access `r.f` elaborates
+      -- to `getField @"f" r` carrying noSrcSpan. Fall back to the enclosing
+      -- binding so the error stays locatable instead of printing `<generated>`.
+      let reportSpanOf r = if isGoodSrcSpan (srcSpan r) then srcSpan r else coreFnSpan r
+          -- Key the grouping on the enclosing function and the rule as well as
+          -- the span. Keying on the span alone made every unlocatable violation
+          -- in a module collapse into ONE group, where `listToMaybe` dropped all
+          -- but one of them and a single whitelisted reader suppressed the rest
+          -- (including violations in unrelated functions, under unrelated rules).
+          groupKeyOf r = (coreFnName r, type_name (rule r), blocked_field (rule r))
+          sortedErrors =
+            sortBy (\a b -> (leftmost_smallest (reportSpanOf a) (reportSpanOf b))
+                              <> compare (groupKeyOf a) (groupKeyOf b)) errors
+          groupedErrors =
+            groupBy (\a b -> reportSpanOf a == reportSpanOf b
+                               && groupKeyOf a == groupKeyOf b) sortedErrors
           childFnFilterLogic srcGrpErrArr = do
-            let srcSpn = maybe Nothing (\value -> Just $ srcSpan value) (listToMaybe srcGrpErrArr)
+            let srcSpn = reportSpanOf <$> listToMaybe srcGrpErrArr
                 srcSpanLine = getSrcSpanLine srcSpn
                 shouldThroughError = (any (\(VoilationRuleResult{..}) -> do
                         let whitelistedRules = field_access_whitelisted_fns rule
@@ -115,16 +130,16 @@ paymentFlow opts modSummary tcEnv = do
               else listToMaybe srcGrpErrArr
           filteredErrors = (\srcGrpErrArr -> childFnFilterLogic srcGrpErrArr) <$> groupedErrors
 #if __GLASGOW_HASKELL__ >= 904
-      mapM_ (\ (VoilationRuleResult {..}) ->  addErrAt srcSpan $ mkPfDiag $ OP.text $ field_rule_fixes rule ) (catMaybes filteredErrors)
+      mapM_ (\ r ->  addErrAt (reportSpanOf r) $ mkPfDiag $ OP.text $ field_rule_fixes (rule r) ) (catMaybes filteredErrors)
 #else
-      mapM_ (\ (VoilationRuleResult {..}) ->  addErrAt srcSpan $ OP.text $ field_rule_fixes rule ) (catMaybes filteredErrors)
+      mapM_ (\ r ->  addErrAt (reportSpanOf r) $ OP.text $ field_rule_fixes (rule r) ) (catMaybes filteredErrors)
 #endif
   return tcEnv
 
 checkBind :: [Rule] ->  LHsBindLR GhcTc GhcTc -> TcM [VoilationRuleResult]
-checkBind rule (L _ (FunBind{..} )) = do
+checkBind rule lbind@(L _ (FunBind{..} )) = do
   let funMatches = unLoc $ mg_alts fun_matches
-  concat <$> mapM (checkMatch rule (getVarNameFromIDP $ unLoc fun_id)) funMatches
+  concat <$> mapM (checkMatch rule (getVarNameFromIDP $ unLoc fun_id, getLoc2 lbind)) funMatches
 #if __GLASGOW_HASKELL__ >= 904
 checkBind rule (L _ (XHsBindsLR (AbsBinds {abs_binds = binds}))) =
   concat <$> (mapM (checkBind rule) $ bagToList binds)
@@ -134,24 +149,27 @@ checkBind rule (L _ (AbsBinds {abs_binds = binds})) =
 #endif
 checkBind _ _ = pure []
 
-checkMatch :: [Rule] -> String ->  LMatch GhcTc (LHsExpr GhcTc) -> TcM [VoilationRuleResult]
+-- The (String, SrcSpan) pair is the enclosing binding's name and span; the span
+-- is carried so a violation with no real source span can still be reported
+-- against the function it occurs in. See 'coreFnSpan'.
+checkMatch :: [Rule] -> (String, SrcSpan) ->  LMatch GhcTc (LHsExpr GhcTc) -> TcM [VoilationRuleResult]
 checkMatch rule coreFn (L _ (Match _ _ _ grhss)) = do
   let whereBinds = (grhssLocalBinds grhss) ^? biplateRef :: [LHsExpr GhcTc]
       nonWhereBinds = (grhssGRHSs grhss) ^? biplateRef :: [LHsExpr GhcTc]
   loopOverExprInArgsPerFnName (nonWhereBinds <> whereBinds) rule coreFn
 checkMatch _ _ _ = pure []
 
-loopOverExprInArgsPerFnName :: [LHsExpr GhcTc] -> [Rule] -> String -> TcM [VoilationRuleResult]
+loopOverExprInArgsPerFnName :: [LHsExpr GhcTc] -> [Rule] -> (String, SrcSpan) -> TcM [VoilationRuleResult]
 loopOverExprInArgsPerFnName exprs rules coreFn = do
   let fnArgTuple = catMaybes (getFnNameWithAllArgs <$> exprs)
   nub <$> concat <$> mapM (lookOverExpr rules coreFn) fnArgTuple
 loopOverExprInArgsPerFnName _ _ _ = pure []
 
-lookOverExpr :: [Rule] -> String ->  (Located Var, [LHsExpr GhcTc]) -> TcM [VoilationRuleResult]
-lookOverExpr rules funId (fnName, args) = do
+lookOverExpr :: [Rule] -> (String, SrcSpan) ->  (Located Var, [LHsExpr GhcTc]) -> TcM [VoilationRuleResult]
+lookOverExpr rules (funId, funSpan) (fnName, args) = do
   let updatedArgs = args ^? biplateRef :: [LHsExpr GhcTc]
   tupleResponse <- catMaybes <$> sequence (checkExpr rules <$> updatedArgs)
-  pure $ (\(x, y) -> VoilationRuleResult { fnName = getVarName fnName, srcSpan = x, rule = y, coreFnName = funId }) <$> tupleResponse
+  pure $ (\(x, y) -> VoilationRuleResult { fnName = getVarName fnName, srcSpan = x, rule = y, coreFnName = funId, coreFnSpan = funSpan }) <$> tupleResponse
 
 checkExpr :: [Rule]-> LHsExpr GhcTc -> TcM (Maybe (SrcSpan, Rule))
 checkExpr rules expr =

--- a/paymentFlow/src/PaymentFlow/Plugin.hs
+++ b/paymentFlow/src/PaymentFlow/Plugin.hs
@@ -38,6 +38,11 @@ import GHC.Tc.Utils.Monad
 import GHC.Tc.Utils.TcType
 import GHC.Types.Annotations
 import qualified GHC.Utils.Outputable as OP
+#if __GLASGOW_HASKELL__ >= 904
+import GHC.Tc.Errors.Types (TcRnMessage, mkTcRnUnknownMessage)
+import GHC.Types.Error (mkPlainError, noHints)
+import GHC.Hs.Type (FieldOcc(..))
+#endif
 #else
 import Bag
 import ConLike
@@ -52,8 +57,18 @@ import TcType
 import TyCoRep
 #endif
 
+#if __GLASGOW_HASKELL__ >= 904
+-- GHC 9.4 changed the error API from raw `SDoc` to structured `TcRnMessage`;
+-- wrap the same rendered text so the emitted error content is unchanged.
+mkPfDiag :: OP.SDoc -> TcRnMessage
+mkPfDiag = mkTcRnUnknownMessage . mkPlainError noHints
+
+mkInvalidYamlFileErr :: String -> TcRnMessage
+mkInvalidYamlFileErr err = mkPfDiag (OP.text err)
+#else
 mkInvalidYamlFileErr :: String -> OP.SDoc
 mkInvalidYamlFileErr err = OP.text err
+#endif
 
 parseYAMLFile :: (FromJSON a) => FilePath -> IO (Either ParseException a)
 parseYAMLFile file = decodeFileEither file
@@ -99,15 +114,24 @@ paymentFlow opts modSummary tcEnv = do
               then Nothing
               else listToMaybe srcGrpErrArr
           filteredErrors = (\srcGrpErrArr -> childFnFilterLogic srcGrpErrArr) <$> groupedErrors
+#if __GLASGOW_HASKELL__ >= 904
+      mapM_ (\ (VoilationRuleResult {..}) ->  addErrAt srcSpan $ mkPfDiag $ OP.text $ field_rule_fixes rule ) (catMaybes filteredErrors)
+#else
       mapM_ (\ (VoilationRuleResult {..}) ->  addErrAt srcSpan $ OP.text $ field_rule_fixes rule ) (catMaybes filteredErrors)
+#endif
   return tcEnv
 
 checkBind :: [Rule] ->  LHsBindLR GhcTc GhcTc -> TcM [VoilationRuleResult]
 checkBind rule (L _ (FunBind{..} )) = do
   let funMatches = unLoc $ mg_alts fun_matches
   concat <$> mapM (checkMatch rule (getVarNameFromIDP $ unLoc fun_id)) funMatches
+#if __GLASGOW_HASKELL__ >= 904
+checkBind rule (L _ (XHsBindsLR (AbsBinds {abs_binds = binds}))) =
+  concat <$> (mapM (checkBind rule) $ bagToList binds)
+#else
 checkBind rule (L _ (AbsBinds {abs_binds = binds})) =
   concat <$> (mapM (checkBind rule) $ bagToList binds)
+#endif
 checkBind _ _ = pure []
 
 checkMatch :: [Rule] -> String ->  LMatch GhcTc (LHsExpr GhcTc) -> TcM [VoilationRuleResult]
@@ -132,7 +156,7 @@ lookOverExpr rules funId (fnName, args) = do
 checkExpr :: [Rule]-> LHsExpr GhcTc -> TcM (Maybe (SrcSpan, Rule))
 checkExpr rules expr =
   case expr of
-    L _ (HsPar _ exp) -> checkExpr rules exp
+    L _ (PatHsPar exp) -> checkExpr rules exp
 
 #if __GLASGOW_HASKELL__ >= 900
     L loc (PatHsExpansion orig expanded) -> checkExpr rules (L loc expanded)
@@ -143,13 +167,17 @@ checkExpr rules expr =
         Nothing -> pure Nothing
         Just rule -> pure $ Just (loc1, rule)
 
-    L _ (HsApp _ (L _ (PatHsWrap _ (HsAppType _ _ (HsWC _ (L (SrcSpanAnn _ loc) (HsTyLit _ (HsStrTy _ fieldName)))) ))) (L _ (HsVar _ (L _ var)))) -> do
+    L _ (HsApp _ (L _ (PatHsWrap _ (PatHsAppType _ (HsWC _ (L (SrcSpanAnn _ loc) (HsTyLit _ (HsStrTy _ fieldName)))) ))) (L _ (HsVar _ (L _ var)))) -> do
       let voilationSatisfiedRules = verifyAndGetRuleVoilatedFnInfoWithExprAndFieldAsName (showS fieldName) var rules
       case listToMaybe voilationSatisfiedRules of
         Nothing -> pure Nothing
         Just rule -> pure $ Just (loc, rule)
 
+#if __GLASGOW_HASKELL__ >= 904
+    L (SrcSpanAnn _ loc) (HsApp _ (L _ (HsRecSel _ (FieldOcc name _))) (L _ (HsVar _ (L _ var)))) -> do
+#else
     L (SrcSpanAnn _ loc) (HsApp _ (L _ (HsRecFld _ (Unambiguous name _))) (L _ (HsVar _ (L _ var)))) -> do
+#endif
       let voilationSatisfiedRules = verifyAndGetRuleVoilatedFnInfoWithExprAndFieldAsName (showS name) var rules
       case listToMaybe voilationSatisfiedRules of
         Nothing -> pure Nothing
@@ -258,11 +286,16 @@ verifyAndGetRuleVoilatedFnInfoWithRightExprAsType var rules = do
 
 getTyConInStringFormat :: Type -> Maybe [String]
 getTyConInStringFormat vType =
-#if __GLASGOW_HASKELL__ >= 900
+#if __GLASGOW_HASKELL__ >= 906
+  -- GHC 9.6 added the FunTyFlag to splitFunTy_maybe's result tuple.
+  case splitFunTy_maybe vType of
+    Just (_, _, tyCon, _) -> Just [showS tyCon]
+    Nothing -> Nothing
+#elif __GLASGOW_HASKELL__ >= 900
   case splitFunTy_maybe vType of
     Just (_, tyCon, _) -> Just [showS tyCon]
-    Nothing -> Nothing 
-#else 
+    Nothing -> Nothing
+#else
   case splitFunTy_maybe vType of
     Just (tyCon, _) -> Just [showS tyCon]
     Nothing -> Nothing
@@ -288,7 +321,7 @@ getLocated ap = L (getLocA ap) (unLoc ap)
 getFnNameWithAllArgs :: LHsExpr GhcTc -> Maybe (Located Var, [LHsExpr GhcTc])
 getFnNameWithAllArgs (L _ (HsVar _ v))                      = Just (getLocated v, [])
 getFnNameWithAllArgs (L _ (HsConLikeOut _ cl))              = (\clId -> (noExprLoc clId, [])) <$> conLikeWrapId cl
-getFnNameWithAllArgs (L _ (HsAppType _ expr _))             = getFnNameWithAllArgs expr
+getFnNameWithAllArgs (L _ (PatHsAppType expr _))            = getFnNameWithAllArgs expr
 getFnNameWithAllArgs (L _ (HsApp _ (L _ (HsVar _ v)) funr)) = Just (getLocated v, [funr])
 getFnNameWithAllArgs (L _ (HsApp _ funl funr))              = do
   let res = getFnNameWithAllArgs funl

--- a/paymentFlow/src/PaymentFlow/Types.hs
+++ b/paymentFlow/src/PaymentFlow/Types.hs
@@ -66,4 +66,9 @@ data VoilationRuleResult = VoilationRuleResult
   , srcSpan :: SrcSpan
   , rule    :: Rule
   , coreFnName :: String
+  -- | Span of the binding the violation was found in. Used as a fallback when
+  -- 'srcSpan' is not a real source span: on GHC >= 9.4 a record-dot access
+  -- @r.f@ elaborates to a @getField \@"f" r@ carrying noSrcSpan, so without
+  -- this every dot access in a module reports at @<generated>@.
+  , coreFnSpan :: SrcSpan
   } deriving (Show, Eq)

--- a/paymentFlow/test/Main.hs
+++ b/paymentFlow/test/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DisambiguateRecordFields #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveAnyClass #-}
@@ -18,6 +19,10 @@ import Data.Aeson as A
 import Types as PT
 import Types1 as PT1
 import Control.Lens
+-- The pinned record-dot-preprocessor rev no longer auto-injects these;
+-- RDP-generated code references them qualified.
+import qualified GHC.Records
+import qualified GHC.Records.Extra
 
 main :: IO ()
 main = putStrLn "Test suite not yet implemented."

--- a/paymentFlow/test/Types.hs
+++ b/paymentFlow/test/Types.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_GHC -fplugin=RecordDotPreprocessor #-}
-{-# LANGUAGE FlexibleInstances, MultiParamTypeClasses, TypeFamilies, UndecidableInstances #-}
+{-# LANGUAGE DataKinds, FlexibleInstances, MultiParamTypeClasses, TypeFamilies, TypeOperators, UndecidableInstances #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Types where
@@ -7,6 +7,10 @@ module Types where
 import Data.Aeson
 import Data.Text
 import Control.Lens
+-- The pinned record-dot-preprocessor rev no longer auto-injects these;
+-- the generated HasField instances reference them qualified.
+import qualified GHC.Records
+import qualified GHC.Records.Extra
 
 data TxnDetail = TxnDetail
 

--- a/paymentFlow/test/Types1.hs
+++ b/paymentFlow/test/Types1.hs
@@ -3,11 +3,15 @@
 -- {-# LANGUAGE MultiParamTypeClasses #-}
 -- {-# LANGUAGE DataKinds #-}
 {-# OPTIONS_GHC -fplugin=RecordDotPreprocessor #-}
-{-# LANGUAGE FlexibleInstances, MultiParamTypeClasses, TypeFamilies, UndecidableInstances #-}
+{-# LANGUAGE DataKinds, FlexibleInstances, MultiParamTypeClasses, TypeFamilies, TypeOperators, UndecidableInstances #-}
 module Types1 where
   
 import Data.Aeson
 import Control.Lens
+-- The pinned record-dot-preprocessor rev no longer auto-injects these;
+-- the generated HasField instances reference them qualified.
+import qualified GHC.Records
+import qualified GHC.Records.Extra
 
 data SurchargeConfig = SurchargeConfig 
   {shouldAddSurchargeToRefund :: Bool,  showSurchargeBreakupScreen :: Maybe Bool}

--- a/sheriff/sheriff.cabal
+++ b/sheriff/sheriff.cabal
@@ -36,6 +36,11 @@ common common-options
                        StandaloneDeriving
                        TypeApplications
                        CPP
+  -- GHC 9.8 promotes `head`/`tail` to -Wx-partial; the plugin uses them on
+  -- lists it has already proven non-empty, so keep the existing behaviour.
+  if impl(ghc >= 9.8)
+    ghc-options:       -Wno-x-partial
+
 library
     import:              common-options
     exposed-modules:    

--- a/sheriff/src/Sheriff/Patterns.hs
+++ b/sheriff/src/Sheriff/Patterns.hs
@@ -14,15 +14,27 @@ import TcEvidence
 import TyCoRep
 #endif
 
+#if __GLASGOW_HASKELL__ >= 904
+-- GHC 9.4 removed the `HsConLikeOut` constructor of `HsExpr GhcTc`; the
+-- typechecked conlike is now carried by the `ConLikeTc` extension constructor.
+import GHC.Hs.Expr (XXExprGhcTc(..))
+import GHC.Core.ConLike (ConLike)
+import GHC.Types.Var (Var)
+#endif
+
 #if __GLASGOW_HASKELL__ >= 900
+#if __GLASGOW_HASKELL__ >= 906
+pattern PatFunTy :: FunTyFlag -> Type -> Type -> Type
+#else
 pattern PatFunTy :: AnonArgFlag -> Type -> Type -> Type
+#endif
 pattern PatFunTy anonArgFlag ty1 ty2 <- (FunTy anonArgFlag _ ty1 ty2)
 
 pattern PatHsIf :: LHsExpr (GhcPass p) -> LHsExpr (GhcPass p) -> LHsExpr (GhcPass p) -> HsExpr (GhcPass p)
 pattern PatHsIf pred thenCl elseCl <- (HsIf _ pred thenCl elseCl)
 
 pattern PatHsWrap :: HsWrapper -> HsExpr GhcTc -> HsExpr GhcTc
-pattern PatHsWrap wrapper expr = (XExpr (WrapExpr (HsWrap wrapper expr))) 
+pattern PatHsWrap wrapper expr = (XExpr (WrapExpr (HsWrap wrapper expr)))
 
 pattern PatHsExpansion :: HsExpr GhcRn -> HsExpr GhcTc -> HsExpr GhcTc
 pattern PatHsExpansion orig expanded <- (XExpr (ExpansionExpr (HsExpanded orig expanded)))
@@ -45,4 +57,28 @@ pattern PatExplicitList :: XExplicitList (GhcPass p) -> [LHsExpr (GhcPass p)] ->
 pattern PatExplicitList typ arg <- (ExplicitList typ _ arg) where
         PatExplicitList typ arg = (ExplicitList typ Nothing arg)
 
+#endif
+
+-- `HsPar` gained surrounding token fields in GHC 9.4; expose a version-stable
+-- pattern that binds only the inner expression so the call sites stay identical.
+#if __GLASGOW_HASKELL__ >= 904
+pattern PatHsPar :: LHsExpr (GhcPass p) -> HsExpr (GhcPass p)
+pattern PatHsPar e <- HsPar _ _ e _
+
+-- `HsAppType` gained an `@` token field in GHC 9.4; bind only the inner
+-- expression and the type argument so call sites stay version-stable.
+pattern PatHsAppType :: LHsExpr (GhcPass p) -> LHsWcType (NoGhcTc (GhcPass p)) -> HsExpr (GhcPass p)
+pattern PatHsAppType e t <- HsAppType _ e _ t
+
+-- Restores the `HsConLikeOut ext con` shape removed in GHC 9.4. The first field
+-- is bound to the (unused) coercion type variables so existing `HsConLikeOut _ cl`
+-- matches continue to work unchanged.
+pattern HsConLikeOut :: [Var] -> ConLike -> HsExpr GhcTc
+pattern HsConLikeOut tvs con <- XExpr (ConLikeTc con tvs _)
+#else
+pattern PatHsPar :: LHsExpr (GhcPass p) -> HsExpr (GhcPass p)
+pattern PatHsPar e <- HsPar _ e
+
+pattern PatHsAppType :: LHsExpr (GhcPass p) -> LHsWcType (NoGhcTc (GhcPass p)) -> HsExpr (GhcPass p)
+pattern PatHsAppType e t <- HsAppType _ e t
 #endif

--- a/sheriff/src/Sheriff/Plugin.hs
+++ b/sheriff/src/Sheriff/Plugin.hs
@@ -54,6 +54,11 @@ import GHC.Tc.Utils.Monad
 import GHC.Tc.Utils.TcType
 import GHC.Types.Annotations
 import qualified GHC.Utils.Outputable as OP
+#if __GLASGOW_HASKELL__ >= 904
+import GHC.Hs.Type (foExt)
+import GHC.Tc.Errors.Types (TcRnMessage, mkTcRnUnknownMessage)
+import GHC.Types.Error (mkPlainError, noHints)
+#endif
 #else
 import Bag
 import Class
@@ -244,7 +249,11 @@ checkInfiniteRecursion recurseForBinds rule (L _ ap@(FunBind{fun_id = funVar, fu
   let ?pluginOpts = ?pluginOpts {nameModuleMap = currNameModMap}
   errs <- mapM (checkAndVerifyAlt recurseForBinds rule funVar) (fmap unLoc . unLoc $ mg_alts matches)
   pure $ concat errs
+#if __GLASGOW_HASKELL__ >= 904
+checkInfiniteRecursion recurseForBinds rule (L _ (XHsBindsLR ap@(AbsBinds{abs_binds = binds, abs_exports = bindVars}))) = do
+#else
 checkInfiniteRecursion recurseForBinds rule (L _ ap@(AbsBinds{abs_binds = binds, abs_exports = bindVars})) = do
+#endif
   let mbVar = case bindVars of
                 x : _ -> Just $ (varName $ abe_poly x, varName $ abe_mono x)
                 _ -> Nothing
@@ -343,7 +352,11 @@ checkAndVerifyAlt recurseForBinds rule ap@(L loc fnVar) match = do
 
     checkAndGetExpr :: LHsExpr GhcTc -> [LHsExpr GhcTc]
     checkAndGetExpr (L loc expr) = case expr of
+#if __GLASGOW_HASKELL__ >= 904
+      HsLet _ _ _ _ inStmt -> checkAndGetExpr inStmt
+#else
       HsLet _ _ inStmt -> checkAndGetExpr inStmt
+#endif
       HsApp _ _ _ -> [L loc expr]
       HsVar _ _ -> [L loc expr]
       HsDo _ _ doStmts -> concatMap checkAndGetExpr $ foldr isLastStmt [] (traverseAst doStmts)
@@ -371,9 +384,17 @@ checkAndVerifyAlt recurseForBinds rule ap@(L loc fnVar) match = do
 
     checkAndGetMaybeLambdaCaseOrLambdaMG :: LHsExpr GhcTc -> Maybe (MatchGroup GhcTc (LHsExpr GhcTc))
     checkAndGetMaybeLambdaCaseOrLambdaMG (L loc expr) = case expr of
+#if __GLASGOW_HASKELL__ >= 904
+      (HsLamCase _ _ mg) -> Just mg -- LambdaCase
+#else
       (HsLamCase _ mg)   -> Just mg -- LambdaCase
+#endif
       (HsLam _ mg)       -> Just mg -- Lambda Function
+#if __GLASGOW_HASKELL__ >= 904
+      (HsLet _ _ _ _ inStmt) -> checkAndGetMaybeLambdaCaseOrLambdaMG inStmt
+#else
       (HsLet _ _ inStmt) -> checkAndGetMaybeLambdaCaseOrLambdaMG inStmt
+#endif
       PatHsWrap _ wrapExpr -> checkAndGetMaybeLambdaCaseOrLambdaMG (L loc wrapExpr)
       OpApp _ _ op rApp -> case showS op of
         "(.)" -> checkAndGetMaybeLambdaCaseOrLambdaMG rApp
@@ -404,7 +425,11 @@ loopOverModBinds _ (L _ ap@(PatBind{})) = do
 loopOverModBinds _ (L _ ap@(VarBind{})) = do 
   -- liftIO $ print "VarBinds" >> showOutputable ap
   pure []
+#if __GLASGOW_HASKELL__ >= 904
+loopOverModBinds rules (L _ (XHsBindsLR ap@(AbsBinds {abs_binds = binds}))) = do
+#else
 loopOverModBinds rules (L _ ap@(AbsBinds {abs_binds = binds})) = do
+#endif
   -- liftIO $ print "AbsBinds" >> showOutputable ap
   list <- mapM (loopOverModBinds rules) $ bagToList binds
   pure (concat list)
@@ -515,7 +540,11 @@ extractTableAndColumn fieldArg = do
     None     -> pure Nothing
     Selector -> do
       let modFieldArg arg = case arg of
+#if __GLASGOW_HASKELL__ >= 904
+                        (L _ (HsRecSel _ fldOcc))   -> showS $ foExt fldOcc
+#else
                         (L _ (HsRecFld _ fldOcc))   -> showS $ selectorAmbiguousFieldOcc fldOcc
+#endif
                         (L loc (PatHsWrap _ wExpr)) -> modFieldArg (L loc wExpr)
                         (L _ expr)                  -> showS expr
       case (splitOn ":" $ modFieldArg fieldArg) of
@@ -529,7 +558,7 @@ extractTableAndColumn fieldArg = do
         then do
           let (lExpr, expr) = head tyApps
           case expr of
-            (HsApp _ (L _ (HsAppType _ _ fldName)) tableVar) -> do
+            (HsApp _ (L _ (PatHsAppType _ fldName)) tableVar) -> do
               typ <- getHsExprType (logTypeDebugging . pluginOpts $ ?pluginOpts) tableVar
               let tblName' = case typ of
                               AppTy ty1 _    -> showS ty1
@@ -546,7 +575,7 @@ extractTableAndColumn fieldArg = do
               -- Fallback to tableVar if the full expression has no source span
               let bestLocExpr = if isGoodSrcSpan (getLoc2 lExpr) then lExpr else tableVar
               pure $ Just (getStrFromHsWildCardBndrs fldName, finalTableName, bestLocExpr)
-            (PatHsWrap (WpCompose (WpEvApp (EvExpr _hasFld)) (WpCompose (WpTyApp _fldType) (WpTyApp tableType))) (HsAppType _ _ fldName)) -> do
+            (PatHsWrap (WpCompose (WpEvApp (EvExpr _hasFld)) (WpCompose (WpTyApp _fldType) (WpTyApp tableType))) (PatHsAppType _ fldName)) -> do
               let tblName' = case tableType of
                                   AppTy ty1 _    -> showS ty1
                                   TyConApp ty1 _ -> showS ty1
@@ -628,9 +657,9 @@ extractTableAndColumn fieldArg = do
     getRecordDotSelectorL :: LHsExpr GhcTc -> Maybe (LHsExpr GhcTc, HsExpr GhcTc)
     getRecordDotSelectorL lExpr@(L loc expr) = 
       case expr of 
-        (HsApp _ (L _ (HsAppType _ _ fldName)) tableVar) -> Just (lExpr, expr)
-        (PatHsWrap (WpCompose (WpEvApp (EvExpr _hasFld)) (WpCompose (WpTyApp _fldType) (WpTyApp tableVar))) (HsAppType _ _ fldName)) -> Just (lExpr, expr)
-        (PatHsWrap (WpCompose _ wp@(WpCompose _ _)) hsat@(HsAppType _ _ fldName)) -> getRecordDotSelectorL (L loc (PatHsWrap wp hsat))
+        (HsApp _ (L _ (PatHsAppType _ fldName)) tableVar) -> Just (lExpr, expr)
+        (PatHsWrap (WpCompose (WpEvApp (EvExpr _hasFld)) (WpCompose (WpTyApp _fldType) (WpTyApp tableVar))) (PatHsAppType _ fldName)) -> Just (lExpr, expr)
+        (PatHsWrap (WpCompose _ wp@(WpCompose _ _)) hsat@(PatHsAppType _ fldName)) -> getRecordDotSelectorL (L loc (PatHsWrap wp hsat))
         _ -> Nothing
 
 --------------------------- Function Rule Validation Logic ---------------------------
@@ -882,7 +911,11 @@ getIsClauseData fieldArg _comp _clause = do
     None     -> when ((logWarnInfo . pluginOpts $ ?pluginOpts)) (liftIO $ print $ "Can't identify the way in which DB field is specified: " <> showS fieldArg) >> pure Nothing
     Selector -> do
       let modFieldArg arg = case arg of
+#if __GLASGOW_HASKELL__ >= 904
+                        (L _ (HsRecSel _ fldOcc))   -> showS $ foExt fldOcc
+#else
                         (L _ (HsRecFld _ fldOcc))   -> showS $ selectorAmbiguousFieldOcc fldOcc
+#endif
                         (L loc (PatHsWrap _ wExpr)) -> modFieldArg (L loc wExpr)
                         (L _ expr)                  -> showS expr
       case (splitOn ":" $ modFieldArg fieldArg) of
@@ -893,7 +926,7 @@ getIsClauseData fieldArg _comp _clause = do
       if length tyApps > 0 
         then 
           case head tyApps of
-            (HsApp _ (L _ (HsAppType _ _ fldName)) tableVar) -> do
+            (HsApp _ (L _ (PatHsAppType _ fldName)) tableVar) -> do
               typ <- getHsExprType (logTypeDebugging . pluginOpts $ ?pluginOpts) tableVar
               let tblName' = case typ of
                               AppTy ty1 _    -> showS ty1
@@ -908,7 +941,7 @@ getIsClauseData fieldArg _comp _clause = do
                                             then unqualifiedTblName 
                                             else strippedName
               pure $ Just (getStrFromHsWildCardBndrs fldName, finalTableName)
-            (PatHsWrap (WpCompose (WpEvApp (EvExpr _hasFld)) (WpCompose (WpTyApp _fldType) (WpTyApp tableType))) (HsAppType _ _ fldName)) ->
+            (PatHsWrap (WpCompose (WpEvApp (EvExpr _hasFld)) (WpCompose (WpTyApp _fldType) (WpTyApp tableType))) (PatHsAppType _ fldName)) ->
               let tblName' = case tableType of
                                   AppTy ty1 _    -> showS ty1
                                   TyConApp ty1 _ -> showS ty1
@@ -992,16 +1025,20 @@ getIsClauseData fieldArg _comp _clause = do
     getRecordDotSelector :: HsExpr GhcTc -> Maybe (HsExpr GhcTc)
     getRecordDotSelector recordDotExpr = 
       case recordDotExpr of 
-        (HsApp _ (L _ (HsAppType _ _ fldName)) tableVar) -> Just recordDotExpr
-        (PatHsWrap (WpCompose (WpEvApp (EvExpr _hasFld)) (WpCompose (WpTyApp _fldType) (WpTyApp tableVar))) (HsAppType _ _ fldName)) -> Just recordDotExpr
-        (PatHsWrap (WpCompose _ wp@(WpCompose _ _)) hsat@(HsAppType _ _ fldName)) -> getRecordDotSelector (PatHsWrap wp hsat)
+        (HsApp _ (L _ (PatHsAppType _ fldName)) tableVar) -> Just recordDotExpr
+        (PatHsWrap (WpCompose (WpEvApp (EvExpr _hasFld)) (WpCompose (WpTyApp _fldType) (WpTyApp tableVar))) (PatHsAppType _ fldName)) -> Just recordDotExpr
+        (PatHsWrap (WpCompose _ wp@(WpCompose _ _)) hsat@(PatHsAppType _ fldName)) -> getRecordDotSelector (PatHsWrap wp hsat)
         _ -> Nothing
 
 -- Get how DB field is being extracted in sequelize
 getDBFieldSpecType :: LHsExpr GhcTc -> DBFieldSpecType
 getDBFieldSpecType (L loc expr)
   | (PatHsWrap _ wExpr) <- expr = getDBFieldSpecType (L loc wExpr)
+#if __GLASGOW_HASKELL__ >= 904
+  | (HsRecSel _ fldOcc) <- expr = checkExprString . showS $ foExt fldOcc
+#else
   | (HsRecFld _ fldOcc) <- expr = checkExprString . showS $ selectorAmbiguousFieldOcc fldOcc
+#endif
   | otherwise                   = checkExprString $ showS expr
   where
     checkExprString exprStr
@@ -1024,7 +1061,7 @@ getWhereClauseFnNameWithAllArgs (L loc (OpApp _ lfun op rfun)) = do
   case showS op of
     "($)" -> getWhereClauseFnNameWithAllArgs $ (L loc (HsApp noExtFieldOrAnn lfun rfun))
     _ -> Nothing
-getWhereClauseFnNameWithAllArgs (L loc ap@(HsPar _ expr)) = getWhereClauseFnNameWithAllArgs expr
+getWhereClauseFnNameWithAllArgs (L loc ap@(PatHsPar expr)) = getWhereClauseFnNameWithAllArgs expr
 -- If condition inside the list, add dummy type
 getWhereClauseFnNameWithAllArgs (L loc ap@(PatHsIf _pred thenCl elseCl)) = Just ("Or", [L loc (PatExplicitList (LitTy (StrTyLit "Dummy")) [thenCl, elseCl])])
 getWhereClauseFnNameWithAllArgs (L loc ap@(PatHsWrap _ expr)) = getWhereClauseFnNameWithAllArgs (L loc expr)
@@ -1044,9 +1081,9 @@ getWhereClauseFnNameWithAllArgs _ = Nothing
 getFnNameAndTypeableExprWithAllArgs :: LHsExpr GhcTc -> Maybe (Located Var, LHsExpr GhcTc, [LHsExpr GhcTc])
 getFnNameAndTypeableExprWithAllArgs ap@(L loc (HsVar _ v)) = Just (getLocated v loc, ap, [])
 getFnNameAndTypeableExprWithAllArgs ap@(L _ (HsConLikeOut _ cl)) = (\clId -> (noExprLoc clId, ap, [])) <$> conLikeWrapId cl
-getFnNameAndTypeableExprWithAllArgs (L _ (HsAppType _ expr _)) = getFnNameAndTypeableExprWithAllArgs expr
+getFnNameAndTypeableExprWithAllArgs (L _ (PatHsAppType expr _)) = getFnNameAndTypeableExprWithAllArgs expr
 getFnNameAndTypeableExprWithAllArgs (L _ (HsApp _ ap@(L loc (HsVar _ v)) funr)) = Just (getLocated v loc, ap, [funr])
-getFnNameAndTypeableExprWithAllArgs (L _ (HsPar _ expr)) = getFnNameAndTypeableExprWithAllArgs expr
+getFnNameAndTypeableExprWithAllArgs (L _ (PatHsPar expr)) = getFnNameAndTypeableExprWithAllArgs expr
 getFnNameAndTypeableExprWithAllArgs (L _ (HsApp _ funl funr)) = do
   let res = getFnNameAndTypeableExprWithAllArgs funl
   case res of
@@ -1074,9 +1111,9 @@ getFnNameAndTypeableExprWithAllArgs _ = Nothing
 getFnNameWithAllArgs :: LHsExpr GhcTc -> Maybe (Located Var, [LHsExpr GhcTc])
 getFnNameWithAllArgs (L loc (HsVar _ v)) = Just (getLocated v loc, [])
 getFnNameWithAllArgs (L _ (HsConLikeOut _ cl)) = (\clId -> (noExprLoc clId, [])) <$> conLikeWrapId cl
-getFnNameWithAllArgs (L _ (HsAppType _ expr _)) = getFnNameWithAllArgs expr
+getFnNameWithAllArgs (L _ (PatHsAppType expr _)) = getFnNameWithAllArgs expr
 getFnNameWithAllArgs (L _ (HsApp _ (L loc (HsVar _ v)) funr)) = Just (getLocated v loc, [funr])
-getFnNameWithAllArgs (L _ (HsPar _ expr)) = getFnNameWithAllArgs expr
+getFnNameWithAllArgs (L _ (PatHsPar expr)) = getFnNameWithAllArgs expr
 getFnNameWithAllArgs (L _ (HsApp _ funl funr)) = do
   let res = getFnNameWithAllArgs funl
   case res of
@@ -1146,8 +1183,19 @@ isAllowedOnCurrentFunction currentFnNameWithModule rule =
   in not $ any (matchNamesWithAsterisk AsteriskInSecond currentFnNameWithModule) ignoredFunctions
 
 -- Create GHC compilation error from CompileError
+#if __GLASGOW_HASKELL__ >= 904
+-- GHC 9.4 changed the error API from raw `SDoc` to structured `TcRnMessage`;
+-- wrap the same rendered text as an unknown-diagnostic message so the emitted
+-- error content is unchanged.
+mkSheriffDiag :: OP.SDoc -> TcRnMessage
+mkSheriffDiag = mkTcRnUnknownMessage . mkPlainError noHints
+
+mkGhcCompileError :: CompileError -> (SrcSpan, TcRnMessage)
+mkGhcCompileError err = (src_span err, mkSheriffDiag $ OP.text $ getErrMsgWithSuggestions (err_msg err) (suggested_fixes err))
+#else
 mkGhcCompileError :: CompileError -> (SrcSpan, OP.SDoc)
 mkGhcCompileError err = (src_span err, OP.text $ getErrMsgWithSuggestions (err_msg err) (suggested_fixes err))
+#endif
 
 -- Make error message with suggestion
 getErrMsgWithSuggestions :: String -> Suggestions -> String
@@ -1161,8 +1209,13 @@ getErrMsgWithSuggestions errMsg suggestions = errMsg
     sixSpaces = twoSpaces <> fourSpaces
 
 -- Create invalid yaml file compilation error
+#if __GLASGOW_HASKELL__ >= 904
+mkInvalidYamlFileErr :: String -> TcRnMessage
+mkInvalidYamlFileErr err = mkSheriffDiag (OP.text err)
+#else
 mkInvalidYamlFileErr :: String -> OP.SDoc
 mkInvalidYamlFileErr err = OP.text err
+#endif
 
 -- Create Internal Representation of Logging Error
 mkCompileError :: String -> (LHsExpr GhcTc, Violation) -> TcM CompileError
@@ -1222,13 +1275,17 @@ getArgTypeWrapper expr@(L _ (OpApp _ lfun op rfun)) =
     "(<>)" -> getArgTypeWrapper lfun
     _ -> getArgType op True
 getArgTypeWrapper (L loc (PatHsWrap _ expr)) = getArgTypeWrapper (L loc expr)
-getArgTypeWrapper (L loc (HsPar _ expr)) = getArgTypeWrapper expr
+getArgTypeWrapper (L loc (PatHsPar expr)) = getArgTypeWrapper expr
 getArgTypeWrapper expr = getArgType expr False
 
 -- [DEPRECATED] Get LHsExpr type
 getArgType :: LHsExpr GhcTc -> Bool -> [Type]
 getArgType (L _ (HsLit _ v)) _ = getLitType v
+#if __GLASGOW_HASKELL__ >= 904
+getArgType (L _ (HsOverLit _ (OverLit (OverLitTc _ _ typ) v))) _ = [typ]
+#else
 getArgType (L _ (HsOverLit _ (OverLit (OverLitTc _ typ) v _))) _ = [typ]
+#endif
 getArgType (L loc (PatHsWrap _ expr)) shouldReturnFinalType = getArgType (L loc expr) shouldReturnFinalType
 getArgType (L loc (HsApp _ lfun rfun)) shouldReturnFinalType = getArgType lfun shouldReturnFinalType
 getArgType arg shouldReturnFinalType = 

--- a/sheriff/src/Sheriff/Plugin.hs
+++ b/sheriff/src/Sheriff/Plugin.hs
@@ -541,7 +541,7 @@ extractTableAndColumn fieldArg = do
     Selector -> do
       let modFieldArg arg = case arg of
 #if __GLASGOW_HASKELL__ >= 904
-                        (L _ (HsRecSel _ fldOcc))   -> showS $ foExt fldOcc
+                        (L _ (HsRecSel _ fldOcc))   -> mkSelectorString fldOcc
 #else
                         (L _ (HsRecFld _ fldOcc))   -> showS $ selectorAmbiguousFieldOcc fldOcc
 #endif
@@ -912,7 +912,7 @@ getIsClauseData fieldArg _comp _clause = do
     Selector -> do
       let modFieldArg arg = case arg of
 #if __GLASGOW_HASKELL__ >= 904
-                        (L _ (HsRecSel _ fldOcc))   -> showS $ foExt fldOcc
+                        (L _ (HsRecSel _ fldOcc))   -> mkSelectorString fldOcc
 #else
                         (L _ (HsRecFld _ fldOcc))   -> showS $ selectorAmbiguousFieldOcc fldOcc
 #endif
@@ -1030,12 +1030,30 @@ getIsClauseData fieldArg _comp _clause = do
         (PatHsWrap (WpCompose _ wp@(WpCompose _ _)) hsat@(PatHsAppType _ fldName)) -> getRecordDotSelector (PatHsWrap wp hsat)
         _ -> Nothing
 
+#if __GLASGOW_HASKELL__ >= 904
+-- On GHC 9.4+ record-field selectors are `HsRecSel (FieldOcc GhcTc)`, and the
+-- FieldOcc's selector `Id` prints as the plain field label -- GHC dropped the
+-- `$sel:<column>:<table>` name mangling that `selectorAmbiguousFieldOcc`
+-- surfaced on <= 9.2. Reconstruct that same string here (column = field label,
+-- table = the selector's parent record TyCon) so all the downstream
+-- `splitOn ":"`-based extraction and the `$sel` classification keep working
+-- exactly as before.
+mkSelectorString :: FieldOcc GhcTc -> String
+mkSelectorString fldOcc =
+  let selId   = foExt fldOcc
+      colName = occNameString (getOccName selId)
+      tblName = case idDetails selId of
+                  RecSelId { sel_tycon = RecSelData tc } -> occNameString (getOccName tc)
+                  _                                      -> ""
+  in "$sel:" <> colName <> ":" <> tblName
+#endif
+
 -- Get how DB field is being extracted in sequelize
 getDBFieldSpecType :: LHsExpr GhcTc -> DBFieldSpecType
 getDBFieldSpecType (L loc expr)
   | (PatHsWrap _ wExpr) <- expr = getDBFieldSpecType (L loc wExpr)
 #if __GLASGOW_HASKELL__ >= 904
-  | (HsRecSel _ fldOcc) <- expr = checkExprString . showS $ foExt fldOcc
+  | (HsRecSel _ fldOcc) <- expr = checkExprString $ mkSelectorString fldOcc
 #else
   | (HsRecFld _ fldOcc) <- expr = checkExprString . showS $ selectorAmbiguousFieldOcc fldOcc
 #endif

--- a/sheriff/src/Sheriff/Plugin.hs
+++ b/sheriff/src/Sheriff/Plugin.hs
@@ -885,11 +885,11 @@ trfWhereToSOP (clause : ls) = do
   let res = getWhereClauseFnNameWithAllArgs clause
       (fnName, args) = fromMaybe ("NA", []) res
   case (fnName, args) of
-    ("And", [(L _ (PatExplicitList _ arg))]) -> do
+    ("And", [lst]) | Just arg <- whereClauseListElems lst -> do
       curr <- trfWhereToSOP arg
       rem  <- trfWhereToSOP ls
       pure [x <> y | x <- curr, y <- rem]
-    ("Or", [(L _ (PatExplicitList _ arg))]) -> do
+    ("Or", [lst]) | Just arg <- whereClauseListElems lst -> do
       curr <- foldM (\r cls -> fmap (<> r) $ trfWhereToSOP [cls]) [] arg
       rem  <- trfWhereToSOP ls
       pure [x <> y | x <- curr, y <- rem]
@@ -900,6 +900,21 @@ trfWhereToSOP (clause : ls) = do
         Nothing -> pure rem
         Just (tblName, colName) -> pure $ fmap (\lst -> (clause, tblName, colName) : lst) rem
     (fn, _) -> when ((logWarnInfo . pluginOpts $ ?pluginOpts)) (liftIO $ print $ "Invalid/unknown clause in `where` clause : " <> fn <> " at " <> (showS . getLoc2 $ clause)) >> trfWhereToSOP ls
+
+-- Peel paren / type-wrap / `HsExpanded` (incl. the OverloadedLists `fromListN [..]`
+-- expansion GHC >= 9.4 introduces) down to the underlying list literal, so that
+-- `Se.And` / `Se.Or` arguments are still recognised. Returns the raw list on the
+-- bare-`ExplicitList` shape, i.e. a no-op for pre-expansion ASTs.
+whereClauseListElems :: LHsExpr GhcTc -> Maybe [LHsExpr GhcTc]
+whereClauseListElems (L loc e) = case e of
+  PatExplicitList _ xs      -> Just xs
+  PatHsPar inner            -> whereClauseListElems inner
+  PatHsWrap _ inner         -> whereClauseListElems (L loc inner)
+#if __GLASGOW_HASKELL__ >= 900
+  PatHsExpansion _ expanded -> whereClauseListElems (L loc expanded)
+#endif
+  HsApp _ f x               -> maybe (whereClauseListElems f) Just (whereClauseListElems x)
+  _                         -> Nothing
 
 -- Get table field name and table name for the `Se.Is` clause
 -- Patterns to match 'getField`, `recordDot`, `overloadedRecordDot` (ghc > 9), selector (duplicate record fields), rec fields (ghc 9), lens

--- a/sheriff/src/Sheriff/Plugin.hs
+++ b/sheriff/src/Sheriff/Plugin.hs
@@ -525,11 +525,22 @@ validateColumnAccessRule rule expr = do
   case mbTableCol of
     Just (colName, tableName, locExpr) -> do
       let knownTables = knownDBTables ?pluginOpts
-      if tableName `notElem` knownTables
+      -- Skip accesses that have no real source span. On GHC >= 9.4 the
+      -- record-dot-preprocessor emits every field's HasField getter as
+      -- `GHC.Records.getField @"col" r`, and those generated instance bodies
+      -- carry noSrcSpan. On GHC < 9.4 the same getter was emitted as a plain
+      -- annotated selector that this check never matched, so generated field
+      -- accesses were always invisible. Honouring the span preserves that
+      -- behaviour and stops us flagging compiler-generated boilerplate for API
+      -- DTOs whose type name merely coincides with a known DB table (e.g. a
+      -- `Customer` request record vs. the `Customer` DB table).
+      if not (isGoodSrcSpan (getLoc2 locExpr))
         then pure []
-        else if colName == column_name rule && tableName `notElem` allowed_tables rule
-          then pure [(expr, ColumnAccessViolation colName tableName rule)]
-          else pure []
+        else if tableName `notElem` knownTables
+          then pure []
+          else if colName == column_name rule && tableName `notElem` allowed_tables rule
+            then pure [(expr, ColumnAccessViolation colName tableName rule)]
+            else pure []
     Nothing -> pure []
 
 -- Extract (ColumnName, TableName) from an expression if possible

--- a/sheriff/src/Sheriff/Plugin.hs
+++ b/sheriff/src/Sheriff/Plugin.hs
@@ -56,6 +56,7 @@ import GHC.Types.Annotations
 import qualified GHC.Utils.Outputable as OP
 #if __GLASGOW_HASKELL__ >= 904
 import GHC.Hs.Type (foExt)
+import GHC.Types.FieldLabel (DuplicateRecordFields(..))
 import GHC.Tc.Errors.Types (TcRnMessage, mkTcRnUnknownMessage)
 import GHC.Types.Error (mkPlainError, noHints)
 #endif
@@ -1059,19 +1060,39 @@ getIsClauseData fieldArg _comp _clause = do
 #if __GLASGOW_HASKELL__ >= 904
 -- On GHC 9.4+ record-field selectors are `HsRecSel (FieldOcc GhcTc)`, and the
 -- FieldOcc's selector `Id` prints as the plain field label -- GHC dropped the
--- `$sel:<column>:<table>` name mangling that `selectorAmbiguousFieldOcc`
--- surfaced on <= 9.2. Reconstruct that same string here (column = field label,
--- table = the selector's parent record TyCon) so all the downstream
--- `splitOn ":"`-based extraction and the `$sel` classification keep working
--- exactly as before.
+-- `$sel:<column>:<constructor>` OccName mangling that
+-- `selectorAmbiguousFieldOcc` surfaced on <= 9.2 (disambiguation moved to the
+-- linker symbol, `$fld:<constructor>:<column>`). Reconstruct the 9.2 string
+-- here so the downstream `splitOn ":"` extraction and the `$sel`
+-- classification keep working, preserving *both* halves of the old condition:
+--
+--   * 9.2 only mangled when the module defining the record had
+--     DuplicateRecordFields on. GHC 9.4+ records that per field on the
+--     FieldLabel, so gate on it -- otherwise every plain record selector in
+--     every module gets manufactured into a Selector and enters rule paths it
+--     never entered on 9.2. Non-DRF selectors keep returning the plain label,
+--     which `getDBFieldSpecType` classifies as `None`, exactly as before.
+--
+--   * the third component is the first data constructor carrying the field,
+--     not the parent TyCon (GHC's own scheme is `$sel:x:MkT`). For beam tables
+--     `data CustomerT f = Customer {..}` that is `Customer` -- which is what
+--     the rule and indexedKeys table names are written against. The TyCon
+--     `CustomerT` would never compare equal to them, silently no-opping the
+--     DB rules for every selector-style where clause.
 mkSelectorString :: FieldOcc GhcTc -> String
 mkSelectorString fldOcc =
-  let selId   = foExt fldOcc
-      colName = occNameString (getOccName selId)
-      tblName = case idDetails selId of
-                  RecSelId { sel_tycon = RecSelData tc } -> occNameString (getOccName tc)
-                  _                                      -> ""
-  in "$sel:" <> colName <> ":" <> tblName
+  let selId    = foExt fldOcc
+      selNm    = idName selId
+      colName  = occNameString (getOccName selId)
+      isFld fl = flSelector fl == selNm
+      mangled  = case idDetails selId of
+        RecSelId { sel_tycon = RecSelData tc }
+          | Just fl <- find isFld (tyConFieldLabels tc)
+          , flHasDuplicateRecordFields fl == DuplicateRecordFields
+          , Just dc <- find (any isFld . dataConFieldLabels) (tyConDataCons tc)
+          -> Just $ "$sel:" <> colName <> ":" <> occNameString (getOccName dc)
+        _ -> Nothing
+  in fromMaybe colName mangled
 #endif
 
 -- Get how DB field is being extracted in sequelize

--- a/sheriff/src/Sheriff/Utils.hs
+++ b/sheriff/src/Sheriff/Utils.hs
@@ -41,6 +41,9 @@ import GHC.Tc.Module
 import GHC.Tc.Types
 import GHC.Tc.Utils.TcType
 import Language.Haskell.GHC.ExactPrint (ExactPrint)
+#if __GLASGOW_HASKELL__ >= 906
+import GHC.Types.Var (isInvisibleFunArg)
+#endif
 #else
 import ConLike
 import DsMonad
@@ -60,6 +63,16 @@ import TyCoRep
   These are the common utility functions which can be used for building any plugin of any sort
   Mainly it has generic functions for all - parse, rename and typecheck plugin.
 -}
+
+#if __GLASGOW_HASKELL__ >= 904
+-- GHC 9.4 changed `initDsTc :: DsM a -> TcM (Messages DsMessage, Maybe a)`
+-- (previously it returned the desugared result directly). For a typechecked
+-- expression desugaring always succeeds, so unwrap the `Maybe` to keep the
+-- original behaviour of yielding the core expression.
+unwrapDsResult :: (msgs, Maybe a) -> a
+unwrapDsResult (_, Just x)  = x
+unwrapDsResult (_, Nothing) = error "Sheriff: desugaring produced no core expression"
+#endif
 
 -- Debug Show any haskell internal representation type
 showS :: (Outputable a) => a -> String
@@ -216,6 +229,10 @@ getLitType (HsFloatPrim _ _) = [floatTy]
 getLitType (HsDoublePrim _ _) = [doubleTy]
 #if __GLASGOW_HASKELL__ < 900
 getLitType _ = []
+#elif __GLASGOW_HASKELL__ >= 904
+-- GHC 9.4+ added sized primitive literals (HsInt8Prim/HsWord8Prim/…); they are
+-- not types we introspect, so fall through to the empty result as before.
+getLitType _ = []
 #endif
 
 -- Check if 1st array has any element in 2nd array
@@ -305,7 +322,11 @@ traverseConditionalUni p (x : xs) =
 -- Get type for a LHsExpr GhcTc
 getHsExprType :: Bool -> LHsExpr GhcTc -> TcM Type
 getHsExprType logTypeDebugging expr = do
+#if __GLASGOW_HASKELL__ >= 904
+  coreExpr <- unwrapDsResult <$> (initDsTc $ dsLExpr expr)
+#else
   coreExpr <- initDsTc $ dsLExpr expr
+#endif
   let typ = exprType coreExpr
   when logTypeDebugging $ liftIO . print $ "DebugType = " <> (debugPrintType typ)
   pure typ
@@ -323,7 +344,14 @@ getHsExprTypeAsTypeDataListWithConstraintCheck ignoreConstraintArg typ = case ty
   TyConApp tycon tys -> [NestedTy $ [TextTy $ getNameWithModuleName (tyConName tycon)] <> (concat $ fmap (getHsExprTypeAsTypeDataListWithConstraintCheck ignoreConstraintArg) tys)]
   AppTy ty1 ty2 -> getHsExprTypeAsTypeDataListWithConstraintCheck ignoreConstraintArg ty1 <> getHsExprTypeAsTypeDataListWithConstraintCheck ignoreConstraintArg ty2
   ForAllTy _ ty -> getHsExprTypeAsTypeDataListWithConstraintCheck ignoreConstraintArg ty
-  PatFunTy anonArgFlag ty1 ty2 -> bool (getHsExprTypeAsTypeDataListWithConstraintCheck ignoreConstraintArg ty1 <> getHsExprTypeAsTypeDataListWithConstraintCheck ignoreConstraintArg ty2) (getHsExprTypeAsTypeDataListWithConstraintCheck ignoreConstraintArg ty2) (ignoreConstraintArg && anonArgFlag == InvisArg)
+  PatFunTy anonArgFlag ty1 ty2 ->
+    let isInvis =
+#if __GLASGOW_HASKELL__ >= 906
+          isInvisibleFunArg anonArgFlag
+#else
+          anonArgFlag == InvisArg
+#endif
+    in bool (getHsExprTypeAsTypeDataListWithConstraintCheck ignoreConstraintArg ty1 <> getHsExprTypeAsTypeDataListWithConstraintCheck ignoreConstraintArg ty2) (getHsExprTypeAsTypeDataListWithConstraintCheck ignoreConstraintArg ty2) (ignoreConstraintArg && isInvis)
   _ -> []
 
 -- Get Qualified Types as List Ignoring constraint checks
@@ -387,7 +415,11 @@ getHsExprTypeGeneric logTypeDebugging expr = case ghcPass @p of
       pure (Just typ)
     GhcTc -> do
       e <- getEnv
+#if __GLASGOW_HASKELL__ >= 904
+      typ <- liftIO $ runIOEnv e $ (exprType . unwrapDsResult) <$> initDsTc (dsLExpr expr)
+#else
       typ <- liftIO $ runIOEnv e $ exprType <$> initDsTc (dsLExpr expr)
+#endif
       when logTypeDebugging $ liftIO . print $ "DebugType = " <> (debugPrintType typ)
       pure (Just typ)
 
@@ -405,8 +437,13 @@ trfPatToSimpleTcExpr :: Pat GhcTc -> SimpleTcExpr
 trfPatToSimpleTcExpr pat = case pat of
   VarPat _ (L _ var)           -> SimpleVar var
   LazyPat _ (L _ lPat)         -> trfPatToSimpleTcExpr lPat
+#if __GLASGOW_HASKELL__ >= 904
+  AsPat _ (L _ var) _ (L _ sPat) -> SimpleAliasPat (SimpleVar var) (trfPatToSimpleTcExpr sPat)
+  ParPat _ _ (L _ sPat) _      -> trfPatToSimpleTcExpr sPat
+#else
   AsPat _ (L _ var) (L _ sPat) -> SimpleAliasPat (SimpleVar var) (trfPatToSimpleTcExpr sPat)
   ParPat _ (L _ sPat)          -> trfPatToSimpleTcExpr sPat
+#endif
   BangPat _ (L _ sPat)         -> trfPatToSimpleTcExpr sPat
   SigPat _ (L _ sPat) _        -> trfPatToSimpleTcExpr sPat
   ListPat _ lPatList           -> SimpleList (fmap (trfPatToSimpleTcExpr . unLoc) lPatList)
@@ -428,8 +465,8 @@ trfLHsExprToSimpleTcExpr (L loc hsExpr) = case hsExpr of
   HsVar _ (L _ var)            -> SimpleVar var
   HsConLikeOut _ cl            -> SimpleDataCon (conLikeWrapId cl) []
   HsLit _ lit                  -> SimpleLit lit
-  HsPar _ expr                 -> trfLHsExprToSimpleTcExpr expr
-  HsAppType _ expr _           -> trfLHsExprToSimpleTcExpr expr
+  PatHsPar expr                -> trfLHsExprToSimpleTcExpr expr
+  PatHsAppType expr _          -> trfLHsExprToSimpleTcExpr expr
   PatHsWrap _ expr             -> trfLHsExprToSimpleTcExpr (L loc expr)
   ExplicitTuple _ ls _         -> SimpleTuple (fmap trfTupleArg ls)
   PatExplicitList _ ls         -> SimpleList (fmap trfLHsExprToSimpleTcExpr ls)

--- a/warner/src/Warner/Plugin.hs
+++ b/warner/src/Warner/Plugin.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE LambdaCase,RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wno-orphans -Wno-error=unused-imports -Wno-error=unused-top-binds #-}
 
 module Warner.Plugin (plugin) where
@@ -16,6 +17,8 @@ import GHC.Data.Bag
 import GHC.Data.FastString
 import GHC.Driver.Env
 import GHC.Driver.Errors
+import GHC.Driver.Errors.Types (WarningMessages, GhcMessage, ghcUnknownMessage)
+import GHC.Driver.Config.Diagnostic (initDiagOpts)
 import GHC.Driver.Plugins
 import GHC.Driver.Session
 import GHC.Tc.Types
@@ -56,6 +59,7 @@ import Data.Text (Text)
 import GHC.Generics (Generic)
 import GHC.IO (unsafePerformIO)
 import qualified Data.ByteString as DBS
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
 import System.Directory (createDirectoryIfMissing,doesFileExist)
 import System.Environment
@@ -100,41 +104,40 @@ instance ToJSON WarningFlag where
     toJSON flag = String $ T.pack $ show flag
 
 instance FromJSON WarningFlag where
-    parseJSON = withText "WarningFlag" $ \t -> do
-        let flagList = filter (\x -> (show x) == (T.unpack t)) getAllWarningFlags
-        if null flagList
-            then fail $ "Invalid WarningFlag: " ++ T.unpack t
-            else pure $ head flagList
+    parseJSON = withText "WarningFlag" $ \t ->
+        case filter (\x -> (show x) == (T.unpack t)) getAllWarningFlags of
+            (flag : _) -> pure flag
+            []         -> fail $ "Invalid WarningFlag: " ++ T.unpack t
 
-instance ToJSON WarnReason where
-    toJSON NoReason = object [
-        "type" .= ("NoReason" :: Text)
+-- GHC 9.8 replaced the old `WarnReason` type with `DiagnosticReason` (carried
+-- on a MsgEnvelope inside a `ResolvedDiagnosticReason` newtype). We only need
+-- ToJSON here, since the reason is stored as a raw aeson Value in
+-- MessageFingerprint and never decoded back into a reason.
+instance ToJSON DiagnosticReason where
+    toJSON WarningWithoutFlag = object [
+        "type" .= ("WarningWithoutFlag" :: Text)
         ]
-    toJSON (Reason flag) = object [
-        "type" .= ("Reason" :: Text),
-        "flag" .= flag
+    toJSON (WarningWithFlags flags) = object [
+        "type" .= ("WarningWithFlags" :: Text),
+        "flags" .= NE.toList flags
         ]
-    toJSON (ErrReason mbFlag) = object [
-        "type" .= ("ErrReason" :: Text),
-        "flag" .= mbFlag
+    toJSON (WarningWithCategory cat) = object [
+        "type" .= ("WarningWithCategory" :: Text),
+        "category" .= T.pack (showSDocUnsafe (ppr cat))
+        ]
+    toJSON ErrorWithoutFlag = object [
+        "type" .= ("ErrorWithoutFlag" :: Text)
         ]
 
-instance FromJSON WarnReason where
-    parseJSON = withObject "WarnReason" $ \v -> do
-        typ <- v .: "type"
-        case typ of
-            "NoReason" -> pure NoReason
-            "Reason" -> Reason <$> v .: "flag"
-            "ErrReason" -> ErrReason <$> v .: "flag"
-            _ -> fail $ "Unknown WarnReason type: " ++ T.unpack typ
+instance ToJSON ResolvedDiagnosticReason where
+    toJSON = toJSON . resolvedDiagnosticReason
 
 #if __GLASGOW_HASKELL__ >= 900
-createFingerprint :: DynFlags -> MsgEnvelope DecoratedSDoc -> MessageFingerprint
-createFingerprint dflags msg = MessageFingerprint 
-    { diagnostic = 
+createFingerprint :: DynFlags -> MsgEnvelope GhcMessage -> MessageFingerprint
+createFingerprint dflags msg = MessageFingerprint
+    { diagnostic =
         let style = mkErrStyle (errMsgContext msg)
-            ctx   = initSDocContext dflags style
-        in renderWithContext (initSDocContext dflags defaultUserStyle) $ withPprStyle style (formatBulleted ctx (renderDiagnostic (errMsgDiagnostic msg)))
+        in renderWithContext (initSDocContext dflags defaultUserStyle) $ withPprStyle style (formatBulleted (diagnosticMessage (defaultDiagnosticOpts @GhcMessage) (errMsgDiagnostic msg)))
     , reason = toJSON $ errMsgReason msg
     , severity = show $ errMsgSeverity msg
     , srcSpan = showSDocUnsafe $ ppr $ errMsgSpan msg
@@ -143,18 +146,21 @@ createFingerprint dflags msg = MessageFingerprint
 -- getCacheWarnings :: MsgEnvelope e -> MsgCache
 
 makeIntoError :: MsgEnvelope e -> MsgEnvelope e
-makeIntoError warning = warning {
-    errMsgSeverity = SevError
-    , errMsgReason = case errMsgReason warning of
-                        Reason flag -> ErrReason (Just flag)
-                        x -> x
-    }
+makeIntoError warning = warning { errMsgSeverity = SevError }
 
 getReason :: MsgEnvelope e -> String
 getReason warning =
-    case errMsgReason warning of
-        Reason flag -> show flag
+    case resolvedDiagnosticReason (errMsgReason warning) of
+        WarningWithFlags flags -> show (NE.head flags)
         _ -> mempty
+
+-- GHC 9.8 dropped `isErrorMessage`/`isWarningMessage` (severity based) from the
+-- API; re-implement the same severity partition the plugin relied on.
+isWarnSev :: MsgEnvelope e -> Bool
+isWarnSev m = errMsgSeverity m == SevWarning
+
+isErrSev :: MsgEnvelope e -> Bool
+isErrSev m = errMsgSeverity m == SevError
 
 mkFileSrcSpan :: ModLocation -> SrcSpan
 mkFileSrcSpan mod_loc
@@ -178,12 +184,12 @@ handleWarns opts mModSummary _tcGblEnv modGuts = do
 
             clearWarnings
             -- THESE WOULD BE MOVED TO ERRORS IF THEY ARE NOT IN THE CACHE
-            warningsList_ <- pure $ filter isWarningMessage $ bagToList warningsBag
+            warningsList_ <- pure $ filter isWarnSev $ bagToList (getMessages warningsBag)
 
             (warningsList,toBeErrors) <- pure $ foldl' (\(warnings,toBeErrors) x -> if ((getReason x) `elem` cacheWarningsList) then (warnings, [x] <> toBeErrors) else ([x] <> warnings,toBeErrors)) ([],[]) warningsList_
 
             -- DO NOT TOUCH ERRORS LIST
-            errorsList <- pure $ filter isErrorMessage $ bagToList warningsBag
+            errorsList <- pure $ filter isErrSev $ bagToList (getMessages warningsBag)
 
             dflags <- getDynFlags
             logger <- getLogger
@@ -192,10 +198,10 @@ handleWarns opts mModSummary _tcGblEnv modGuts = do
                 then do
                     let cacheList = map (createFingerprint dflags) toBeErrors
                     liftIO $ DBS.writeFile (modulePath <> ".json") (DBS.toStrict $ encodePretty cacheList)
-                    updatedWarningsBag <- pure $ listToBag $ errorsList <> warningsList <> (map makeIntoError toBeErrors)
-                    if (any isErrorMessage errorsList)
+                    updatedWarningsBag <- pure $ mkMessages $ listToBag $ errorsList <> warningsList <> (map makeIntoError toBeErrors)
+                    if (any isErrSev errorsList)
                         then throwErrors updatedWarningsBag
-                        else liftIO $ printOrThrowWarnings logger dflags updatedWarningsBag
+                        else liftIO $ printOrThrowDiagnostics logger (defaultDiagnosticOpts @GhcMessage) (initDiagOpts dflags) updatedWarningsBag
                 else do
                     fileExists <- liftIO $ doesFileExist (modulePath <> ".json")
                     whiteListedWarns <- if fileExists then liftIO $ DBS.readFile (modulePath <> ".json") else pure $ mempty
@@ -204,10 +210,10 @@ handleWarns opts mModSummary _tcGblEnv modGuts = do
                                 Just (l :: [MessageFingerprint]) -> 
                                     (filter (\x -> not ((createFingerprint dflags x) `elem` l)) toBeErrors,filter (\x -> ((createFingerprint dflags x) `elem` l)) toBeErrors)
                                 Nothing -> (toBeErrors,mempty)
-                    updatedWarningsBag <- pure $ listToBag $ errorsList <> warningsList <> (map makeIntoError filteredToBeErrors) <> isCacheButNeedToMention
-                    if (any isErrorMessage (bagToList updatedWarningsBag))
+                    updatedWarningsBag <- pure $ mkMessages $ listToBag $ errorsList <> warningsList <> (map makeIntoError filteredToBeErrors) <> isCacheButNeedToMention
+                    if (any isErrSev (bagToList (getMessages updatedWarningsBag)))
                         then throwErrors updatedWarningsBag
-                        else liftIO $ printOrThrowWarnings logger dflags updatedWarningsBag
+                        else liftIO $ printOrThrowDiagnostics logger (defaultDiagnosticOpts @GhcMessage) (initDiagOpts dflags) updatedWarningsBag
         Nothing -> do
             liftIO $ print ("Warner : MOD summary is Nothing" :: String)
             pure ()
@@ -217,7 +223,7 @@ handleWarns opts mModSummary _tcGblEnv modGuts = do
         getWarnings = Hsc $ \_ w -> return (w, w)
 
         clearWarnings :: Hsc ()
-        clearWarnings = Hsc $ \_ _ -> return ((), emptyBag)
+        clearWarnings = Hsc $ \_ _ -> return ((), emptyMessages)
 
 data CliOptions = CliOptions {
     error :: Maybe Bool
@@ -232,7 +238,7 @@ fixedLengthListAction opts _ tcEnv = do
     return tcEnv
     where
         checkModule :: LHsBindLR GhcTc GhcTc -> TcM ()
-        checkModule (L _ AbsBinds{abs_binds = binds}) = do
+        checkModule (L _ (XHsBindsLR AbsBinds{abs_binds = binds})) = do
             forM_ (bagToList binds) checkModule
         checkModule x = checkBind x
 
@@ -255,7 +261,7 @@ fixedLengthListAction opts _ tcEnv = do
         -- checkBind _ = pure ()
 
         checkMatchGroup :: (MatchGroup GhcTc (LHsExpr GhcTc)) -> TcM ()
-        checkMatchGroup ((MG _ (L _ matches) _)) = 
+        checkMatchGroup ((MG _ (L _ matches))) = 
             forM_ matches $ \(L _ match) -> do
                 forM_ (m_pats match) checkPattern
                 forM_ (grhssGRHSs $ m_grhss match) checkGRHSs
@@ -271,7 +277,7 @@ fixedLengthListAction opts _ tcEnv = do
                 checkCaseScrutinee (getLocA x) scrut
                 checkExpr scrut
                 checkMatchGroup matches
-            HsLet _ binds body -> do
+            HsLet _ _ binds _ body -> do
                 checkLocalBinds binds
                 checkExpr body
             HsLam _ matches -> 
@@ -279,7 +285,7 @@ fixedLengthListAction opts _ tcEnv = do
             HsApp _ e1 e2 -> do
                 checkExpr e1
                 checkExpr e2
-            HsAppType _ e _ -> 
+            HsAppType _ e _ _ ->
                 checkExpr e
             OpApp _ e1 op e2 -> do
                 checkExpr e1
@@ -287,7 +293,7 @@ fixedLengthListAction opts _ tcEnv = do
                 checkExpr e2
             NegApp _ e _ -> 
                 checkExpr e
-            HsPar _ e -> 
+            HsPar _ _ e _ ->
                 checkExpr e
             SectionL _ e1 e2 -> do
                 checkExpr e1
@@ -306,9 +312,9 @@ fixedLengthListAction opts _ tcEnv = do
                 checkStmts stmts
             ExplicitList _ elems ->
                 mapM_ checkExpr elems
-            RecordCon _ _ (HsRecFields fields _) -> 
-                forM_ fields $ \(L _ field) -> 
-                checkExpr (hsRecFieldArg field)
+            RecordCon _ _ (HsRecFields fields _) ->
+                forM_ fields $ \(L _ field) ->
+                checkExpr (hfbRHS field)
             --   RecordUpd _ e fields -> do
             --     checkExpr e
             --     forM_ fields $ \(L _ field) -> 
@@ -328,14 +334,9 @@ fixedLengthListAction opts _ tcEnv = do
                     checkExpr e1
                     checkExpr e2
                     checkExpr e3
-            HsBracket _ _ -> 
-                return ()
-            --   HsRnBracketOut _ _ _ -> 
-            --     return ()
-            HsTcBracketOut _ _ _ _ -> 
-                return ()
-            HsSpliceE _ _ -> 
-                return ()
+            -- NB: GHC 9.8 renamed the TH bracket/splice constructors
+            -- (HsBracket/HsTcBracketOut/HsSpliceE). They were no-ops here, so
+            -- they now fall through to the `_ -> return ()` case below.
             HsProc _ pat body -> do
                 checkPattern pat
                 checkCmdTop body
@@ -347,11 +348,11 @@ fixedLengthListAction opts _ tcEnv = do
             --   HsArrForm _ e _ cmds -> do
             --     checkExpr e
             --     mapM_ checkCmd cmds
-            HsTick _ _ e -> 
-                checkExpr e
-            HsBinTick _ _ _ e -> 
-                checkExpr e
-            --   HsTickPragma _ _ _ e -> 
+            -- NB: GHC 9.8 moved HsTick/HsBinTick out of HsExpr into the XExpr
+            -- (XXExprGhcTc) extension. They don't occur in typechecked binds
+            -- (ticks are inserted during desugaring), so these cases are dropped
+            -- and handled by the `_ -> return ()` fall-through below.
+            --   HsTickPragma _ _ _ e ->
             --     checkExpr e
             _ -> 
                 return ()
@@ -369,7 +370,7 @@ fixedLengthListAction opts _ tcEnv = do
                 checkExpr e
             HsCmdLam _ matches -> 
                 checkCmdMatchGroup matches
-            HsCmdPar _ c -> 
+            HsCmdPar _ _ c _ ->
                 checkCmd c
             HsCmdCase _ e matches -> do
                 checkExpr e
@@ -378,7 +379,7 @@ fixedLengthListAction opts _ tcEnv = do
                 checkExpr e
                 checkCmd c1
                 checkCmd c2
-            HsCmdLet _ binds c -> do
+            HsCmdLet _ _ binds _ c -> do
                 checkLocalBinds binds
                 checkCmd c
             HsCmdDo _ (L _ stmts) -> 
@@ -390,7 +391,7 @@ fixedLengthListAction opts _ tcEnv = do
         checkCmdTop (L _ (HsCmdTop _ cmd)) = checkCmd cmd
 
         checkCmdMatchGroup :: (MatchGroup GhcTc (LHsCmd GhcTc)) -> TcM ()
-        checkCmdMatchGroup ((MG _ (L _ matches) _)) = 
+        checkCmdMatchGroup ((MG _ (L _ matches))) = 
             forM_ matches $ \(L _ match) -> do
                 forM_ (m_pats match) checkPattern
                 -- forM_ (grhssLocalBinds $ m_grhss match) checkLocalBinds
@@ -470,7 +471,7 @@ fixedLengthListAction opts _ tcEnv = do
                 return ()
             SigPat _ p _ -> 
                 checkPattern p
-            AsPat _ _ p -> 
+            AsPat _ _ _ p ->
                 checkPattern p
             TuplePat _ pats _ -> 
                 mapM_ checkPattern pats
@@ -480,7 +481,7 @@ fixedLengthListAction opts _ tcEnv = do
                 checkPattern p
             LazyPat _ p -> 
                 checkPattern p
-            ParPat _ p -> 
+            ParPat _ _ p _ ->
                 checkPattern p
             VarPat {} -> 
                 return ()
@@ -508,16 +509,15 @@ fixedLengthListAction opts _ tcEnv = do
                                     Just (CliOptions{error=error_}) -> fromMaybe False error_
                                     Nothing -> False
             let errorMessage = "Case matching on a fixed-length list literal is not allowed. Use a tuple or cons to pattern match in case scrutinee "
-            -- let errorMsg = (loc, errorMessage)
-            let errorMessages = listToBag [
-                        if (shouldThrowError == True)
-                            then mkErr loc reallyAlwaysQualify (mkDecorated [text errorMessage])
-                            else mkWarnMsg loc reallyAlwaysQualify (text errorMessage)
-                    ]
+            dflags <- getDynFlags
+            logger <- getLogger
             if shouldThrowError
-                then throwErrors errorMessages
-                else do
-                    dflags <- getDynFlags
-                    logger <- getLogger
-                    liftIO $ printOrThrowWarnings logger dflags errorMessages
+                then throwErrors $ mkMessages $ listToBag [
+                        mkErrorMsgEnvelope loc reallyAlwaysQualify
+                            (ghcUnknownMessage (mkPlainError noHints (text errorMessage)))
+                        ]
+                else liftIO $ printOrThrowDiagnostics logger (defaultDiagnosticOpts @GhcMessage) (initDiagOpts dflags) $ mkMessages $ listToBag [
+                        mkMsgEnvelope (initDiagOpts dflags) loc reallyAlwaysQualify
+                            (ghcUnknownMessage (mkPlainDiagnostic WarningWithoutFlag noHints (text errorMessage)))
+                        ]
 #endif

--- a/warner/src/Warner/Plugin.hs
+++ b/warner/src/Warner/Plugin.hs
@@ -113,20 +113,32 @@ instance FromJSON WarningFlag where
 -- on a MsgEnvelope inside a `ResolvedDiagnosticReason` newtype). We only need
 -- ToJSON here, since the reason is stored as a raw aeson Value in
 -- MessageFingerprint and never decoded back into a reason.
+--
+-- The encoding below deliberately keeps the pre-9.8 `WarnReason` tag names
+-- ("NoReason"/"Reason"/"ErrReason") rather than the new constructor names: the
+-- fingerprints cached under ./.juspay/existing-errors are a persisted on-disk
+-- format written by older compilers, and `reason` is compared as a raw aeson
+-- Value. Renaming the tags would make every existing baseline entry miss,
+-- silently promoting already-grandfathered warnings to build errors.
+--
+-- `WarningWithFlags` carries a NonEmpty where `Reason` carried a single flag.
+-- Taking the head matches getReason below, which selects messages for caching
+-- on the head flag too, so the two stay consistent.
 instance ToJSON DiagnosticReason where
     toJSON WarningWithoutFlag = object [
-        "type" .= ("WarningWithoutFlag" :: Text)
+        "type" .= ("NoReason" :: Text)
         ]
     toJSON (WarningWithFlags flags) = object [
-        "type" .= ("WarningWithFlags" :: Text),
-        "flags" .= NE.toList flags
+        "type" .= ("Reason" :: Text),
+        "flag" .= NE.head flags
         ]
     toJSON (WarningWithCategory cat) = object [
         "type" .= ("WarningWithCategory" :: Text),
         "category" .= T.pack (showSDocUnsafe (ppr cat))
         ]
     toJSON ErrorWithoutFlag = object [
-        "type" .= ("ErrorWithoutFlag" :: Text)
+        "type" .= ("ErrReason" :: Text),
+        "flag" .= (Nothing :: Maybe WarningFlag)
         ]
 
 instance ToJSON ResolvedDiagnosticReason where


### PR DESCRIPTION
Migrating plugins to GHC 9.8.4 :

1. Toolchain — flake.nix rewrite (nixpkgs repinned to euler-nix-common's ghc984 set so the patched GHC substitutes from the juspay cache; GHC 8.10.7 project dropped; forks swapped; large-anon family moved to Hackage), regenerated flake.lock (−531 lines), the rebased desugar-plugin patch + new thread-statistics primop patch, cabal.project reorder.
2. Shared migration patterns — a table of the ~20 recurring 9.4→9.8 API breaks and the CPP-gated fix used for each (pattern synonyms for token-field arity, XHsBindsLR AbsBinds, HsFieldBind, LHsRecUpdFields, ParsedResult hooks, TcRnMessage/GhcMessage, Messages newtype, tcPluginRewrite, …).
3. Per-plugin sections for sheriff, warner, api-contract, paymentFlow, fdep, dc, fieldInspector, keyLookupTracker.
4. Behavioural deltas — the 8 places where runtime behaviour actually changes, each with the reason: sheriff's mkSelectorString ($sel: names gone on 9.4+), whereClauseListElems (Se.Or/Se.And lists now wrapped by the OverloadedLists expansion), the isGoodSrcSpan guard on column-access rules, api-contract's HsBracket→HsUntypedBracket rename, and warner's reason-tag wire format / makeIntoError / dropped AST cases.
5. Compatibility notes and testing.

6.  `mkSelectorString` (added in the 9.2.8 → 9.8.4 port) rebuilds the pre-9.4
  `$sel:<column>:<constructor>` string that sheriff parses to identify the DB
  table/column in a `Se.Is` where clause. It diverged from 9.2 in two ways.
  fix :  **Fix:** match the field's `FieldLabel` by selector `Name`, gate on
  `flHasDuplicateRecordFields` (9.4+ records the exact 9.2 mangling condition
  per field), and take the first data constructor carrying the field via
  `dataConFieldLabels`. Non-DRF selectors fall back to the plain label, which
  `getDBFieldSpecType` classifies as `None` — as on 9.2.